### PR TITLE
[EXSHAPP-0569]: Currency symbol detaches from amount due to line break in notifications

### DIFF
--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/expenseshareapp/core/designsystem/presentation/formatter/AmountFormatter.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/expenseshareapp/core/designsystem/presentation/formatter/AmountFormatter.kt
@@ -36,11 +36,15 @@ fun formatCurrencyAmount(amount: Long, currencyCode: String, locale: Locale): St
     val localeSymbol = currencyInstance.getSymbol(locale)
     val nativeSymbol = resolveNativeSymbol(currencyInstance)
 
-    return if (nativeSymbol != null && localeSymbol != nativeSymbol && localeSymbol == currencyInstance.currencyCode) {
+    val finalFormatted = if (nativeSymbol != null && localeSymbol != nativeSymbol && localeSymbol == currencyInstance.currencyCode) {
         formatted.replace(localeSymbol, nativeSymbol)
     } else {
         formatted
     }
+
+    // Replace standard spaces with non-breaking spaces (\u00A0)
+    // to prevent the currency symbol from detaching on line breaks
+    return finalFormatted.replace(" ", "\u00A0")
 }
 
 /**

--- a/core/design-system/src/test/kotlin/es/pedrazamiguez/expenseshareapp/core/designsystem/presentation/formatter/AmountFormatterTest.kt
+++ b/core/design-system/src/test/kotlin/es/pedrazamiguez/expenseshareapp/core/designsystem/presentation/formatter/AmountFormatterTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.expenseshareapp.core.designsystem.presentation.formatte
 
 import es.pedrazamiguez.expenseshareapp.domain.model.Expense
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -187,8 +188,32 @@ class AmountFormatterTest {
             val groupFormatted = expense.formatAmount(usLocale)
             val sourceFormatted = expense.formatSourceAmount(usLocale)
             // They should differ — EUR vs THB
-            assert(groupFormatted != sourceFormatted) {
+            assertNotEquals(
+                groupFormatted, sourceFormatted,
                 "Expected different output but got: $groupFormatted"
+            )
+        }
+    }
+
+    // ---------- Non-breaking space (prevents currency symbol detachment) ----------
+
+    @Nested
+    @DisplayName("Non-breaking space in formatted output")
+    inner class NonBreakingSpace {
+
+        @Test
+        fun `formatted amount never contains a regular space`() {
+            val currencies = listOf("EUR", "USD", "GBP", "JPY", "THB", "CNY", "MXN", "CAD")
+            val locales = listOf(usLocale, esLocale, Locale.FRANCE, Locale.JAPAN)
+
+            for (currency in currencies) {
+                for (locale in locales) {
+                    val result = formatCurrencyAmount(amount = 10050, currencyCode = currency, locale = locale)
+                    assertEquals(
+                        -1, result.indexOf(' '),
+                        "Regular space found in \"$result\" for $currency / $locale"
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #569 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
