### PR TITLE
[EXSHAPP-0608]: Sync status indicators & stale exchange rate warnings for offline-first UX

### DIFF
--- a/build-logic/src/main/kotlin/JacocoExclusions.kt
+++ b/build-logic/src/main/kotlin/JacocoExclusions.kt
@@ -100,9 +100,12 @@ object JacocoExclusions {
         "**/messaging/channel/**",
         // ── Local data sources — thin Room DAO wrappers requiring Android/Robolectric
         "**/local/datasource/impl/**",
-        // Room DAO interfaces — abstract; generated _Impl already excluded above
+        // Room DAO interfaces — abstract; generated _Impl already excluded above.
+        // @Transaction default methods require instrumented tests with inMemoryDatabaseBuilder.
         "**/local/dao/*Dao.*",
         "**/local/dao/*Dao\$*.*",
+        // Room entity projection data classes — pure data holders with no testable logic
+        "**/local/entity/SyncStatusEntry*.*",
         // ── Remote data sources — Retrofit HTTP (requires OkHttp/network runtime)
         "**/remote/datasource/impl/**",
         // ── Settings UI models — sealed subclasses with @Composable lambda fields

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ sonarqube {
             "${layout.buildDirectory.get()}/reports/jacoco/merged/jacocoMergedReport.xml",
         )
 
-        // ── Coverage exclusions (mirrors jacocoExcludes above) ──────────────────
+        // ── Coverage exclusions (mirrors JacocoExclusions.classExcludes) ────────
         // Keep both lists in sync: JaCoCo uses class-path globs, Sonar uses source-path globs.
         property(
             "sonar.coverage.exclusions",
@@ -113,16 +113,27 @@ sonarqube {
                 "**/*Module\$*.kt",
                 "**/R.kt",
                 "**/BuildConfig.kt",
+                // Preview helpers (debug source set)
+                "**/*PreviewHelper*.kt",
                 // Compose UI — only reachable via instrumentation tests, not JUnit
                 "**/presentation/feature/**/*.kt",
                 "**/presentation/screen/**/*.kt",
                 "**/presentation/component/**/*.kt",
                 "**/presentation/preview/**/*.kt",
+                // Static Compose data lists (icons, UI constants — e.g. SettingsData.kt)
+                "**/presentation/data/**/*.kt",
+                // Settings UI models — sealed subclasses with @Composable lambda fields
+                "**/presentation/model/SettingsItemModel*.kt",
+                "**/presentation/model/SettingsSectionModel*.kt",
                 // Design-system: composable components, theme, navigation primitives
                 "**/designsystem/presentation/**/*.kt",
                 "**/designsystem/foundation/**/*.kt",
                 "**/designsystem/navigation/**/*.kt",
                 "**/designsystem/permission/**/*.kt",
+                // Design-system: debug previews, transitions, extensions — UI-only
+                "**/designsystem/preview/**/*.kt",
+                "**/designsystem/transition/**/*.kt",
+                "**/designsystem/extension/**/*.kt",
                 // Compose navigation graphs — only testable via instrumentation
                 "**/navigation/*Navigation.kt",
                 "**/navigation/*NavHost.kt",
@@ -133,13 +144,39 @@ sonarqube {
                 "**/*ModuleAggregations*.kt",
                 // DataStore — requires Android Context, not unit-testable
                 "**/datastore/**/*.kt",
+                // PreferenceRepository — thin DataStore delegate wrapper
+                "**/PreferenceRepositoryImpl.kt",
                 // AndroidViewModel — requires Application, not unit-testable
                 "**/AppVersionViewModel.kt",
+                // InstallationIdViewModel — requires Firebase Installation ID (Android runtime)
+                "**/InstallationIdViewModel.kt",
+                // Android entry points — require Android runtime
+                "**/splittrip/App.kt",
+                "**/splittrip/MainActivity.kt",
+                // Crashlytics logging tree — requires Android Crashlytics SDK
+                "**/logging/**/*.kt",
+                // Context-dependent provider implementations (require Android Context)
+                "**/provider/impl/**/*.kt",
+                // WorkManager — requires Android runtime
+                "**/worker/**/*.kt",
                 // Firebase cloud infra — Tasks.await() requires Android main looper
                 "**/firestore/datasource/impl/**/*.kt",
+                // Firestore document data classes (pure DTOs with Firebase Timestamp)
+                "**/firestore/document/**/*.kt",
                 "**/auth/service/impl/**/*.kt",
                 "**/messaging/repository/impl/**/*.kt",
+                "**/messaging/service/**/*.kt",
+                "**/messaging/channel/**/*.kt",
                 "**/installation/service/impl/**/*.kt",
+                // Room DAO interfaces — abstract methods + @Transaction defaults;
+                // requires instrumented tests with Room.inMemoryDatabaseBuilder()
+                "**/local/dao/*.kt",
+                // Room entity projection data classes — pure data holders
+                "**/local/entity/SyncStatusEntry.kt",
+                // Local data sources — thin Room DAO wrappers requiring Android/Robolectric
+                "**/local/datasource/impl/**/*.kt",
+                // Remote data sources — Retrofit HTTP (requires OkHttp/network runtime)
+                "**/remote/datasource/impl/**/*.kt",
                 // Database migrations — raw DDL SQL; no meaningful unit-test path
                 "**/database/DatabaseMigrations.kt",
             ).joinToString(","),

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCard.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCard.kt
@@ -9,7 +9,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,11 +20,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import es.pedrazamiguez.splittrip.core.common.presentation.UiText
+import es.pedrazamiguez.splittrip.core.designsystem.R
 import es.pedrazamiguez.splittrip.core.designsystem.extension.asString
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.input.StyledOutlinedTextField
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.input.rememberAutoFocusRequester
@@ -72,6 +77,7 @@ fun CurrencyConversionCard(
                 exchangeRateLockedHint = state.exchangeRateLockedHint,
                 isInsufficientCash = state.isInsufficientCash
             )
+            StaleRateBanner(isStale = state.isExchangeRateStale)
         }
     }
 }
@@ -156,6 +162,29 @@ private fun ConversionCardLockedHint(
             } else {
                 MaterialTheme.colorScheme.onSurfaceVariant
             }
+        )
+    }
+}
+
+@Composable
+private fun StaleRateBanner(isStale: Boolean) {
+    if (!isStale) return
+
+    Spacer(Modifier.height(8.dp))
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Warning,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.error
+        )
+        Text(
+            text = stringResource(R.string.stale_rate_warning),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error
         )
     }
 }

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCardState.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCardState.kt
@@ -19,6 +19,7 @@ import es.pedrazamiguez.splittrip.core.common.presentation.UiText
  * @param exchangeRateLockedHint Optional hint explaining why the rate is locked.
  * @param isInsufficientCash  Drives error colouring on the locked hint text.
  * @param isGroupAmountError  Shows error styling on the group-amount field.
+ * @param isExchangeRateStale When true, shows a warning that the rate may be outdated.
  * @param autoFocus           If `true`, the exchange-rate field requests focus on first composition.
  */
 data class CurrencyConversionCardState(
@@ -32,5 +33,6 @@ data class CurrencyConversionCardState(
     val exchangeRateLockedHint: UiText? = null,
     val isInsufficientCash: Boolean = false,
     val isGroupAmountError: Boolean = false,
+    val isExchangeRateStale: Boolean = false,
     val autoFocus: Boolean = false
 )

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/layout/SyncStatusIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/layout/SyncStatusIndicator.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.icons.outlined.SyncProblem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,6 +24,10 @@ import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
  *
  * Hidden when the status is [SyncStatus.SYNCED].
  *
+ * Uses [LocalContentColor] for PENDING_SYNC so the indicator automatically
+ * adapts to whatever surface it is placed on (e.g., surfaceContainerLow,
+ * primaryContainer for selected items, etc.).
+ *
  * @param syncStatus Current synchronization status of the entity.
  * @param showLabel  When true, displays a short text label next to the icon.
  * @param modifier   Outer modifier applied to the [Row].
@@ -38,7 +43,7 @@ fun SyncStatusIndicator(
     val isPending = syncStatus == SyncStatus.PENDING_SYNC
     val icon = if (isPending) Icons.Outlined.CloudOff else Icons.Outlined.SyncProblem
     val tint = if (isPending) {
-        MaterialTheme.colorScheme.outline
+        LocalContentColor.current.copy(alpha = 0.7f)
     } else {
         MaterialTheme.colorScheme.error
     }

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/layout/SyncStatusIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/layout/SyncStatusIndicator.kt
@@ -1,0 +1,70 @@
+package es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.SyncProblem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import es.pedrazamiguez.splittrip.core.designsystem.R
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
+
+/**
+ * Compact sync-status indicator that shows an icon + optional text
+ * when the entity has not yet been synced to the cloud.
+ *
+ * Hidden when the status is [SyncStatus.SYNCED].
+ *
+ * @param syncStatus Current synchronization status of the entity.
+ * @param showLabel  When true, displays a short text label next to the icon.
+ * @param modifier   Outer modifier applied to the [Row].
+ */
+@Composable
+fun SyncStatusIndicator(
+    syncStatus: SyncStatus,
+    modifier: Modifier = Modifier,
+    showLabel: Boolean = false
+) {
+    if (syncStatus == SyncStatus.SYNCED) return
+
+    val isPending = syncStatus == SyncStatus.PENDING_SYNC
+    val icon = if (isPending) Icons.Outlined.CloudOff else Icons.Outlined.SyncProblem
+    val tint = if (isPending) {
+        MaterialTheme.colorScheme.outline
+    } else {
+        MaterialTheme.colorScheme.error
+    }
+    val contentDesc = if (isPending) {
+        stringResource(R.string.sync_status_pending)
+    } else {
+        stringResource(R.string.sync_status_failed)
+    }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDesc,
+            modifier = Modifier.size(16.dp),
+            tint = tint
+        )
+        if (showLabel) {
+            Text(
+                text = contentDesc,
+                style = MaterialTheme.typography.labelSmall,
+                color = tint
+            )
+        }
+    }
+}

--- a/core/design-system/src/main/res/values-es/strings.xml
+++ b/core/design-system/src/main/res/values-es/strings.xml
@@ -43,6 +43,13 @@
     <string name="content_description_close">Cerrar</string>
     <string name="content_description_menu">Abrir menú</string>
 
+    <!-- Sync Status -->
+    <string name="sync_status_pending">Aún no sincronizado con el servidor</string>
+    <string name="sync_status_failed">Error de sincronización</string>
+
+    <!-- Stale Exchange Rate -->
+    <string name="stale_rate_warning">⚠️ Los tipos de cambio podrían estar desactualizados</string>
+
     <!-- Generic Error -->
     <string name="error_generic">¡Ups! Algo salió mal</string>
     <string name="error_no_connection">¿Sin internet? Revisa tu conexión</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -43,6 +43,13 @@
     <string name="content_description_close">Close</string>
     <string name="content_description_menu">Open menu</string>
 
+    <!-- Sync Status -->
+    <string name="sync_status_pending">Not yet synced to server</string>
+    <string name="sync_status_failed">Sync failed</string>
+
+    <!-- Stale Exchange Rate -->
+    <string name="stale_rate_warning">⚠️ Rates may be outdated</string>
+
     <!-- Generic Error -->
     <string name="error_generic">Oops! Something went wrong</string>
     <string name="error_no_connection">No internet? Check your connection</string>

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImpl.kt
@@ -4,6 +4,8 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.MetadataChanges
+import com.google.firebase.firestore.Source
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.GroupDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.GroupMemberDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.mapper.toAdminMemberDocument
@@ -81,12 +83,7 @@ class FirestoreGroupDataSourceImpl(
 
         batch
             .commit()
-            .addOnFailureListener { exception ->
-                Timber.w(
-                    exception,
-                    "Create group failed"
-                )
-            }
+            .await()
 
         return groupId
     }
@@ -166,6 +163,15 @@ class FirestoreGroupDataSourceImpl(
             .await()
     }
 
+    override suspend fun verifyGroupOnServer(groupId: String): Boolean {
+        val doc = firestore
+            .collection(GroupDocument.COLLECTION_PATH)
+            .document(groupId)
+            .get(Source.SERVER)
+            .await()
+        return doc.exists()
+    }
+
     override suspend fun fetchAllGroups(): List<Group> {
         val userId = authenticationService.requireUserId()
 
@@ -220,7 +226,11 @@ class FirestoreGroupDataSourceImpl(
             GroupMemberDocument.USER_ID_FIELD,
             userId
         )
-        .addSnapshotListener { snapshot, error ->
+        // MetadataChanges.INCLUDE ensures the listener fires when Firestore
+        // confirms pending local writes (hasPendingWrites transitions to false).
+        // Without this, offline-created groups would stay PENDING_SYNC indefinitely
+        // because the listener only fires on data changes, not metadata changes.
+        .addSnapshotListener(MetadataChanges.INCLUDE) { snapshot, error ->
             if (error != null) {
                 Timber.e(
                     error,

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImplTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImplTest.kt
@@ -1,6 +1,5 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.datasource.impl
 
-import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
@@ -74,11 +73,9 @@ class FirestoreGroupDataSourceImplTest {
 
     private fun mockBatch(): WriteBatch {
         val batch = mockk<WriteBatch>(relaxed = true)
-        val commitTask = mockk<Task<Void>>(relaxed = true)
         every { firestore.batch() } returns batch
         every { batch.set(any(), any()) } returns batch
-        every { batch.commit() } returns commitTask
-        every { commitTask.addOnFailureListener(any()) } returns commitTask
+        every { batch.commit() } returns Tasks.forResult(null)
         return batch
     }
 

--- a/data/local/schemas/es.pedrazamiguez.splittrip.data.local.database.AppDatabase/25.json
+++ b/data/local/schemas/es.pedrazamiguez.splittrip.data.local.database.AppDatabase/25.json
@@ -1,0 +1,787 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "03ee479787745efa0c0db90f5fb76e6b",
+    "entities": [
+      {
+        "tableName": "currencies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`code` TEXT NOT NULL, `symbol` TEXT NOT NULL, `defaultName` TEXT NOT NULL, `decimalDigits` INTEGER NOT NULL, PRIMARY KEY(`code`))",
+        "fields": [
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultName",
+            "columnName": "defaultName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimalDigits",
+            "columnName": "decimalDigits",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "code"
+          ]
+        }
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`baseCurrencyCode` TEXT NOT NULL, `currencyCode` TEXT NOT NULL, `rate` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL, PRIMARY KEY(`baseCurrencyCode`, `currencyCode`))",
+        "fields": [
+          {
+            "fieldPath": "baseCurrencyCode",
+            "columnName": "baseCurrencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "baseCurrencyCode",
+            "currencyCode"
+          ]
+        }
+      },
+      {
+        "tableName": "groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `currencyCode` TEXT NOT NULL, `extraCurrencies` TEXT NOT NULL, `memberIds` TEXT NOT NULL, `mainImagePath` TEXT, `createdAtMillis` INTEGER, `lastUpdatedAtMillis` INTEGER, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraCurrencies",
+            "columnName": "extraCurrencies",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberIds",
+            "columnName": "memberIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mainImagePath",
+            "columnName": "mainImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAtMillis",
+            "columnName": "lastUpdatedAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "expenses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `groupId` TEXT NOT NULL, `title` TEXT NOT NULL, `sourceAmount` INTEGER NOT NULL, `sourceCurrency` TEXT NOT NULL, `groupAmount` INTEGER NOT NULL, `groupCurrency` TEXT NOT NULL, `exchangeRate` TEXT NOT NULL, `category` TEXT, `vendor` TEXT, `notes` TEXT, `paymentMethod` TEXT NOT NULL, `paymentStatus` TEXT, `dueDateMillis` INTEGER, `receiptLocalUri` TEXT, `createdBy` TEXT NOT NULL, `payerType` TEXT NOT NULL, `payerId` TEXT, `splitType` TEXT NOT NULL, `createdAtMillis` INTEGER, `lastUpdatedAtMillis` INTEGER, `cashTranchesJson` TEXT, `addOnsJson` TEXT, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `groups`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceAmount",
+            "columnName": "sourceAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceCurrency",
+            "columnName": "sourceCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupAmount",
+            "columnName": "groupAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupCurrency",
+            "columnName": "groupCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exchangeRate",
+            "columnName": "exchangeRate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vendor",
+            "columnName": "vendor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "paymentMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentStatus",
+            "columnName": "paymentStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dueDateMillis",
+            "columnName": "dueDateMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "receiptLocalUri",
+            "columnName": "receiptLocalUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdBy",
+            "columnName": "createdBy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payerType",
+            "columnName": "payerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payerId",
+            "columnName": "payerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "splitType",
+            "columnName": "splitType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAtMillis",
+            "columnName": "lastUpdatedAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cashTranchesJson",
+            "columnName": "cashTranchesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addOnsJson",
+            "columnName": "addOnsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_expenses_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_expenses_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "groups",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "expense_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `expenseId` TEXT NOT NULL, `userId` TEXT NOT NULL, `amountCents` INTEGER NOT NULL, `percentage` TEXT, `isExcluded` INTEGER NOT NULL, `isCoveredById` TEXT, `subunitId` TEXT, FOREIGN KEY(`expenseId`) REFERENCES `expenses`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expenseId",
+            "columnName": "expenseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amountCents",
+            "columnName": "amountCents",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isExcluded",
+            "columnName": "isExcluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCoveredById",
+            "columnName": "isCoveredById",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subunitId",
+            "columnName": "subunitId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_expense_splits_expenseId",
+            "unique": false,
+            "columnNames": [
+              "expenseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_expense_splits_expenseId` ON `${TABLE_NAME}` (`expenseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "expenses",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "expenseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contributions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `groupId` TEXT NOT NULL, `userId` TEXT NOT NULL, `createdBy` TEXT NOT NULL, `contributionScope` TEXT NOT NULL, `subunitId` TEXT, `linkedExpenseId` TEXT, `amount` INTEGER NOT NULL, `currency` TEXT NOT NULL, `createdAtMillis` INTEGER, `lastUpdatedAtMillis` INTEGER, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `groups`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdBy",
+            "columnName": "createdBy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributionScope",
+            "columnName": "contributionScope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subunitId",
+            "columnName": "subunitId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linkedExpenseId",
+            "columnName": "linkedExpenseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAtMillis",
+            "columnName": "lastUpdatedAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributions_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributions_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_contributions_groupId_linkedExpenseId",
+            "unique": false,
+            "columnNames": [
+              "groupId",
+              "linkedExpenseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributions_groupId_linkedExpenseId` ON `${TABLE_NAME}` (`groupId`, `linkedExpenseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "groups",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cash_withdrawals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `groupId` TEXT NOT NULL, `withdrawnBy` TEXT NOT NULL, `createdBy` TEXT NOT NULL, `withdrawalScope` TEXT NOT NULL, `subunitId` TEXT, `amountWithdrawn` INTEGER NOT NULL, `remainingAmount` INTEGER NOT NULL, `currency` TEXT NOT NULL, `deductedBaseAmount` INTEGER NOT NULL, `exchangeRate` TEXT NOT NULL, `createdAtMillis` INTEGER, `lastUpdatedAtMillis` INTEGER, `addOnsJson` TEXT, `title` TEXT, `notes` TEXT, `receiptLocalUri` TEXT, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `groups`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withdrawnBy",
+            "columnName": "withdrawnBy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdBy",
+            "columnName": "createdBy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withdrawalScope",
+            "columnName": "withdrawalScope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subunitId",
+            "columnName": "subunitId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "amountWithdrawn",
+            "columnName": "amountWithdrawn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remainingAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deductedBaseAmount",
+            "columnName": "deductedBaseAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exchangeRate",
+            "columnName": "exchangeRate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAtMillis",
+            "columnName": "lastUpdatedAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addOnsJson",
+            "columnName": "addOnsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "receiptLocalUri",
+            "columnName": "receiptLocalUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cash_withdrawals_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cash_withdrawals_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "groups",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT, `profileImagePath` TEXT, `createdAtMillis` INTEGER, `lastUpdatedAtMillis` INTEGER, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "profileImagePath",
+            "columnName": "profileImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAtMillis",
+            "columnName": "lastUpdatedAtMillis",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "subunits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `groupId` TEXT NOT NULL, `name` TEXT NOT NULL, `memberIds` TEXT NOT NULL, `memberShares` TEXT NOT NULL, `createdBy` TEXT NOT NULL, `createdAtMillis` INTEGER, `lastUpdatedAtMillis` INTEGER, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `groups`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberIds",
+            "columnName": "memberIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberShares",
+            "columnName": "memberShares",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdBy",
+            "columnName": "createdBy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMillis",
+            "columnName": "createdAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAtMillis",
+            "columnName": "lastUpdatedAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subunits_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subunits_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "groups",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '03ee479787745efa0c0db90f5fb76e6b')"
+    ]
+  }
+}

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import es.pedrazamiguez.splittrip.data.local.entity.CashWithdrawalEntity
+import es.pedrazamiguez.splittrip.data.local.entity.SyncStatusEntry
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -69,6 +70,14 @@ interface CashWithdrawalDao {
     suspend fun clearAllWithdrawals()
 
     /**
+     * Returns sync status metadata for withdrawals in a group that are NOT fully synced.
+     * Used during cloud snapshot reconciliation to preserve PENDING_SYNC / SYNC_FAILED
+     * statuses that would otherwise be overwritten by the upsert (which defaults to SYNCED).
+     */
+    @Query("SELECT id, syncStatus FROM cash_withdrawals WHERE groupId = :groupId AND syncStatus != 'SYNCED'")
+    suspend fun getUnsyncedWithdrawalStatuses(groupId: String): List<SyncStatusEntry>
+
+    /**
      * Deletes withdrawals whose IDs are in the provided list.
      * Used to selectively remove stale withdrawals during sync reconciliation.
      */
@@ -79,21 +88,33 @@ interface CashWithdrawalDao {
      * Reconciles local withdrawals for a group with the authoritative cloud snapshot.
      *
      * Uses a merge strategy instead of destructive delete+insert:
-     * 1. Upsert all remote withdrawals (adds new, updates existing)
-     * 2. Delete only local withdrawals whose IDs are NOT in the remote set
+     * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
+     * 2. Upsert all remote withdrawals (adds new, updates existing — sets syncStatus to SYNCED)
+     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 4. Delete only stale synced withdrawals (not in remote set AND fully synced)
      *
      * This preserves locally-created withdrawals that haven't synced to the cloud yet.
      */
     @Transaction
     suspend fun replaceWithdrawalsForGroup(groupId: String, withdrawals: List<CashWithdrawalEntity>) {
+        // Step 1: Capture non-SYNCED statuses before the upsert overwrites them
+        val unsyncedStatuses = getUnsyncedWithdrawalStatuses(groupId)
+        val unsyncedIds = unsyncedStatuses.map { it.id }.toSet()
+
         val remoteIds = withdrawals.map { it.id }.toSet()
         val localIds = getWithdrawalIdsByGroupId(groupId)
-        val staleIds = localIds.filter { it !in remoteIds }
 
-        // 1. Upsert remote withdrawals (adds new ones, updates existing)
+        // Step 2: Upsert remote withdrawals (sets syncStatus to SYNCED for all)
         insertWithdrawals(withdrawals)
 
-        // 2. Remove only stale withdrawals (exist locally but not in remote snapshot)
+        // Step 3: Restore non-SYNCED statuses for items that existed before
+        for (entry in unsyncedStatuses) {
+            updateSyncStatus(entry.id, entry.syncStatus)
+        }
+
+        // Step 4: Remove stale withdrawals — only those that are NOT in the remote set
+        // AND are NOT in a non-SYNCED state (protect unsynced local data)
+        val staleIds = localIds.filter { it !in remoteIds && it !in unsyncedIds }
         if (staleIds.isNotEmpty()) {
             deleteWithdrawalsByIds(staleIds)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
@@ -28,8 +28,8 @@ interface CashWithdrawalDao {
      */
     @Query(
         """
-        SELECT * FROM cash_withdrawals 
-        WHERE groupId = :groupId AND currency = :currency AND remainingAmount > 0 
+        SELECT * FROM cash_withdrawals
+        WHERE groupId = :groupId AND currency = :currency AND remainingAmount > 0
         ORDER BY createdAtMillis ASC
         """
     )
@@ -51,6 +51,13 @@ interface CashWithdrawalDao {
 
     @Query("DELETE FROM cash_withdrawals WHERE id = :withdrawalId")
     suspend fun deleteWithdrawal(withdrawalId: String)
+
+    /**
+     * Updates the sync status of a single cash withdrawal.
+     * Used to transition between PENDING_SYNC → SYNCED or SYNC_FAILED after cloud sync.
+     */
+    @Query("UPDATE cash_withdrawals SET syncStatus = :status WHERE id = :id")
+    suspend fun updateSyncStatus(id: String, status: String)
 
     @Query("DELETE FROM cash_withdrawals WHERE groupId = :groupId")
     suspend fun deleteWithdrawalsByGroupId(groupId: String)

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import es.pedrazamiguez.splittrip.data.local.entity.ContributionEntity
+import es.pedrazamiguez.splittrip.data.local.entity.SyncStatusEntry
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -48,6 +49,14 @@ interface ContributionDao {
     suspend fun findByLinkedExpenseId(groupId: String, expenseId: String): ContributionEntity?
 
     /**
+     * Returns sync status metadata for contributions in a group that are NOT fully synced.
+     * Used during cloud snapshot reconciliation to preserve PENDING_SYNC / SYNC_FAILED
+     * statuses that would otherwise be overwritten by the upsert (which defaults to SYNCED).
+     */
+    @Query("SELECT id, syncStatus FROM contributions WHERE groupId = :groupId AND syncStatus != 'SYNCED'")
+    suspend fun getUnsyncedContributionStatuses(groupId: String): List<SyncStatusEntry>
+
+    /**
      * Deletes contributions whose IDs are in the provided list.
      * Used to selectively remove stale contributions during sync reconciliation.
      */
@@ -58,21 +67,33 @@ interface ContributionDao {
      * Reconciles local contributions for a group with the authoritative cloud snapshot.
      *
      * Uses a merge strategy instead of destructive delete+insert:
-     * 1. Upsert all remote contributions (adds new, updates existing)
-     * 2. Delete only local contributions whose IDs are NOT in the remote set
+     * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
+     * 2. Upsert all remote contributions (adds new, updates existing — sets syncStatus to SYNCED)
+     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 4. Delete only stale synced contributions (not in remote set AND fully synced)
      *
      * This preserves locally-created contributions that haven't synced to the cloud yet.
      */
     @Transaction
     suspend fun replaceContributionsForGroup(groupId: String, contributions: List<ContributionEntity>) {
+        // Step 1: Capture non-SYNCED statuses before the upsert overwrites them
+        val unsyncedStatuses = getUnsyncedContributionStatuses(groupId)
+        val unsyncedIds = unsyncedStatuses.map { it.id }.toSet()
+
         val remoteIds = contributions.map { it.id }.toSet()
         val localIds = getContributionIdsByGroupId(groupId)
-        val staleIds = localIds.filter { it !in remoteIds }
 
-        // 1. Upsert remote contributions (adds new ones, updates existing)
+        // Step 2: Upsert remote contributions (sets syncStatus to SYNCED for all)
         insertContributions(contributions)
 
-        // 2. Remove only stale contributions (exist locally but not in remote snapshot)
+        // Step 3: Restore non-SYNCED statuses for items that existed before
+        for (entry in unsyncedStatuses) {
+            updateSyncStatus(entry.id, entry.syncStatus)
+        }
+
+        // Step 4: Remove stale contributions — only those that are NOT in the remote set
+        // AND are NOT in a non-SYNCED state (protect unsynced local data)
+        val staleIds = localIds.filter { it !in remoteIds && it !in unsyncedIds }
         if (staleIds.isNotEmpty()) {
             deleteContributionsByIds(staleIds)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
@@ -25,6 +25,13 @@ interface ContributionDao {
     @Query("DELETE FROM contributions WHERE id = :contributionId")
     suspend fun deleteContribution(contributionId: String)
 
+    /**
+     * Updates the sync status of a single contribution.
+     * Used to transition between PENDING_SYNC → SYNCED or SYNC_FAILED after cloud sync.
+     */
+    @Query("UPDATE contributions SET syncStatus = :status WHERE id = :id")
+    suspend fun updateSyncStatus(id: String, status: String)
+
     @Query("DELETE FROM contributions WHERE groupId = :groupId")
     suspend fun deleteContributionsByGroupId(groupId: String)
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
@@ -25,6 +25,13 @@ interface ExpenseDao {
     @Query("DELETE FROM expenses WHERE id = :expenseId")
     suspend fun deleteExpense(expenseId: String)
 
+    /**
+     * Updates the sync status of a single expense.
+     * Used to transition between PENDING_SYNC → SYNCED or SYNC_FAILED after cloud sync.
+     */
+    @Query("UPDATE expenses SET syncStatus = :status WHERE id = :id")
+    suspend fun updateSyncStatus(id: String, status: String)
+
     @Query("DELETE FROM expenses WHERE groupId = :groupId")
     suspend fun deleteExpensesByGroupId(groupId: String)
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import es.pedrazamiguez.splittrip.data.local.entity.ExpenseEntity
+import es.pedrazamiguez.splittrip.data.local.entity.SyncStatusEntry
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -42,6 +43,14 @@ interface ExpenseDao {
     suspend fun clearAllExpenses()
 
     /**
+     * Returns sync status metadata for expenses in a group that are NOT fully synced.
+     * Used during cloud snapshot reconciliation to preserve PENDING_SYNC / SYNC_FAILED
+     * statuses that would otherwise be overwritten by the upsert (which defaults to SYNCED).
+     */
+    @Query("SELECT id, syncStatus FROM expenses WHERE groupId = :groupId AND syncStatus != 'SYNCED'")
+    suspend fun getUnsyncedExpenseStatuses(groupId: String): List<SyncStatusEntry>
+
+    /**
      * Deletes expenses whose IDs are in the provided list.
      * Used to selectively remove stale expenses during sync reconciliation.
      */
@@ -52,24 +61,33 @@ interface ExpenseDao {
      * Reconciles local expenses for a group with the authoritative cloud snapshot.
      *
      * Uses a merge strategy instead of destructive delete+insert:
-     * 1. Upsert all remote expenses (adds new, updates existing)
-     * 2. Delete only local expenses whose IDs are NOT in the remote set
+     * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
+     * 2. Upsert all remote expenses (adds new, updates existing — sets syncStatus to SYNCED)
+     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 4. Delete only stale synced expenses (not in remote set AND fully synced)
      *
      * This preserves locally-created expenses that haven't synced to the cloud yet.
-     * The Firestore SDK's latency compensation includes pending writes in snapshots,
-     * so this race is extremely narrow, but the merge strategy provides an extra
-     * safety net to prevent data loss of unsynced offline changes.
      */
     @Transaction
     suspend fun replaceExpensesForGroup(groupId: String, expenses: List<ExpenseEntity>) {
+        // Step 1: Capture non-SYNCED statuses before the upsert overwrites them
+        val unsyncedStatuses = getUnsyncedExpenseStatuses(groupId)
+        val unsyncedIds = unsyncedStatuses.map { it.id }.toSet()
+
         val remoteIds = expenses.map { it.id }.toSet()
         val localIds = getExpenseIdsByGroupId(groupId)
-        val staleIds = localIds.filter { it !in remoteIds }
 
-        // 1. Upsert remote expenses (adds new ones, updates existing)
+        // Step 2: Upsert remote expenses (sets syncStatus to SYNCED for all)
         insertExpenses(expenses)
 
-        // 2. Remove only stale expenses (exist locally but not in remote snapshot)
+        // Step 3: Restore non-SYNCED statuses for items that existed before
+        for (entry in unsyncedStatuses) {
+            updateSyncStatus(entry.id, entry.syncStatus)
+        }
+
+        // Step 4: Remove stale expenses — only those that are NOT in the remote set
+        // AND are NOT in a non-SYNCED state (protect unsynced local data)
+        val staleIds = localIds.filter { it !in remoteIds && it !in unsyncedIds }
         if (staleIds.isNotEmpty()) {
             deleteExpensesByIds(staleIds)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/GroupDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/GroupDao.kt
@@ -62,6 +62,13 @@ interface GroupDao {
     suspend fun deleteGroup(groupId: String)
 
     /**
+     * Updates the sync status of a single group.
+     * Used to transition between PENDING_SYNC → SYNCED or SYNC_FAILED after cloud sync.
+     */
+    @Query("UPDATE groups SET syncStatus = :status WHERE id = :id")
+    suspend fun updateSyncStatus(id: String, status: String)
+
+    /**
      * Retrieves all group IDs currently stored locally.
      * Used during reconciliation to identify stale groups.
      */

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/GroupDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/GroupDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import es.pedrazamiguez.splittrip.data.local.entity.GroupEntity
+import es.pedrazamiguez.splittrip.data.local.entity.SyncStatusEntry
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -76,6 +77,21 @@ interface GroupDao {
     suspend fun getAllGroupIds(): List<String>
 
     /**
+     * Returns sync status metadata for all groups that are NOT fully synced.
+     * Used during cloud snapshot reconciliation to preserve PENDING_SYNC / SYNC_FAILED
+     * statuses that would otherwise be overwritten by the upsert (which defaults to SYNCED).
+     */
+    @Query("SELECT id, syncStatus FROM groups WHERE syncStatus != 'SYNCED'")
+    suspend fun getUnsyncedGroupStatuses(): List<SyncStatusEntry>
+
+    /**
+     * Returns IDs of groups that are still waiting for server confirmation.
+     * Used after reconciliation to attempt server verification and transition to SYNCED.
+     */
+    @Query("SELECT id FROM groups WHERE syncStatus = 'PENDING_SYNC'")
+    suspend fun getPendingSyncGroupIds(): List<String>
+
+    /**
      * Deletes groups whose IDs are in the provided list.
      * Used to selectively remove stale groups during sync reconciliation.
      */
@@ -86,27 +102,40 @@ interface GroupDao {
      * Reconciles local groups with the authoritative cloud snapshot.
      *
      * Uses a merge strategy instead of destructive delete+insert:
-     * 1. Upsert all remote groups (adds new, updates existing)
-     * 2. Delete only local groups whose IDs are NOT in the remote set
+     * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
+     * 2. Upsert all remote groups (adds new, updates existing — sets syncStatus to SYNCED)
+     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 4. Delete only stale synced groups (not in remote set AND fully synced)
      *
-     * This preserves locally-created groups that haven't synced to the cloud yet
-     * (their IDs won't be in the remote set, but they also won't be deleted because
-     * the Firestore SDK's latency compensation includes pending writes in snapshots).
+     * This preserves locally-created groups that haven't synced to the cloud yet:
+     * - Their syncStatus (PENDING_SYNC / SYNC_FAILED) is restored after upsert
+     * - They are protected from stale deletion even if not in the remote snapshot
      *
-     * In the narrow race where a snapshot fires before the Firestore local write,
-     * this prevents data loss by keeping unsynced local groups alive until the next
-     * snapshot reconciliation includes them.
+     * The Firestore SDK's latency compensation includes pending writes in snapshots,
+     * so unsynced items typically appear in the remote set. The non-SYNCED protection
+     * adds an extra safety net for the narrow race where a snapshot fires before
+     * the Firestore SDK caches the pending write.
      */
     @Transaction
     suspend fun replaceAllGroups(groups: List<GroupEntity>) {
+        // Step 1: Capture non-SYNCED statuses before the upsert overwrites them
+        val unsyncedStatuses = getUnsyncedGroupStatuses()
+        val unsyncedIds = unsyncedStatuses.map { it.id }.toSet()
+
         val remoteIds = groups.map { it.id }.toSet()
         val localIds = getAllGroupIds()
-        val staleIds = localIds.filter { it !in remoteIds }
 
-        // 1. Upsert remote groups (adds new ones, updates existing)
+        // Step 2: Upsert remote groups (sets syncStatus to SYNCED for all)
         insertGroups(groups)
 
-        // 2. Remove only stale groups (exist locally but not in remote snapshot)
+        // Step 3: Restore non-SYNCED statuses for items that existed before
+        for (entry in unsyncedStatuses) {
+            updateSyncStatus(entry.id, entry.syncStatus)
+        }
+
+        // Step 4: Remove stale groups — only those that are NOT in the remote set
+        // AND are NOT in a non-SYNCED state (protect unsynced local data)
+        val staleIds = localIds.filter { it !in remoteIds && it !in unsyncedIds }
         if (staleIds.isNotEmpty()) {
             deleteGroupsByIds(staleIds)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
@@ -31,6 +31,13 @@ interface SubunitDao {
     @Query("DELETE FROM subunits WHERE id = :subunitId")
     suspend fun deleteSubunit(subunitId: String)
 
+    /**
+     * Updates the sync status of a single subunit.
+     * Used to transition between PENDING_SYNC → SYNCED or SYNC_FAILED after cloud sync.
+     */
+    @Query("UPDATE subunits SET syncStatus = :status WHERE id = :id")
+    suspend fun updateSyncStatus(id: String, status: String)
+
     @Query("DELETE FROM subunits WHERE groupId = :groupId")
     suspend fun deleteSubunitsByGroupId(groupId: String)
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import es.pedrazamiguez.splittrip.data.local.entity.SubunitEntity
+import es.pedrazamiguez.splittrip.data.local.entity.SyncStatusEntry
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -45,6 +46,14 @@ interface SubunitDao {
     suspend fun clearAllSubunits()
 
     /**
+     * Returns sync status metadata for subunits in a group that are NOT fully synced.
+     * Used during cloud snapshot reconciliation to preserve PENDING_SYNC / SYNC_FAILED
+     * statuses that would otherwise be overwritten by the upsert (which defaults to SYNCED).
+     */
+    @Query("SELECT id, syncStatus FROM subunits WHERE groupId = :groupId AND syncStatus != 'SYNCED'")
+    suspend fun getUnsyncedSubunitStatuses(groupId: String): List<SyncStatusEntry>
+
+    /**
      * Deletes subunits whose IDs are in the provided list.
      * Used to selectively remove stale subunits during sync reconciliation.
      */
@@ -55,21 +64,33 @@ interface SubunitDao {
      * Reconciles local subunits for a group with the authoritative cloud snapshot.
      *
      * Uses a merge strategy instead of destructive delete+insert:
-     * 1. Upsert all remote subunits (adds new, updates existing)
-     * 2. Delete only local subunits whose IDs are NOT in the remote set
+     * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
+     * 2. Upsert all remote subunits (adds new, updates existing — sets syncStatus to SYNCED)
+     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 4. Delete only stale synced subunits (not in remote set AND fully synced)
      *
      * This preserves locally-created subunits that haven't synced to the cloud yet.
      */
     @Transaction
     suspend fun replaceSubunitsForGroup(groupId: String, subunits: List<SubunitEntity>) {
+        // Step 1: Capture non-SYNCED statuses before the upsert overwrites them
+        val unsyncedStatuses = getUnsyncedSubunitStatuses(groupId)
+        val unsyncedIds = unsyncedStatuses.map { it.id }.toSet()
+
         val remoteIds = subunits.map { it.id }.toSet()
         val localIds = getSubunitIdsByGroupId(groupId)
-        val staleIds = localIds.filter { it !in remoteIds }
 
-        // 1. Upsert remote subunits (adds new ones, updates existing)
+        // Step 2: Upsert remote subunits (sets syncStatus to SYNCED for all)
         insertSubunits(subunits)
 
-        // 2. Remove only stale subunits (exist locally but not in remote snapshot)
+        // Step 3: Restore non-SYNCED statuses for items that existed before
+        for (entry in unsyncedStatuses) {
+            updateSyncStatus(entry.id, entry.syncStatus)
+        }
+
+        // Step 4: Remove stale subunits — only those that are NOT in the remote set
+        // AND are NOT in a non-SYNCED state (protect unsynced local data)
+        val staleIds = localIds.filter { it !in remoteIds && it !in unsyncedIds }
         if (staleIds.isNotEmpty()) {
             deleteSubunitsByIds(staleIds)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/database/AppDatabase.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/database/AppDatabase.kt
@@ -39,7 +39,7 @@ import es.pedrazamiguez.splittrip.data.local.entity.UserEntity
         UserEntity::class,
         SubunitEntity::class
     ],
-    version = 24,
+    version = 25,
     exportSchema = true
 )
 @TypeConverters(

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/database/DatabaseMigrations.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/database/DatabaseMigrations.kt
@@ -533,6 +533,23 @@ internal val MIGRATION_23_24 = object : Migration(23, 24) {
 }
 
 /**
+ * Adds `syncStatus` column to all 5 entity tables for offline-first sync tracking.
+ * Defaults to 'SYNCED' so all existing rows (which arrived via cloud snapshot
+ * reconciliation) are correctly marked as already synchronized.
+ *
+ * This column is local-only metadata — it is NOT synced to Firestore.
+ */
+internal val MIGRATION_24_25 = object : Migration(24, 25) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE expenses ADD COLUMN syncStatus TEXT NOT NULL DEFAULT 'SYNCED'")
+        db.execSQL("ALTER TABLE groups ADD COLUMN syncStatus TEXT NOT NULL DEFAULT 'SYNCED'")
+        db.execSQL("ALTER TABLE contributions ADD COLUMN syncStatus TEXT NOT NULL DEFAULT 'SYNCED'")
+        db.execSQL("ALTER TABLE cash_withdrawals ADD COLUMN syncStatus TEXT NOT NULL DEFAULT 'SYNCED'")
+        db.execSQL("ALTER TABLE subunits ADD COLUMN syncStatus TEXT NOT NULL DEFAULT 'SYNCED'")
+    }
+}
+
+/**
  * All Room database migrations, ordered sequentially.
  * Referenced by [es.pedrazamiguez.splittrip.data.local.di.dataLocalModule]
  * when building the [androidx.room.RoomDatabase].
@@ -552,5 +569,6 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_20_21,
     MIGRATION_21_22,
     MIGRATION_22_23,
-    MIGRATION_23_24
+    MIGRATION_23_24,
+    MIGRATION_24_25
 )

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalCashWithdrawalDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalCashWithdrawalDataSourceImpl.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.data.local.dao.CashWithdrawalDao
 import es.pedrazamiguez.splittrip.data.local.mapper.toDomain
 import es.pedrazamiguez.splittrip.data.local.mapper.toEntity
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCashWithdrawalDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -51,6 +52,10 @@ class LocalCashWithdrawalDataSourceImpl(private val cashWithdrawalDao: CashWithd
 
     override suspend fun getWithdrawalIdsByGroup(groupId: String): List<String> =
         cashWithdrawalDao.getWithdrawalIdsByGroupId(groupId)
+
+    override suspend fun updateSyncStatus(withdrawalId: String, syncStatus: SyncStatus) {
+        cashWithdrawalDao.updateSyncStatus(withdrawalId, syncStatus.name)
+    }
 
     override suspend fun clearAllWithdrawals() {
         cashWithdrawalDao.clearAllWithdrawals()

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalContributionDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalContributionDataSourceImpl.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.data.local.dao.ContributionDao
 import es.pedrazamiguez.splittrip.data.local.mapper.toDomain
 import es.pedrazamiguez.splittrip.data.local.mapper.toEntity
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalContributionDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -39,6 +40,10 @@ class LocalContributionDataSourceImpl(private val contributionDao: ContributionD
 
     override suspend fun clearAllContributions() {
         contributionDao.clearAllContributions()
+    }
+
+    override suspend fun updateSyncStatus(contributionId: String, syncStatus: SyncStatus) {
+        contributionDao.updateSyncStatus(contributionId, syncStatus.name)
     }
 
     override suspend fun deleteByLinkedExpenseId(groupId: String, linkedExpenseId: String) {

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalContributionDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalContributionDataSourceImpl.kt
@@ -20,6 +20,9 @@ class LocalContributionDataSourceImpl(private val contributionDao: ContributionD
         contributionDao.insertContribution(contribution.toEntity())
     }
 
+    override suspend fun findContributionById(contributionId: String): Contribution? =
+        contributionDao.getContributionById(contributionId)?.toDomain()
+
     override suspend fun deleteContribution(contributionId: String) {
         contributionDao.deleteContribution(contributionId)
     }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalExpenseDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalExpenseDataSourceImpl.kt
@@ -9,6 +9,7 @@ import es.pedrazamiguez.splittrip.data.local.mapper.toDomainSplits
 import es.pedrazamiguez.splittrip.data.local.mapper.toEntity
 import es.pedrazamiguez.splittrip.data.local.mapper.toSplitEntities
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalExpenseDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -92,6 +93,10 @@ class LocalExpenseDataSourceImpl(
 
     override suspend fun getExpenseIdsByGroup(groupId: String): List<String> =
         expenseDao.getExpenseIdsByGroupId(groupId)
+
+    override suspend fun updateSyncStatus(expenseId: String, syncStatus: SyncStatus) {
+        expenseDao.updateSyncStatus(expenseId, syncStatus.name)
+    }
 
     override suspend fun clearAllExpenses() {
         expenseDao.clearAllExpenses()

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalGroupDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalGroupDataSourceImpl.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.data.local.dao.GroupDao
 import es.pedrazamiguez.splittrip.data.local.mapper.toDomain
 import es.pedrazamiguez.splittrip.data.local.mapper.toEntity
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalGroupDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -38,6 +39,10 @@ class LocalGroupDataSourceImpl(private val groupDao: GroupDao) : LocalGroupDataS
 
     override suspend fun deleteGroup(groupId: String) {
         groupDao.deleteGroup(groupId)
+    }
+
+    override suspend fun updateSyncStatus(groupId: String, syncStatus: SyncStatus) {
+        groupDao.updateSyncStatus(groupId, syncStatus.name)
     }
 
     override suspend fun clearAllGroups() {

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalGroupDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalGroupDataSourceImpl.kt
@@ -45,6 +45,9 @@ class LocalGroupDataSourceImpl(private val groupDao: GroupDao) : LocalGroupDataS
         groupDao.updateSyncStatus(groupId, syncStatus.name)
     }
 
+    override suspend fun getPendingSyncGroupIds(): List<String> =
+        groupDao.getPendingSyncGroupIds()
+
     override suspend fun clearAllGroups() {
         groupDao.clearAllGroups()
     }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalSubunitDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalSubunitDataSourceImpl.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.data.local.dao.SubunitDao
 import es.pedrazamiguez.splittrip.data.local.mapper.toDomain
 import es.pedrazamiguez.splittrip.data.local.mapper.toEntity
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalSubunitDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -41,6 +42,10 @@ class LocalSubunitDataSourceImpl(private val subunitDao: SubunitDao) : LocalSubu
         subunitDao.getSubunitIdsByGroupId(groupId)
 
     override suspend fun getSubunitById(subunitId: String): Subunit? = subunitDao.getSubunitById(subunitId)?.toDomain()
+
+    override suspend fun updateSyncStatus(subunitId: String, syncStatus: SyncStatus) {
+        subunitDao.updateSyncStatus(subunitId, syncStatus.name)
+    }
 
     override suspend fun clearAllSubunits() {
         subunitDao.clearAllSubunits()

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/CashWithdrawalEntity.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/CashWithdrawalEntity.kt
@@ -35,5 +35,6 @@ data class CashWithdrawalEntity(
     val addOnsJson: String? = null,
     val title: String? = null,
     val notes: String? = null,
-    val receiptLocalUri: String? = null
+    val receiptLocalUri: String? = null,
+    val syncStatus: String = "SYNCED"
 )

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/ContributionEntity.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/ContributionEntity.kt
@@ -32,5 +32,6 @@ data class ContributionEntity(
     val amount: Long,
     val currency: String,
     val createdAtMillis: Long?,
-    val lastUpdatedAtMillis: Long?
+    val lastUpdatedAtMillis: Long?,
+    val syncStatus: String = "SYNCED"
 )

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/ExpenseEntity.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/ExpenseEntity.kt
@@ -41,5 +41,6 @@ data class ExpenseEntity(
     val createdAtMillis: Long?,
     val lastUpdatedAtMillis: Long?,
     val cashTranchesJson: String? = null,
-    val addOnsJson: String? = null
+    val addOnsJson: String? = null,
+    val syncStatus: String = "SYNCED"
 )

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/GroupEntity.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/GroupEntity.kt
@@ -19,5 +19,6 @@ data class GroupEntity(
     val memberIds: List<String>,
     val mainImagePath: String?,
     val createdAtMillis: Long?,
-    val lastUpdatedAtMillis: Long?
+    val lastUpdatedAtMillis: Long?,
+    val syncStatus: String = "SYNCED"
 )

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/SubunitEntity.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/SubunitEntity.kt
@@ -27,5 +27,6 @@ data class SubunitEntity(
     val memberShares: Map<String, BigDecimal>,
     val createdBy: String,
     val createdAtMillis: Long?,
-    val lastUpdatedAtMillis: Long?
+    val lastUpdatedAtMillis: Long?,
+    val syncStatus: String = "SYNCED"
 )

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/SyncStatusEntry.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/entity/SyncStatusEntry.kt
@@ -1,0 +1,8 @@
+package es.pedrazamiguez.splittrip.data.local.entity
+
+/**
+ * Lightweight projection for querying sync status metadata.
+ * Used by DAO @Transaction methods to preserve non-SYNCED statuses
+ * during cloud snapshot reconciliation.
+ */
+data class SyncStatusEntry(val id: String, val syncStatus: String)

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/CashWithdrawalEntityMapper.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/CashWithdrawalEntityMapper.kt
@@ -5,6 +5,7 @@ import es.pedrazamiguez.splittrip.core.common.extensions.toLocalDateTimeUtc
 import es.pedrazamiguez.splittrip.data.local.converter.AddOnListConverter
 import es.pedrazamiguez.splittrip.data.local.entity.CashWithdrawalEntity
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import java.math.BigDecimal
 
@@ -27,7 +28,8 @@ fun CashWithdrawalEntity.toDomain(): CashWithdrawal = CashWithdrawal(
     notes = notes,
     receiptLocalUri = receiptLocalUri,
     createdAt = createdAtMillis?.toLocalDateTimeUtc(),
-    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc()
+    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc(),
+    syncStatus = SyncStatus.fromStringOrDefault(syncStatus)
 )
 
 fun CashWithdrawal.toEntity(): CashWithdrawalEntity {
@@ -51,7 +53,8 @@ fun CashWithdrawal.toEntity(): CashWithdrawalEntity {
         addOnsJson = addOnConverter.fromAddOnList(addOns.ifEmpty { null }),
         title = title,
         notes = notes,
-        receiptLocalUri = receiptLocalUri
+        receiptLocalUri = receiptLocalUri,
+        syncStatus = syncStatus.name
     )
 }
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ContributionEntityMapper.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ContributionEntityMapper.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.core.common.extensions.toEpochMillisUtc
 import es.pedrazamiguez.splittrip.core.common.extensions.toLocalDateTimeUtc
 import es.pedrazamiguez.splittrip.data.local.entity.ContributionEntity
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 
 fun ContributionEntity.toDomain(): Contribution = Contribution(
@@ -17,7 +18,8 @@ fun ContributionEntity.toDomain(): Contribution = Contribution(
     amount = amount,
     currency = currency,
     createdAt = createdAtMillis?.toLocalDateTimeUtc(),
-    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc()
+    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc(),
+    syncStatus = SyncStatus.fromStringOrDefault(syncStatus)
 )
 
 fun Contribution.toEntity(): ContributionEntity {
@@ -35,7 +37,8 @@ fun Contribution.toEntity(): ContributionEntity {
         amount = amount,
         currency = currency,
         createdAtMillis = effectiveCreatedAtMillis,
-        lastUpdatedAtMillis = effectiveLastUpdatedAtMillis
+        lastUpdatedAtMillis = effectiveLastUpdatedAtMillis,
+        syncStatus = syncStatus.name
     )
 }
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ExpenseEntityMapper.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ExpenseEntityMapper.kt
@@ -10,6 +10,7 @@ import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import java.math.BigDecimal
 
@@ -46,7 +47,8 @@ fun ExpenseEntity.toDomain(): Expense {
         payerType = resolvedPayerType,
         payerId = payerId.takeUnless { resolvedPayerType == PayerType.GROUP },
         createdAt = createdAtMillis?.toLocalDateTimeUtc(),
-        lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc()
+        lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc(),
+        syncStatus = SyncStatus.fromStringOrDefault(syncStatus)
     )
 }
 
@@ -77,7 +79,8 @@ fun Expense.toEntity(): ExpenseEntity {
         createdAtMillis = effectiveCreatedAtMillis,
         lastUpdatedAtMillis = effectiveLastUpdatedAtMillis,
         cashTranchesJson = cashTrancheConverter.fromCashTrancheList(cashTranches.ifEmpty { null }),
-        addOnsJson = addOnConverter.fromAddOnList(addOns.ifEmpty { null })
+        addOnsJson = addOnConverter.fromAddOnList(addOns.ifEmpty { null }),
+        syncStatus = syncStatus.name
     )
 }
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/GroupEntityMapper.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/GroupEntityMapper.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.local.mapper
 import es.pedrazamiguez.splittrip.core.common.extensions.toEpochMillisUtc
 import es.pedrazamiguez.splittrip.core.common.extensions.toLocalDateTimeUtc
 import es.pedrazamiguez.splittrip.data.local.entity.GroupEntity
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 
 /**
@@ -17,7 +18,8 @@ fun GroupEntity.toDomain(): Group = Group(
     members = memberIds.sorted(),
     mainImagePath = mainImagePath,
     createdAt = createdAtMillis?.toLocalDateTimeUtc(),
-    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc()
+    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc(),
+    syncStatus = SyncStatus.fromStringOrDefault(syncStatus)
 )
 
 /**
@@ -32,7 +34,8 @@ fun Group.toEntity(): GroupEntity = GroupEntity(
     memberIds = members,
     mainImagePath = mainImagePath,
     createdAtMillis = createdAt?.toEpochMillisUtc(),
-    lastUpdatedAtMillis = lastUpdatedAt?.toEpochMillisUtc()
+    lastUpdatedAtMillis = lastUpdatedAt?.toEpochMillisUtc(),
+    syncStatus = syncStatus.name
 )
 
 /**

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/SubunitEntityMapper.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/SubunitEntityMapper.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.local.mapper
 import es.pedrazamiguez.splittrip.core.common.extensions.toEpochMillisUtc
 import es.pedrazamiguez.splittrip.core.common.extensions.toLocalDateTimeUtc
 import es.pedrazamiguez.splittrip.data.local.entity.SubunitEntity
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 
 fun SubunitEntity.toDomain(): Subunit = Subunit(
@@ -13,7 +14,8 @@ fun SubunitEntity.toDomain(): Subunit = Subunit(
     memberShares = memberShares,
     createdBy = createdBy,
     createdAt = createdAtMillis?.toLocalDateTimeUtc(),
-    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc()
+    lastUpdatedAt = lastUpdatedAtMillis?.toLocalDateTimeUtc(),
+    syncStatus = SyncStatus.fromStringOrDefault(syncStatus)
 )
 
 fun Subunit.toEntity(): SubunitEntity {
@@ -28,7 +30,8 @@ fun Subunit.toEntity(): SubunitEntity {
         memberShares = memberShares,
         createdBy = createdBy,
         createdAtMillis = effectiveCreatedAtMillis,
-        lastUpdatedAtMillis = effectiveLastUpdatedAtMillis
+        lastUpdatedAtMillis = effectiveLastUpdatedAtMillis,
+        syncStatus = syncStatus.name
     )
 }
 

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/CashWithdrawalEntityMapperTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/CashWithdrawalEntityMapperTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.local.mapper
 
 import es.pedrazamiguez.splittrip.data.local.entity.CashWithdrawalEntity
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -112,6 +113,23 @@ class CashWithdrawalEntityMapperTest {
             assertEquals("For dinner", cw.notes)
             assertEquals("file://receipt.jpg", cw.receiptLocalUri)
         }
+
+        @Test
+        fun `default syncStatus maps to SYNCED`() {
+            assertEquals(SyncStatus.SYNCED, fullEntity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `PENDING_SYNC syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "PENDING_SYNC")
+            assertEquals(SyncStatus.PENDING_SYNC, entity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `SYNC_FAILED syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "SYNC_FAILED")
+            assertEquals(SyncStatus.SYNC_FAILED, entity.toDomain().syncStatus)
+        }
     }
 
     @Nested
@@ -181,6 +199,12 @@ class CashWithdrawalEntityMapperTest {
             val entities = listOf(cw, cw.copy(id = "cw-2")).toEntity()
             assertEquals(2, entities.size)
             assertEquals("cw-2", entities[1].id)
+        }
+
+        @Test
+        fun `maps syncStatus to entity string`() {
+            val cw = fullEntity.toDomain().copy(syncStatus = SyncStatus.PENDING_SYNC)
+            assertEquals("PENDING_SYNC", cw.toEntity().syncStatus)
         }
     }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ContributionEntityMapperTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ContributionEntityMapperTest.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.data.local.mapper
 
 import es.pedrazamiguez.splittrip.data.local.entity.ContributionEntity
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -122,6 +123,31 @@ class ContributionEntityMapperTest {
 
             assertEquals("", contribution.createdBy)
         }
+
+        @Test
+        fun `default syncStatus maps to SYNCED`() {
+            val contribution = fullEntity.toDomain()
+
+            assertEquals(SyncStatus.SYNCED, contribution.syncStatus)
+        }
+
+        @Test
+        fun `PENDING_SYNC syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "PENDING_SYNC")
+
+            val contribution = entity.toDomain()
+
+            assertEquals(SyncStatus.PENDING_SYNC, contribution.syncStatus)
+        }
+
+        @Test
+        fun `SYNC_FAILED syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "SYNC_FAILED")
+
+            val contribution = entity.toDomain()
+
+            assertEquals(SyncStatus.SYNC_FAILED, contribution.syncStatus)
+        }
     }
 
     @Nested
@@ -214,6 +240,15 @@ class ContributionEntityMapperTest {
             assertEquals(testSubunitId, entities[0].subunitId)
             assertEquals("contrib-456", entities[1].id)
             assertNull(entities[1].subunitId)
+        }
+
+        @Test
+        fun `maps syncStatus to entity string`() {
+            val pending = fullContribution.copy(syncStatus = SyncStatus.PENDING_SYNC)
+
+            val entity = pending.toEntity()
+
+            assertEquals("PENDING_SYNC", entity.syncStatus)
         }
     }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ExpenseEntityMapperTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/ExpenseEntityMapperTest.kt
@@ -6,6 +6,7 @@ import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -206,6 +207,27 @@ class ExpenseEntityMapperTest {
             assertEquals(PayerType.GROUP, expense.payerType)
             assertNull(expense.payerId)
         }
+
+        @Test
+        fun `default syncStatus maps to SYNCED`() {
+            val expense = fullEntity.toDomain()
+
+            assertEquals(SyncStatus.SYNCED, expense.syncStatus)
+        }
+
+        @Test
+        fun `PENDING_SYNC syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "PENDING_SYNC")
+
+            assertEquals(SyncStatus.PENDING_SYNC, entity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `SYNC_FAILED syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "SYNC_FAILED")
+
+            assertEquals(SyncStatus.SYNC_FAILED, entity.toDomain().syncStatus)
+        }
     }
 
     @Nested
@@ -314,6 +336,15 @@ class ExpenseEntityMapperTest {
             assertEquals(2, entities.size)
             assertEquals("exp-1", entities[0].id)
             assertEquals("exp-2", entities[1].id)
+        }
+
+        @Test
+        fun `maps syncStatus to entity string`() {
+            val expense = fullEntity.toDomain().copy(syncStatus = SyncStatus.SYNC_FAILED)
+
+            val entity = expense.toEntity()
+
+            assertEquals("SYNC_FAILED", entity.syncStatus)
         }
     }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/GroupEntityMapperTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/GroupEntityMapperTest.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.data.local.mapper
 
 import es.pedrazamiguez.splittrip.data.local.entity.GroupEntity
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -69,6 +70,23 @@ class GroupEntityMapperTest {
             val group = entity.toDomain()
             assertNull(group.createdAt)
             assertNull(group.lastUpdatedAt)
+        }
+
+        @Test
+        fun `default syncStatus maps to SYNCED`() {
+            assertEquals(SyncStatus.SYNCED, fullEntity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `PENDING_SYNC syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "PENDING_SYNC")
+            assertEquals(SyncStatus.PENDING_SYNC, entity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `SYNC_FAILED syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "SYNC_FAILED")
+            assertEquals(SyncStatus.SYNC_FAILED, entity.toDomain().syncStatus)
         }
     }
 
@@ -144,6 +162,12 @@ class GroupEntityMapperTest {
             val entities = listOf(group, group.copy(id = "grp-2")).toEntity()
             assertEquals(2, entities.size)
             assertEquals("grp-2", entities[1].id)
+        }
+
+        @Test
+        fun `maps syncStatus to entity string`() {
+            val group = fullEntity.toDomain().copy(syncStatus = SyncStatus.PENDING_SYNC)
+            assertEquals("PENDING_SYNC", group.toEntity().syncStatus)
         }
     }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/SubunitEntityMapperTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/mapper/SubunitEntityMapperTest.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.data.local.mapper
 
 import es.pedrazamiguez.splittrip.data.local.entity.SubunitEntity
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -97,6 +98,12 @@ class SubunitEntityMapperTest {
             assertTrue(entity.memberIds.isEmpty())
             assertTrue(entity.memberShares.isEmpty())
         }
+
+        @Test
+        fun `maps syncStatus to entity string`() {
+            val subunit = fullSubunit.copy(syncStatus = SyncStatus.PENDING_SYNC)
+            assertEquals("PENDING_SYNC", subunit.toEntity().syncStatus)
+        }
     }
 
     @Nested
@@ -157,6 +164,23 @@ class SubunitEntityMapperTest {
 
             assertTrue(subunit.memberIds.isEmpty())
             assertTrue(subunit.memberShares.isEmpty())
+        }
+
+        @Test
+        fun `default syncStatus maps to SYNCED`() {
+            assertEquals(SyncStatus.SYNCED, fullEntity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `PENDING_SYNC syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "PENDING_SYNC")
+            assertEquals(SyncStatus.PENDING_SYNC, entity.toDomain().syncStatus)
+        }
+
+        @Test
+        fun `SYNC_FAILED syncStatus maps correctly`() {
+            val entity = fullEntity.copy(syncStatus = "SYNC_FAILED")
+            assertEquals(SyncStatus.SYNC_FAILED, entity.toDomain().syncStatus)
         }
     }
 

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
@@ -34,6 +34,13 @@ class CashWithdrawalRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
+    /**
+     * Tracks IDs of cash withdrawals deleted locally while in PENDING_SYNC state.
+     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
+     * these entities during reconciliation.
+     */
+    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
     override suspend fun addWithdrawal(groupId: String, withdrawal: CashWithdrawal) {
         val withdrawalId = withdrawal.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -144,8 +151,17 @@ class CashWithdrawalRepositoryImpl(
     }
 
     override suspend fun deleteWithdrawal(groupId: String, withdrawalId: String) {
+        val withdrawal = localCashWithdrawalDataSource.getWithdrawalById(withdrawalId)
+        val wasPendingSync = withdrawal?.syncStatus == SyncStatus.PENDING_SYNC
+
         // Delete from local first - UI updates instantly via Flow
         localCashWithdrawalDataSource.deleteWithdrawal(withdrawalId)
+
+        if (wasPendingSync) {
+            deletedPendingSyncIds.add(withdrawalId)
+            Timber.d("Cash withdrawal deleted locally (was PENDING_SYNC, skipping cloud): $withdrawalId")
+            return
+        }
 
         // Sync deletion to cloud in background
         syncScope.launch {
@@ -174,11 +190,21 @@ class CashWithdrawalRepositoryImpl(
             cloudCashWithdrawalDataSource.getWithdrawalsByGroupIdFlow(groupId)
                 .collect { remoteWithdrawals ->
                     try {
-                        Timber.d("Real-time sync: ${remoteWithdrawals.size} cash withdrawals for group $groupId")
+                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
+                            remoteWithdrawals.filter { it.id !in deletedPendingSyncIds }
+                        } else {
+                            remoteWithdrawals
+                        }
+                        Timber.d("Real-time sync: ${filtered.size} cash withdrawals for group $groupId")
                         localCashWithdrawalDataSource.replaceWithdrawalsForGroup(
                             groupId,
-                            remoteWithdrawals
+                            filtered
                         )
+
+                        if (deletedPendingSyncIds.isNotEmpty()) {
+                            val remoteIds = remoteWithdrawals.map { it.id }.toSet()
+                            deletedPendingSyncIds.removeAll(remoteIds)
+                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling cash withdrawals from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudCashWithdrawalDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCashWithdrawalDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
@@ -46,7 +47,8 @@ class CashWithdrawalRepositoryImpl(
             remainingAmount = withdrawal.remainingAmount.takeIf { it > 0 }
                 ?: withdrawal.amountWithdrawn,
             createdAt = withdrawal.createdAt ?: currentTimestamp,
-            lastUpdatedAt = currentTimestamp
+            lastUpdatedAt = currentTimestamp,
+            syncStatus = SyncStatus.PENDING_SYNC
         )
 
         // Save to local first - UI updates instantly via Flow
@@ -56,9 +58,11 @@ class CashWithdrawalRepositoryImpl(
         syncScope.launch {
             try {
                 cloudCashWithdrawalDataSource.addWithdrawal(groupId, withdrawalWithMetadata)
+                localCashWithdrawalDataSource.updateSyncStatus(withdrawalWithMetadata.id, SyncStatus.SYNCED)
                 Timber.d("Cash withdrawal synced to cloud: ${withdrawalWithMetadata.id}")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to sync cash withdrawal to cloud, will retry later")
+                localCashWithdrawalDataSource.updateSyncStatus(withdrawalWithMetadata.id, SyncStatus.SYNC_FAILED)
+                Timber.w(e, "Failed to sync cash withdrawal to cloud")
             }
         }
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
@@ -34,6 +34,13 @@ class ContributionRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
+    /**
+     * Tracks IDs of contributions deleted locally while in PENDING_SYNC state.
+     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
+     * these entities during reconciliation.
+     */
+    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
     override suspend fun addContribution(groupId: String, contribution: Contribution) {
         val contributionId = contribution.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -85,8 +92,17 @@ class ContributionRepositoryImpl(
             }
 
     override suspend fun deleteContribution(groupId: String, contributionId: String) {
+        val contribution = localContributionDataSource.findContributionById(contributionId)
+        val wasPendingSync = contribution?.syncStatus == SyncStatus.PENDING_SYNC
+
         // Delete from local first - UI updates instantly via Flow
         localContributionDataSource.deleteContribution(contributionId)
+
+        if (wasPendingSync) {
+            deletedPendingSyncIds.add(contributionId)
+            Timber.d("Contribution deleted locally (was PENDING_SYNC, skipping cloud): $contributionId")
+            return
+        }
 
         // Sync deletion to cloud in background
         syncScope.launch {
@@ -148,11 +164,21 @@ class ContributionRepositoryImpl(
             cloudContributionDataSource.getContributionsByGroupIdFlow(groupId)
                 .collect { remoteContributions ->
                     try {
-                        Timber.d("Real-time sync: ${remoteContributions.size} contributions for group $groupId")
+                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
+                            remoteContributions.filter { it.id !in deletedPendingSyncIds }
+                        } else {
+                            remoteContributions
+                        }
+                        Timber.d("Real-time sync: ${filtered.size} contributions for group $groupId")
                         localContributionDataSource.replaceContributionsForGroup(
                             groupId,
-                            remoteContributions
+                            filtered
                         )
+
+                        if (deletedPendingSyncIds.isNotEmpty()) {
+                            val remoteIds = remoteContributions.map { it.id }.toSet()
+                            deletedPendingSyncIds.removeAll(remoteIds)
+                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling contributions from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudContributionDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalContributionDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
@@ -44,7 +45,8 @@ class ContributionRepositoryImpl(
             userId = contribution.userId.ifBlank { currentUserId },
             createdBy = currentUserId,
             createdAt = contribution.createdAt ?: currentTimestamp,
-            lastUpdatedAt = currentTimestamp
+            lastUpdatedAt = currentTimestamp,
+            syncStatus = SyncStatus.PENDING_SYNC
         )
 
         // Save to local first - UI updates instantly via Flow
@@ -54,9 +56,11 @@ class ContributionRepositoryImpl(
         syncScope.launch {
             try {
                 cloudContributionDataSource.addContribution(groupId, contributionWithMetadata)
+                localContributionDataSource.updateSyncStatus(contributionWithMetadata.id, SyncStatus.SYNCED)
                 Timber.d("Contribution synced to cloud: ${contributionWithMetadata.id}")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to sync contribution to cloud, will retry later")
+                localContributionDataSource.updateSyncStatus(contributionWithMetadata.id, SyncStatus.SYNC_FAILED)
+                Timber.w(e, "Failed to sync contribution to cloud")
             }
         }
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -34,6 +34,13 @@ class ExpenseRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
+    /**
+     * Tracks IDs of expenses deleted locally while in PENDING_SYNC state.
+     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
+     * these entities during reconciliation.
+     */
+    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
     override suspend fun addExpense(groupId: String, expense: Expense) {
         val expenseId = expense.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -67,8 +74,17 @@ class ExpenseRepositoryImpl(
     override suspend fun getExpenseById(expenseId: String): Expense? = localExpenseDataSource.getExpenseById(expenseId)
 
     override suspend fun deleteExpense(groupId: String, expenseId: String) {
+        val expense = localExpenseDataSource.getExpenseById(expenseId)
+        val wasPendingSync = expense?.syncStatus == SyncStatus.PENDING_SYNC
+
         // Delete from local first - UI updates instantly via Flow
         localExpenseDataSource.deleteExpense(expenseId)
+
+        if (wasPendingSync) {
+            deletedPendingSyncIds.add(expenseId)
+            Timber.d("Expense deleted locally (was PENDING_SYNC, skipping cloud): $expenseId")
+            return
+        }
 
         // Sync deletion to cloud in background
         syncScope.launch {
@@ -123,8 +139,18 @@ class ExpenseRepositoryImpl(
             cloudExpenseDataSource.getExpensesByGroupIdFlow(groupId)
                 .collect { remoteExpenses ->
                     try {
-                        Timber.d("Real-time sync: ${remoteExpenses.size} expenses for group $groupId")
-                        localExpenseDataSource.replaceExpensesForGroup(groupId, remoteExpenses)
+                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
+                            remoteExpenses.filter { it.id !in deletedPendingSyncIds }
+                        } else {
+                            remoteExpenses
+                        }
+                        Timber.d("Real-time sync: ${filtered.size} expenses for group $groupId")
+                        localExpenseDataSource.replaceExpensesForGroup(groupId, filtered)
+
+                        if (deletedPendingSyncIds.isNotEmpty()) {
+                            val remoteIds = remoteExpenses.map { it.id }.toSet()
+                            deletedPendingSyncIds.removeAll(remoteIds)
+                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling expenses from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudExpenseDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalExpenseDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
@@ -43,7 +44,8 @@ class ExpenseRepositoryImpl(
             groupId = groupId,
             createdBy = expense.createdBy.ifBlank { currentUserId },
             createdAt = expense.createdAt ?: currentTimestamp,
-            lastUpdatedAt = currentTimestamp
+            lastUpdatedAt = currentTimestamp,
+            syncStatus = SyncStatus.PENDING_SYNC
         )
 
         // Save to local first - UI updates instantly via Flow
@@ -53,9 +55,11 @@ class ExpenseRepositoryImpl(
         syncScope.launch {
             try {
                 cloudExpenseDataSource.addExpense(groupId, expenseWithMetadata)
+                localExpenseDataSource.updateSyncStatus(expenseWithMetadata.id, SyncStatus.SYNCED)
                 Timber.d("Expense synced to cloud: ${expenseWithMetadata.id}")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to sync expense to cloud, will retry later")
+                localExpenseDataSource.updateSyncStatus(expenseWithMetadata.id, SyncStatus.SYNC_FAILED)
+                Timber.w(e, "Failed to sync expense to cloud")
             }
         }
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
@@ -148,7 +148,7 @@ class GroupRepositoryImpl(
                 // Keep as PENDING_SYNC (already the current status from local save).
                 // The confirmPendingSyncGroups() mechanism will transition to SYNCED
                 // when the snapshot listener re-fires after server confirmation.
-                Timber.d("Group saved to Firestore cache, pending server confirmation: $groupId")
+                Timber.d(e, "Group saved to Firestore cache, pending server confirmation: $groupId")
             }
         }
 
@@ -294,7 +294,7 @@ class GroupRepositoryImpl(
                 }
             } catch (e: Exception) {
                 // Server unreachable — keep as PENDING_SYNC
-                Timber.d("Cannot confirm group $id — server unreachable")
+                Timber.d(e, "Cannot confirm group $id — server unreachable")
             }
         }
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
@@ -7,6 +7,7 @@ import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import es.pedrazamiguez.splittrip.domain.repository.GroupRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +42,14 @@ class GroupRepositoryImpl(
      * WhileSubscribed resubscriptions).
      */
     private var cloudSubscriptionJob: Job? = null
+
+    /**
+     * Tracks IDs of groups deleted locally while in PENDING_SYNC state (never synced to server).
+     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
+     * these entities during reconciliation. Safe as in-memory only: if the process dies,
+     * the Firestore SDK's pending write cache also dies, eliminating the resurrection vector.
+     */
+    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     /**
      * Returns a Flow of groups from local storage.
@@ -83,6 +92,14 @@ class GroupRepositoryImpl(
     /**
      * Creates a group locally first, then syncs to cloud.
      * Ensures offline support by saving to local database before cloud sync.
+     *
+     * The sync status transitions follow a two-phase verification:
+     * 1. Cloud write: batch commit to Firestore (may resolve from local cache if offline)
+     * 2. Server verification: Source.SERVER read to confirm the write reached the server
+     *
+     * - Online: both succeed → SYNCED
+     * - Offline: write cached locally, verification fails → stays PENDING_SYNC
+     * - Error: write rejected by Firestore (permissions, etc.) → SYNC_FAILED
      */
     override suspend fun createGroup(group: Group): String {
         val groupId = java.util.UUID.randomUUID().toString()
@@ -109,15 +126,29 @@ class GroupRepositoryImpl(
         // Save to local FIRST - UI updates instantly
         localGroupDataSource.saveGroup(createdGroup)
 
-        // Sync to cloud in background
+        // Sync to cloud in background with two-phase verification
         syncScope.launch {
+            // Phase 1: Write to Firestore (resolves from local cache if offline)
             try {
                 cloudGroupDataSource.createGroup(createdGroup)
-                localGroupDataSource.updateSyncStatus(groupId, SyncStatus.SYNCED)
-                Timber.d("Group synced to cloud: $groupId")
             } catch (e: Exception) {
+                // Actual write failure (permission denied, invalid data, etc.)
                 localGroupDataSource.updateSyncStatus(groupId, SyncStatus.SYNC_FAILED)
                 Timber.w(e, "Failed to sync group to cloud")
+                return@launch
+            }
+
+            // Phase 2: Verify the write reached the server (Source.SERVER round-trip)
+            try {
+                cloudGroupDataSource.verifyGroupOnServer(groupId)
+                localGroupDataSource.updateSyncStatus(groupId, SyncStatus.SYNCED)
+                Timber.d("Group synced and confirmed on server: $groupId")
+            } catch (e: Exception) {
+                // Server unreachable — write is cached in Firestore, will sync automatically.
+                // Keep as PENDING_SYNC (already the current status from local save).
+                // The confirmPendingSyncGroups() mechanism will transition to SYNCED
+                // when the snapshot listener re-fires after server confirmation.
+                Timber.d("Group saved to Firestore cache, pending server confirmation: $groupId")
             }
         }
 
@@ -147,9 +178,24 @@ class GroupRepositoryImpl(
      *    d. Delete the group document
      */
     override suspend fun deleteGroup(groupId: String) {
+        // Check sync status before deleting — if PENDING_SYNC, the group was never
+        // synced to the server, so there's nothing to delete remotely.
+        val group = localGroupDataSource.getGroupById(groupId)
+        val wasPendingSync = group?.syncStatus == SyncStatus.PENDING_SYNC
+
         // 1. Delete from Room immediately — FK CASCADE handles child entities.
         // UI updates instantly via the observed Room Flow.
         localGroupDataSource.deleteGroup(groupId)
+
+        if (wasPendingSync) {
+            // Track the ID to prevent resurrection via snapshot reconciliation.
+            // The Firestore SDK's pending write cache from createGroup() may still
+            // include this group — the snapshot listener would re-insert it without
+            // this protection.
+            deletedPendingSyncIds.add(groupId)
+            Timber.d("Group deleted locally (was PENDING_SYNC, skipping cloud): $groupId")
+            return
+        }
 
         // 2. Signal Firestore to initiate server-side cascading delete.
         syncScope.launch {
@@ -178,6 +224,11 @@ class GroupRepositoryImpl(
      * - Group modifications by other users → groups are updated locally
      * - Locally-created groups not yet synced → preserved (not deleted)
      *
+     * After reconciliation, [confirmPendingSyncGroups] attempts to verify
+     * any PENDING_SYNC items against the server. This handles the
+     * PENDING_SYNC → SYNCED transition when the device comes back online
+     * and the snapshot listener re-fires with MetadataChanges.INCLUDE.
+     *
      * The Room Flow re-emits automatically after each reconciliation,
      * keeping the UI in sync across all devices in near real-time.
      */
@@ -186,14 +237,65 @@ class GroupRepositoryImpl(
             cloudGroupDataSource.getAllGroupsFlow()
                 .collect { remoteGroups ->
                     try {
-                        Timber.d("Real-time sync: ${remoteGroups.size} groups received")
-                        localGroupDataSource.replaceAllGroups(remoteGroups)
+                        // Filter out groups that were deleted locally while PENDING_SYNC.
+                        // These may appear in the snapshot due to the Firestore SDK's
+                        // pending write cache from the original createGroup() call.
+                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
+                            remoteGroups.filter { it.id !in deletedPendingSyncIds }
+                        } else {
+                            remoteGroups
+                        }
+
+                        val filteredCount = remoteGroups.size - filtered.size
+                        Timber.d(
+                            "Real-time sync: %d groups received (%d filtered)",
+                            filtered.size,
+                            filteredCount
+                        )
+                        localGroupDataSource.replaceAllGroups(filtered)
+                        confirmPendingSyncGroups()
+
+                        // Clean up: IDs from this snapshot cycle have been excluded
+                        if (deletedPendingSyncIds.isNotEmpty()) {
+                            val remoteIds = remoteGroups.map { it.id }.toSet()
+                            deletedPendingSyncIds.removeAll(remoteIds)
+                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling groups from cloud snapshot")
                     }
                 }
         } catch (e: Exception) {
             Timber.w(e, "Error subscribing to cloud group changes, using local cache")
+        }
+    }
+
+    /**
+     * Attempts to confirm PENDING_SYNC groups by verifying their existence on the server.
+     *
+     * Called after each reconciliation cycle. When the device is online and Firestore
+     * has confirmed the pending write, the server verification succeeds and the
+     * group transitions to SYNCED. When offline, the verification throws and the
+     * group remains PENDING_SYNC.
+     *
+     * This mechanism works in conjunction with MetadataChanges.INCLUDE on the
+     * Firestore snapshot listener, which ensures the listener re-fires when
+     * pending writes are confirmed by the server — triggering a new reconciliation
+     * cycle that reaches this method.
+     */
+    private suspend fun confirmPendingSyncGroups() {
+        val pendingIds = localGroupDataSource.getPendingSyncGroupIds()
+        if (pendingIds.isEmpty()) return
+
+        for (id in pendingIds) {
+            try {
+                if (cloudGroupDataSource.verifyGroupOnServer(id)) {
+                    localGroupDataSource.updateSyncStatus(id, SyncStatus.SYNCED)
+                    Timber.d("Confirmed group sync: $id")
+                }
+            } catch (e: Exception) {
+                // Server unreachable — keep as PENDING_SYNC
+                Timber.d("Cannot confirm group $id — server unreachable")
+            }
         }
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 import es.pedrazamiguez.splittrip.data.worker.GroupDeletionRetryScheduler
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudGroupDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalGroupDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import es.pedrazamiguez.splittrip.domain.repository.GroupRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
@@ -101,7 +102,8 @@ class GroupRepositoryImpl(
             id = groupId,
             members = membersWithCreator,
             createdAt = group.createdAt ?: currentTimestamp,
-            lastUpdatedAt = currentTimestamp
+            lastUpdatedAt = currentTimestamp,
+            syncStatus = SyncStatus.PENDING_SYNC
         )
 
         // Save to local FIRST - UI updates instantly
@@ -111,9 +113,11 @@ class GroupRepositoryImpl(
         syncScope.launch {
             try {
                 cloudGroupDataSource.createGroup(createdGroup)
+                localGroupDataSource.updateSyncStatus(groupId, SyncStatus.SYNCED)
                 Timber.d("Group synced to cloud: $groupId")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to sync group to cloud, will retry later")
+                localGroupDataSource.updateSyncStatus(groupId, SyncStatus.SYNC_FAILED)
+                Timber.w(e, "Failed to sync group to cloud")
             }
         }
 

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
@@ -35,6 +35,13 @@ class SubunitRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
+    /**
+     * Tracks IDs of subunits deleted locally while in PENDING_SYNC state.
+     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
+     * these entities during reconciliation.
+     */
+    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
     override suspend fun createSubunit(groupId: String, subunit: Subunit): String {
         val subunitId = subunit.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -93,8 +100,17 @@ class SubunitRepositoryImpl(
     }
 
     override suspend fun deleteSubunit(groupId: String, subunitId: String) {
+        val subunit = localSubunitDataSource.getSubunitById(subunitId)
+        val wasPendingSync = subunit?.syncStatus == SyncStatus.PENDING_SYNC
+
         // Delete from local first - UI updates instantly via Flow
         localSubunitDataSource.deleteSubunit(subunitId)
+
+        if (wasPendingSync) {
+            deletedPendingSyncIds.add(subunitId)
+            Timber.d("Subunit deleted locally (was PENDING_SYNC, skipping cloud): $subunitId")
+            return
+        }
 
         // Sync deletion to cloud in background
         syncScope.launch {
@@ -147,11 +163,21 @@ class SubunitRepositoryImpl(
             cloudSubunitDataSource.getSubunitsByGroupIdFlow(groupId)
                 .collect { remoteSubunits ->
                     try {
-                        Timber.d("Real-time sync: ${remoteSubunits.size} subunits for group $groupId")
+                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
+                            remoteSubunits.filter { it.id !in deletedPendingSyncIds }
+                        } else {
+                            remoteSubunits
+                        }
+                        Timber.d("Real-time sync: ${filtered.size} subunits for group $groupId")
                         localSubunitDataSource.replaceSubunitsForGroup(
                             groupId,
-                            remoteSubunits
+                            filtered
                         )
+
+                        if (deletedPendingSyncIds.isNotEmpty()) {
+                            val remoteIds = remoteSubunits.map { it.id }.toSet()
+                            deletedPendingSyncIds.removeAll(remoteIds)
+                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling subunits from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudSubunitDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalSubunitDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import es.pedrazamiguez.splittrip.domain.repository.SubunitRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
@@ -44,7 +45,8 @@ class SubunitRepositoryImpl(
             groupId = groupId,
             createdBy = subunit.createdBy.ifBlank { currentUserId },
             createdAt = subunit.createdAt ?: currentTimestamp,
-            lastUpdatedAt = currentTimestamp
+            lastUpdatedAt = currentTimestamp,
+            syncStatus = SyncStatus.PENDING_SYNC
         )
 
         // Save to local first - UI updates instantly via Flow
@@ -54,9 +56,11 @@ class SubunitRepositoryImpl(
         syncScope.launch {
             try {
                 cloudSubunitDataSource.addSubunit(groupId, subunitWithMetadata)
+                localSubunitDataSource.updateSyncStatus(subunitWithMetadata.id, SyncStatus.SYNCED)
                 Timber.d("Subunit synced to cloud: ${subunitWithMetadata.id}")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to sync subunit to cloud, will retry later")
+                localSubunitDataSource.updateSyncStatus(subunitWithMetadata.id, SyncStatus.SYNC_FAILED)
+                Timber.w(e, "Failed to sync subunit to cloud")
             }
         }
 
@@ -68,7 +72,8 @@ class SubunitRepositoryImpl(
 
         val updatedSubunit = subunit.copy(
             groupId = groupId,
-            lastUpdatedAt = currentTimestamp
+            lastUpdatedAt = currentTimestamp,
+            syncStatus = SyncStatus.PENDING_SYNC
         )
 
         // Save to local first (upsert) - UI updates instantly via Flow
@@ -78,9 +83,11 @@ class SubunitRepositoryImpl(
         syncScope.launch {
             try {
                 cloudSubunitDataSource.updateSubunit(groupId, updatedSubunit)
+                localSubunitDataSource.updateSyncStatus(updatedSubunit.id, SyncStatus.SYNCED)
                 Timber.d("Subunit update synced to cloud: ${updatedSubunit.id}")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to sync subunit update to cloud, will retry later")
+                localSubunitDataSource.updateSyncStatus(updatedSubunit.id, SyncStatus.SYNC_FAILED)
+                Timber.w(e, "Failed to sync subunit update to cloud")
             }
         }
     }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
@@ -266,5 +266,82 @@ class CashWithdrawalRepositoryImplTest {
                 cloudDataSource.deleteWithdrawal(testGroupId, "w-1")
             }
         }
+
+        @Test
+        fun `skips cloud deletion when withdrawal is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — withdrawal was created offline, never synced
+            val withdrawalId = "pending-w"
+            val pendingWithdrawal = testWithdrawal.copy(
+                id = withdrawalId,
+                syncStatus = SyncStatus.PENDING_SYNC
+            )
+            coEvery { localDataSource.getWithdrawalById(withdrawalId) } returns pendingWithdrawal
+            coEvery { localDataSource.deleteWithdrawal(withdrawalId) } just Runs
+
+            // When
+            repository.deleteWithdrawal(testGroupId, withdrawalId)
+            advanceUntilIdle()
+
+            // Then — should NOT attempt any cloud operation
+            coVerify(exactly = 0) { cloudDataSource.deleteWithdrawal(any(), any()) }
+            // Local delete should still happen
+            coVerify(exactly = 1) { localDataSource.deleteWithdrawal(withdrawalId) }
+        }
+
+        @Test
+        fun `syncs to cloud when withdrawal is SYNCED`() = runTest(testDispatcher) {
+            // Given
+            val withdrawalId = "synced-w"
+            val syncedWithdrawal = testWithdrawal.copy(
+                id = withdrawalId,
+                syncStatus = SyncStatus.SYNCED
+            )
+            coEvery { localDataSource.getWithdrawalById(withdrawalId) } returns syncedWithdrawal
+            coEvery { localDataSource.deleteWithdrawal(withdrawalId) } just Runs
+            coEvery { cloudDataSource.deleteWithdrawal(any(), any()) } just Runs
+
+            // When
+            repository.deleteWithdrawal(testGroupId, withdrawalId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should happen
+            coVerify(exactly = 1) {
+                cloudDataSource.deleteWithdrawal(testGroupId, withdrawalId)
+            }
+        }
+
+        @Test
+        fun `syncs to cloud when withdrawal not found locally`() = runTest(testDispatcher) {
+            // Given — withdrawal not found (null syncStatus != PENDING_SYNC)
+            val withdrawalId = "unknown-w"
+            coEvery { localDataSource.getWithdrawalById(withdrawalId) } returns null
+            coEvery { localDataSource.deleteWithdrawal(withdrawalId) } just Runs
+            coEvery { cloudDataSource.deleteWithdrawal(any(), any()) } just Runs
+
+            // When
+            repository.deleteWithdrawal(testGroupId, withdrawalId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should still happen
+            coVerify(exactly = 1) {
+                cloudDataSource.deleteWithdrawal(testGroupId, withdrawalId)
+            }
+        }
+
+        @Test
+        fun `cloud failure does not affect local delete`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localDataSource.deleteWithdrawal("w-1") } just Runs
+            coEvery {
+                cloudDataSource.deleteWithdrawal(any(), any())
+            } throws RuntimeException("Network error")
+
+            // When
+            repository.deleteWithdrawal(testGroupId, "w-1")
+            advanceUntilIdle()
+
+            // Then - Local delete should still have happened
+            coVerify(exactly = 1) { localDataSource.deleteWithdrawal("w-1") }
+        }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudCashWithdrawalDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCashWithdrawalDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import io.mockk.Runs
@@ -154,6 +155,54 @@ class CashWithdrawalRepositoryImplTest {
 
             // Then - Local save should succeed
             coVerify { localDataSource.saveWithdrawal(any()) }
+        }
+
+        @Test
+        fun `saves with PENDING_SYNC status`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localDataSource.saveWithdrawal(any()) } just Runs
+
+            // When
+            repository.addWithdrawal(testGroupId, testWithdrawal)
+
+            // Then
+            coVerify {
+                localDataSource.saveWithdrawal(
+                    match { it.syncStatus == SyncStatus.PENDING_SYNC }
+                )
+            }
+        }
+
+        @Test
+        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localDataSource.saveWithdrawal(any()) } just Runs
+            coEvery { cloudDataSource.addWithdrawal(any(), any()) } just Runs
+            coEvery { localDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.addWithdrawal(testGroupId, testWithdrawal)
+            advanceUntilIdle()
+
+            // Then
+            coVerify { localDataSource.updateSyncStatus(any(), SyncStatus.SYNCED) }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localDataSource.saveWithdrawal(any()) } just Runs
+            coEvery {
+                cloudDataSource.addWithdrawal(any(), any())
+            } throws RuntimeException("No network")
+            coEvery { localDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.addWithdrawal(testGroupId, testWithdrawal)
+            advanceUntilIdle()
+
+            // Then
+            coVerify { localDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED) }
         }
     }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudContributionDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalContributionDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import io.mockk.Runs
@@ -188,6 +189,68 @@ class ContributionRepositoryImplTest {
 
             // Then - Local save should still have happened
             coVerify(exactly = 1) { localContributionDataSource.saveContribution(any()) }
+        }
+
+        @Test
+        fun `saves with PENDING_SYNC status`() = runTest(testDispatcher) {
+            // Given
+            val contribution = Contribution(amount = 5000L, currency = "EUR")
+            coEvery { localContributionDataSource.saveContribution(any()) } just Runs
+
+            // When
+            repository.addContribution(testGroupId, contribution)
+
+            // Then
+            coVerify {
+                localContributionDataSource.saveContribution(
+                    match { it.syncStatus == SyncStatus.PENDING_SYNC }
+                )
+            }
+        }
+
+        @Test
+        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+            // Given
+            val contribution = Contribution(amount = 5000L, currency = "EUR")
+            coEvery { localContributionDataSource.saveContribution(any()) } just Runs
+            coEvery { cloudContributionDataSource.addContribution(any(), any()) } just Runs
+            coEvery {
+                localContributionDataSource.updateSyncStatus(any(), any())
+            } just Runs
+
+            // When
+            repository.addContribution(testGroupId, contribution)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localContributionDataSource.updateSyncStatus(any(), SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+            // Given
+            val contribution = Contribution(amount = 5000L, currency = "EUR")
+            coEvery { localContributionDataSource.saveContribution(any()) } just Runs
+            coEvery {
+                cloudContributionDataSource.addContribution(any(), any())
+            } throws RuntimeException("Network error")
+            coEvery {
+                localContributionDataSource.updateSyncStatus(any(), any())
+            } just Runs
+
+            // When
+            repository.addContribution(testGroupId, contribution)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localContributionDataSource.updateSyncStatus(
+                    any(),
+                    SyncStatus.SYNC_FAILED
+                )
+            }
         }
     }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
@@ -366,6 +366,87 @@ class ContributionRepositoryImplTest {
                 localContributionDataSource.deleteContribution(contributionId)
             }
         }
+
+        @Test
+        fun `skips cloud deletion when contribution is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — contribution was created offline, never synced
+            val contributionId = "pending-contrib"
+            val pendingContribution = testContribution.copy(
+                id = contributionId,
+                syncStatus = SyncStatus.PENDING_SYNC
+            )
+            coEvery {
+                localContributionDataSource.findContributionById(contributionId)
+            } returns pendingContribution
+            coEvery {
+                localContributionDataSource.deleteContribution(contributionId)
+            } just Runs
+
+            // When
+            repository.deleteContribution(testGroupId, contributionId)
+            advanceUntilIdle()
+
+            // Then — should NOT attempt any cloud operation
+            coVerify(exactly = 0) {
+                cloudContributionDataSource.deleteContribution(any(), any())
+            }
+            // Local delete should still happen
+            coVerify(exactly = 1) {
+                localContributionDataSource.deleteContribution(contributionId)
+            }
+        }
+
+        @Test
+        fun `syncs to cloud when contribution is SYNCED`() = runTest(testDispatcher) {
+            // Given
+            val contributionId = "synced-contrib"
+            val syncedContribution = testContribution.copy(
+                id = contributionId,
+                syncStatus = SyncStatus.SYNCED
+            )
+            coEvery {
+                localContributionDataSource.findContributionById(contributionId)
+            } returns syncedContribution
+            coEvery {
+                localContributionDataSource.deleteContribution(contributionId)
+            } just Runs
+            coEvery {
+                cloudContributionDataSource.deleteContribution(any(), any())
+            } just Runs
+
+            // When
+            repository.deleteContribution(testGroupId, contributionId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should happen
+            coVerify(exactly = 1) {
+                cloudContributionDataSource.deleteContribution(testGroupId, contributionId)
+            }
+        }
+
+        @Test
+        fun `syncs to cloud when contribution not found locally`() = runTest(testDispatcher) {
+            // Given — contribution not found (null syncStatus != PENDING_SYNC)
+            val contributionId = "unknown-contrib"
+            coEvery {
+                localContributionDataSource.findContributionById(contributionId)
+            } returns null
+            coEvery {
+                localContributionDataSource.deleteContribution(contributionId)
+            } just Runs
+            coEvery {
+                cloudContributionDataSource.deleteContribution(any(), any())
+            } just Runs
+
+            // When
+            repository.deleteContribution(testGroupId, contributionId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should still happen
+            coVerify(exactly = 1) {
+                cloudContributionDataSource.deleteContribution(testGroupId, contributionId)
+            }
+        }
     }
 
     @Nested

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -625,5 +625,66 @@ class ExpenseRepositoryImplTest {
             // Then
             coVerify { cloudExpenseDataSource.deleteExpense(groupId, expenseId) }
         }
+
+        @Test
+        fun `skips cloud deletion when expense is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — expense was created offline, never synced
+            val expenseId = "pending-expense"
+            val pendingExpense = testExpense.copy(
+                id = expenseId,
+                syncStatus = SyncStatus.PENDING_SYNC
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns pendingExpense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+
+            // When
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            // Then — should NOT attempt any cloud operation
+            coVerify(exactly = 0) { cloudExpenseDataSource.deleteExpense(any(), any()) }
+            // Local delete should still happen
+            coVerify(exactly = 1) { localExpenseDataSource.deleteExpense(expenseId) }
+        }
+
+        @Test
+        fun `syncs to cloud when expense is SYNCED`() = runTest(testDispatcher) {
+            // Given
+            val expenseId = "synced-expense"
+            val syncedExpense = testExpense.copy(
+                id = expenseId,
+                syncStatus = SyncStatus.SYNCED
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns syncedExpense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
+
+            // When
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should happen
+            coVerify(exactly = 1) {
+                cloudExpenseDataSource.deleteExpense(testGroupId, expenseId)
+            }
+        }
+
+        @Test
+        fun `syncs to cloud when expense not found locally`() = runTest(testDispatcher) {
+            // Given — expense not found (null syncStatus != PENDING_SYNC)
+            val expenseId = "unknown-expense"
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns null
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
+
+            // When
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should still happen
+            coVerify(exactly = 1) {
+                cloudExpenseDataSource.deleteExpense(testGroupId, expenseId)
+            }
+        }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudExpenseDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalExpenseDataSource
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import io.mockk.Runs
@@ -278,6 +279,58 @@ class ExpenseRepositoryImplTest {
 
             // Verify local save succeeded despite cloud failure
             coVerify { localExpenseDataSource.saveExpense(any()) }
+        }
+
+        @Test
+        fun `saves with PENDING_SYNC status`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localExpenseDataSource.saveExpense(any()) } just Runs
+
+            // When
+            repository.addExpense(testGroupId, testExpense)
+
+            // Then
+            coVerify {
+                localExpenseDataSource.saveExpense(
+                    match { it.syncStatus == SyncStatus.PENDING_SYNC }
+                )
+            }
+        }
+
+        @Test
+        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localExpenseDataSource.saveExpense(any()) } just Runs
+            coEvery { cloudExpenseDataSource.addExpense(any(), any()) } just Runs
+            coEvery { localExpenseDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.addExpense(testGroupId, testExpense)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localExpenseDataSource.updateSyncStatus(any(), SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localExpenseDataSource.saveExpense(any()) } just Runs
+            coEvery {
+                cloudExpenseDataSource.addExpense(any(), any())
+            } throws RuntimeException("Network error")
+            coEvery { localExpenseDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.addExpense(testGroupId, testExpense)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localExpenseDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED)
+            }
         }
     }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
@@ -335,11 +335,12 @@ class GroupRepositoryImplTest {
         }
 
         @Test
-        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+        fun `updates to SYNCED after successful cloud sync and server verification`() = runTest(testDispatcher) {
             // Given
             val newGroup = testGroup.copy(id = "")
             coEvery { localGroupDataSource.saveGroup(any()) } just Runs
             coEvery { cloudGroupDataSource.createGroup(any()) } returns "new-id"
+            coEvery { cloudGroupDataSource.verifyGroupOnServer(any()) } returns true
             coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
 
             // When
@@ -353,13 +354,37 @@ class GroupRepositoryImplTest {
         }
 
         @Test
-        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+        fun `stays PENDING_SYNC when server verification fails (offline)`() = runTest(testDispatcher) {
+            // Given
+            val newGroup = testGroup.copy(id = "")
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+            coEvery { cloudGroupDataSource.createGroup(any()) } returns "new-id"
+            coEvery {
+                cloudGroupDataSource.verifyGroupOnServer(any())
+            } throws RuntimeException("Server unreachable")
+            coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createGroup(newGroup)
+            advanceUntilIdle()
+
+            // Then — should NOT update to SYNCED or SYNC_FAILED
+            coVerify(exactly = 0) {
+                localGroupDataSource.updateSyncStatus(any(), SyncStatus.SYNCED)
+            }
+            coVerify(exactly = 0) {
+                localGroupDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED)
+            }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED when cloud write fails`() = runTest(testDispatcher) {
             // Given
             val newGroup = testGroup.copy(id = "")
             coEvery { localGroupDataSource.saveGroup(any()) } just Runs
             coEvery {
                 cloudGroupDataSource.createGroup(any())
-            } throws RuntimeException("Network error")
+            } throws RuntimeException("Permission denied")
             coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
 
             // When
@@ -369,6 +394,10 @@ class GroupRepositoryImplTest {
             // Then
             coVerify {
                 localGroupDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED)
+            }
+            // Verify server verification was NOT attempted after write failure
+            coVerify(exactly = 0) {
+                cloudGroupDataSource.verifyGroupOnServer(any())
             }
         }
     }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -81,6 +82,71 @@ class GroupRepositoryImplTest {
 
             // Then
             coVerify(exactly = 1) { localGroupDataSource.deleteGroup(testGroupId) }
+        }
+
+        @Test
+        fun `skips cloud deletion when group is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — group was created offline, never synced
+            val pendingGroup = testGroup.copy(syncStatus = SyncStatus.PENDING_SYNC)
+            coEvery { localGroupDataSource.getGroupById(testGroupId) } returns pendingGroup
+            coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
+
+            // When
+            repository.deleteGroup(testGroupId)
+            advanceUntilIdle()
+
+            // Then — should NOT attempt any cloud operation
+            coVerify(exactly = 0) { cloudGroupDataSource.requestGroupDeletion(any()) }
+            coVerify(exactly = 0) { cloudGroupDataSource.deleteGroup(any()) }
+            // Local delete should still happen
+            coVerify(exactly = 1) { localGroupDataSource.deleteGroup(testGroupId) }
+        }
+
+        @Test
+        fun `requests cloud deletion when group is not PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — group was previously synced (null syncStatus defaults to SYNCED behavior)
+            coEvery { localGroupDataSource.getGroupById(testGroupId) } returns testGroup
+            coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
+            coEvery { cloudGroupDataSource.requestGroupDeletion(testGroupId) } just Runs
+
+            // When
+            repository.deleteGroup(testGroupId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should be requested
+            coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
+        }
+
+        @Test
+        fun `requests cloud deletion when group is SYNCED`() = runTest(testDispatcher) {
+            // Given
+            val syncedGroup = testGroup.copy(syncStatus = SyncStatus.SYNCED)
+            coEvery { localGroupDataSource.getGroupById(testGroupId) } returns syncedGroup
+            coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
+            coEvery { cloudGroupDataSource.requestGroupDeletion(testGroupId) } just Runs
+
+            // When
+            repository.deleteGroup(testGroupId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should be requested
+            coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
+        }
+
+        @Test
+        fun `requests cloud deletion when group is SYNC_FAILED`() = runTest(testDispatcher) {
+            // Given
+            val failedGroup = testGroup.copy(syncStatus = SyncStatus.SYNC_FAILED)
+            coEvery { localGroupDataSource.getGroupById(testGroupId) } returns failedGroup
+            coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
+            coEvery { cloudGroupDataSource.requestGroupDeletion(testGroupId) } just Runs
+
+            // When
+            repository.deleteGroup(testGroupId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should be requested even for SYNC_FAILED
+            coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
         }
 
         @Test
@@ -153,6 +219,21 @@ class GroupRepositoryImplTest {
 
             // Then - Old deleteGroup should NOT be called; only requestGroupDeletion
             coVerify(exactly = 0) { cloudGroupDataSource.deleteGroup(any()) }
+            coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
+        }
+
+        @Test
+        fun `requests cloud deletion when group not found locally`() = runTest(testDispatcher) {
+            // Given — group is not found locally (already deleted, or race condition)
+            coEvery { localGroupDataSource.getGroupById(testGroupId) } returns null
+            coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
+            coEvery { cloudGroupDataSource.requestGroupDeletion(testGroupId) } just Runs
+
+            // When
+            repository.deleteGroup(testGroupId)
+            advanceUntilIdle()
+
+            // Then — null syncStatus != PENDING_SYNC, so cloud deletion is requested
             coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
         }
     }
@@ -398,6 +479,180 @@ class GroupRepositoryImplTest {
             // Verify server verification was NOT attempted after write failure
             coVerify(exactly = 0) {
                 cloudGroupDataSource.verifyGroupOnServer(any())
+            }
+        }
+
+        @Test
+        fun `adds current user to members list when not already included`() = runTest(testDispatcher) {
+            // Given — members list does NOT include the current user
+            val newGroup = testGroup.copy(
+                id = "",
+                members = listOf("other-user-1", "other-user-2")
+            )
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+            coEvery { cloudGroupDataSource.createGroup(any()) } returns "new-id"
+            coEvery { cloudGroupDataSource.verifyGroupOnServer(any()) } returns true
+            coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createGroup(newGroup)
+
+            // Then — creator should be appended to members
+            coVerify {
+                localGroupDataSource.saveGroup(
+                    match {
+                        "current-user-id" in it.members &&
+                            "other-user-1" in it.members &&
+                            "other-user-2" in it.members &&
+                            it.members.size == 3
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `does not duplicate current user in members list when already included`() = runTest(testDispatcher) {
+            // Given — members list already includes the current user
+            val newGroup = testGroup.copy(
+                id = "",
+                members = listOf("current-user-id", "other-user-1")
+            )
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+            coEvery { cloudGroupDataSource.createGroup(any()) } returns "new-id"
+            coEvery { cloudGroupDataSource.verifyGroupOnServer(any()) } returns true
+            coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createGroup(newGroup)
+
+            // Then — should keep original members (no duplicate)
+            coVerify {
+                localGroupDataSource.saveGroup(
+                    match {
+                        it.members.size == 2 &&
+                            it.members.count { m -> m == "current-user-id" } == 1
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `generates UUID for group ID`() = runTest(testDispatcher) {
+            // Given
+            val newGroup = testGroup.copy(id = "")
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+
+            // When
+            val returnedId = repository.createGroup(newGroup)
+
+            // Then — should generate a non-empty UUID
+            assertNotEquals("", returnedId)
+            coVerify {
+                localGroupDataSource.saveGroup(match { it.id.isNotBlank() })
+            }
+        }
+    }
+
+    @Nested
+    inner class ConfirmPendingSyncGroups {
+
+        @Test
+        fun `transitions PENDING_SYNC groups to SYNCED when server confirms`() = runTest(testDispatcher) {
+            // Given — cloud returns groups, local has pending sync IDs
+            val remoteGroups = listOf(testGroup)
+            every { localGroupDataSource.getGroupsFlow() } returns flowOf(emptyList())
+            every { cloudGroupDataSource.getAllGroupsFlow() } returns flowOf(remoteGroups)
+            coEvery { localGroupDataSource.replaceAllGroups(any()) } just Runs
+            coEvery { localGroupDataSource.getPendingSyncGroupIds() } returns listOf("pending-1")
+            coEvery { cloudGroupDataSource.verifyGroupOnServer("pending-1") } returns true
+            coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When — trigger the flow to start the cloud subscription
+            repository.getAllGroupsFlow().first()
+            advanceUntilIdle()
+
+            // Then — pending group should be confirmed as SYNCED
+            coVerify { localGroupDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED) }
+        }
+
+        @Test
+        fun `keeps PENDING_SYNC when server verification fails`() = runTest(testDispatcher) {
+            // Given
+            val remoteGroups = listOf(testGroup)
+            every { localGroupDataSource.getGroupsFlow() } returns flowOf(emptyList())
+            every { cloudGroupDataSource.getAllGroupsFlow() } returns flowOf(remoteGroups)
+            coEvery { localGroupDataSource.replaceAllGroups(any()) } just Runs
+            coEvery { localGroupDataSource.getPendingSyncGroupIds() } returns listOf("pending-1")
+            coEvery {
+                cloudGroupDataSource.verifyGroupOnServer("pending-1")
+            } throws RuntimeException("Server unreachable")
+
+            // When
+            repository.getAllGroupsFlow().first()
+            advanceUntilIdle()
+
+            // Then — should NOT update sync status
+            coVerify(exactly = 0) {
+                localGroupDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `skips when no pending groups exist`() = runTest(testDispatcher) {
+            // Given
+            val remoteGroups = listOf(testGroup)
+            every { localGroupDataSource.getGroupsFlow() } returns flowOf(emptyList())
+            every { cloudGroupDataSource.getAllGroupsFlow() } returns flowOf(remoteGroups)
+            coEvery { localGroupDataSource.replaceAllGroups(any()) } just Runs
+            coEvery { localGroupDataSource.getPendingSyncGroupIds() } returns emptyList()
+
+            // When
+            repository.getAllGroupsFlow().first()
+            advanceUntilIdle()
+
+            // Then — should not attempt any verification
+            coVerify(exactly = 0) { cloudGroupDataSource.verifyGroupOnServer(any()) }
+        }
+    }
+
+    @Nested
+    inner class SubscribeToCloudChangesFiltering {
+
+        @Test
+        fun `filters out deleted PENDING_SYNC groups from cloud snapshot`() = runTest(testDispatcher) {
+            // Given — a group was created locally and then deleted while PENDING_SYNC
+            val pendingGroup = testGroup.copy(
+                id = "pending-deleted-group",
+                syncStatus = SyncStatus.PENDING_SYNC
+            )
+            coEvery { localGroupDataSource.getGroupById("pending-deleted-group") } returns pendingGroup
+            coEvery { localGroupDataSource.deleteGroup("pending-deleted-group") } just Runs
+
+            // Delete the PENDING_SYNC group first to populate deletedPendingSyncIds
+            repository.deleteGroup("pending-deleted-group")
+            advanceUntilIdle()
+
+            // Now set up the cloud subscription that includes the deleted group in its snapshot
+            val remoteGroups = listOf(
+                testGroup.copy(id = "pending-deleted-group"),
+                testGroup.copy(id = "normal-group")
+            )
+            every { localGroupDataSource.getGroupsFlow() } returns flowOf(emptyList())
+            every { cloudGroupDataSource.getAllGroupsFlow() } returns flowOf(remoteGroups)
+            coEvery { localGroupDataSource.replaceAllGroups(any()) } just Runs
+            coEvery { localGroupDataSource.getPendingSyncGroupIds() } returns emptyList()
+
+            // When — trigger cloud subscription
+            repository.getAllGroupsFlow().first()
+            advanceUntilIdle()
+
+            // Then — replaceAllGroups should receive the filtered list (without the deleted group)
+            coVerify {
+                localGroupDataSource.replaceAllGroups(
+                    match { groups ->
+                        groups.size == 1 && groups[0].id == "normal-group"
+                    }
+                )
             }
         }
     }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 import es.pedrazamiguez.splittrip.data.worker.GroupDeletionRetryScheduler
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudGroupDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalGroupDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import io.mockk.Runs
@@ -314,6 +315,61 @@ class GroupRepositoryImplTest {
 
             // Then - Local save should happen
             coVerify(exactly = 1) { localGroupDataSource.saveGroup(any()) }
+        }
+
+        @Test
+        fun `saves with PENDING_SYNC status`() = runTest(testDispatcher) {
+            // Given
+            val newGroup = testGroup.copy(id = "")
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+
+            // When
+            repository.createGroup(newGroup)
+
+            // Then
+            coVerify {
+                localGroupDataSource.saveGroup(
+                    match { it.syncStatus == SyncStatus.PENDING_SYNC }
+                )
+            }
+        }
+
+        @Test
+        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+            // Given
+            val newGroup = testGroup.copy(id = "")
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+            coEvery { cloudGroupDataSource.createGroup(any()) } returns "new-id"
+            coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createGroup(newGroup)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localGroupDataSource.updateSyncStatus(any(), SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+            // Given
+            val newGroup = testGroup.copy(id = "")
+            coEvery { localGroupDataSource.saveGroup(any()) } just Runs
+            coEvery {
+                cloudGroupDataSource.createGroup(any())
+            } throws RuntimeException("Network error")
+            coEvery { localGroupDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createGroup(newGroup)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localGroupDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED)
+            }
         }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
@@ -396,6 +396,132 @@ class SubunitRepositoryImplTest {
                 localSubunitDataSource.deleteSubunit(subunitId)
             }
         }
+
+        @Test
+        fun `skips cloud deletion when subunit is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — subunit was created offline, never synced
+            val subunitId = "pending-sub"
+            val pendingSubunit = testSubunit.copy(
+                id = subunitId,
+                syncStatus = SyncStatus.PENDING_SYNC
+            )
+            coEvery {
+                localSubunitDataSource.getSubunitById(subunitId)
+            } returns pendingSubunit
+            coEvery { localSubunitDataSource.deleteSubunit(subunitId) } just Runs
+
+            // When
+            repository.deleteSubunit(testGroupId, subunitId)
+            advanceUntilIdle()
+
+            // Then — should NOT attempt any cloud operation
+            coVerify(exactly = 0) {
+                cloudSubunitDataSource.deleteSubunit(any(), any())
+            }
+            // Local delete should still happen
+            coVerify(exactly = 1) {
+                localSubunitDataSource.deleteSubunit(subunitId)
+            }
+        }
+
+        @Test
+        fun `syncs to cloud when subunit is SYNCED`() = runTest(testDispatcher) {
+            // Given
+            val subunitId = "synced-sub"
+            val syncedSubunit = testSubunit.copy(
+                id = subunitId,
+                syncStatus = SyncStatus.SYNCED
+            )
+            coEvery {
+                localSubunitDataSource.getSubunitById(subunitId)
+            } returns syncedSubunit
+            coEvery { localSubunitDataSource.deleteSubunit(subunitId) } just Runs
+            coEvery { cloudSubunitDataSource.deleteSubunit(any(), any()) } just Runs
+
+            // When
+            repository.deleteSubunit(testGroupId, subunitId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should happen
+            coVerify(exactly = 1) {
+                cloudSubunitDataSource.deleteSubunit(testGroupId, subunitId)
+            }
+        }
+
+        @Test
+        fun `syncs to cloud when subunit not found locally`() = runTest(testDispatcher) {
+            // Given — subunit not found (null syncStatus != PENDING_SYNC)
+            val subunitId = "unknown-sub"
+            coEvery { localSubunitDataSource.getSubunitById(subunitId) } returns null
+            coEvery { localSubunitDataSource.deleteSubunit(subunitId) } just Runs
+            coEvery { cloudSubunitDataSource.deleteSubunit(any(), any()) } just Runs
+
+            // When
+            repository.deleteSubunit(testGroupId, subunitId)
+            advanceUntilIdle()
+
+            // Then — cloud deletion should still happen
+            coVerify(exactly = 1) {
+                cloudSubunitDataSource.deleteSubunit(testGroupId, subunitId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("UpdateSubunit - Sync Status")
+    inner class UpdateSubunitSyncStatus {
+
+        @Test
+        fun `saves with PENDING_SYNC status`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localSubunitDataSource.saveSubunit(any()) } just Runs
+
+            // When
+            repository.updateSubunit(testGroupId, testSubunit)
+
+            // Then
+            coVerify {
+                localSubunitDataSource.saveSubunit(
+                    match { it.syncStatus == SyncStatus.PENDING_SYNC }
+                )
+            }
+        }
+
+        @Test
+        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localSubunitDataSource.saveSubunit(any()) } just Runs
+            coEvery { cloudSubunitDataSource.updateSubunit(any(), any()) } just Runs
+            coEvery { localSubunitDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.updateSubunit(testGroupId, testSubunit)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localSubunitDataSource.updateSyncStatus(any(), SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+            // Given
+            coEvery { localSubunitDataSource.saveSubunit(any()) } just Runs
+            coEvery {
+                cloudSubunitDataSource.updateSubunit(any(), any())
+            } throws RuntimeException("Network error")
+            coEvery { localSubunitDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.updateSubunit(testGroupId, testSubunit)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localSubunitDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED)
+            }
+        }
     }
 
     @Nested

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudSubunitDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalSubunitDataSource
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import io.mockk.Runs
@@ -200,6 +201,61 @@ class SubunitRepositoryImplTest {
 
             // Then - Local save should still have happened
             coVerify(exactly = 1) { localSubunitDataSource.saveSubunit(any()) }
+        }
+
+        @Test
+        fun `saves with PENDING_SYNC status`() = runTest(testDispatcher) {
+            // Given
+            val subunit = Subunit(name = "Couple", memberIds = listOf("u1", "u2"))
+            coEvery { localSubunitDataSource.saveSubunit(any()) } just Runs
+
+            // When
+            repository.createSubunit(testGroupId, subunit)
+
+            // Then
+            coVerify {
+                localSubunitDataSource.saveSubunit(
+                    match { it.syncStatus == SyncStatus.PENDING_SYNC }
+                )
+            }
+        }
+
+        @Test
+        fun `updates to SYNCED after successful cloud sync`() = runTest(testDispatcher) {
+            // Given
+            val subunit = Subunit(name = "Couple", memberIds = listOf("u1", "u2"))
+            coEvery { localSubunitDataSource.saveSubunit(any()) } just Runs
+            coEvery { cloudSubunitDataSource.addSubunit(any(), any()) } just Runs
+            coEvery { localSubunitDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createSubunit(testGroupId, subunit)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localSubunitDataSource.updateSyncStatus(any(), SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `updates to SYNC_FAILED after cloud sync failure`() = runTest(testDispatcher) {
+            // Given
+            val subunit = Subunit(name = "Couple", memberIds = listOf("u1", "u2"))
+            coEvery { localSubunitDataSource.saveSubunit(any()) } just Runs
+            coEvery {
+                cloudSubunitDataSource.addSubunit(any(), any())
+            } throws RuntimeException("Network error")
+            coEvery { localSubunitDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When
+            repository.createSubunit(testGroupId, subunit)
+            advanceUntilIdle()
+
+            // Then
+            coVerify {
+                localSubunitDataSource.updateSyncStatus(any(), SyncStatus.SYNC_FAILED)
+            }
         }
     }
 

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudGroupDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudGroupDataSource.kt
@@ -41,4 +41,17 @@ interface CloudGroupDataSource {
      * Emits local cache first, then server data as it arrives.
      */
     fun getAllGroupsFlow(): Flow<List<Group>>
+
+    /**
+     * Verifies that a group document exists on the Firestore server (not just local cache).
+     * Forces a server round-trip — throws if the device is offline.
+     *
+     * Used by repositories to confirm that a locally-created group has been
+     * successfully persisted to the server, enabling the PENDING_SYNC → SYNCED transition.
+     *
+     * @param groupId The ID of the group to verify.
+     * @return true if the group exists on the server.
+     * @throws Exception if the server is unreachable (e.g., airplane mode).
+     */
+    suspend fun verifyGroupOnServer(groupId: String): Boolean
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalCashWithdrawalDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalCashWithdrawalDataSource.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.datasource.local
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import kotlinx.coroutines.flow.Flow
 
@@ -36,6 +37,12 @@ interface LocalCashWithdrawalDataSource {
     suspend fun replaceWithdrawalsForGroup(groupId: String, withdrawals: List<CashWithdrawal>)
 
     suspend fun getWithdrawalIdsByGroup(groupId: String): List<String>
+
+    /**
+     * Updates the sync status of a single cash withdrawal.
+     * Used by repositories to track cloud sync progress (PENDING_SYNC → SYNCED / SYNC_FAILED).
+     */
+    suspend fun updateSyncStatus(withdrawalId: String, syncStatus: SyncStatus)
 
     suspend fun clearAllWithdrawals()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalContributionDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalContributionDataSource.kt
@@ -10,6 +10,11 @@ interface LocalContributionDataSource {
 
     suspend fun saveContribution(contribution: Contribution)
 
+    /**
+     * Finds a contribution by its ID, or null if not found.
+     */
+    suspend fun findContributionById(contributionId: String): Contribution?
+
     suspend fun deleteContribution(contributionId: String)
 
     suspend fun deleteContributionsByGroupId(groupId: String)

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalContributionDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalContributionDataSource.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.datasource.local
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import kotlinx.coroutines.flow.Flow
 
@@ -20,6 +21,12 @@ interface LocalContributionDataSource {
     suspend fun replaceContributionsForGroup(groupId: String, contributions: List<Contribution>)
 
     suspend fun getContributionIdsByGroup(groupId: String): List<String>
+
+    /**
+     * Updates the sync status of a single contribution.
+     * Used by repositories to track cloud sync progress (PENDING_SYNC → SYNCED / SYNC_FAILED).
+     */
+    suspend fun updateSyncStatus(contributionId: String, syncStatus: SyncStatus)
 
     suspend fun clearAllContributions()
 

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalExpenseDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalExpenseDataSource.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.datasource.local
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import kotlinx.coroutines.flow.Flow
 
@@ -25,6 +26,12 @@ interface LocalExpenseDataSource {
     suspend fun replaceExpensesForGroup(groupId: String, expenses: List<Expense>)
 
     suspend fun getExpenseIdsByGroup(groupId: String): List<String>
+
+    /**
+     * Updates the sync status of a single expense.
+     * Used by repositories to track cloud sync progress (PENDING_SYNC → SYNCED / SYNC_FAILED).
+     */
+    suspend fun updateSyncStatus(expenseId: String, syncStatus: SyncStatus)
 
     suspend fun clearAllExpenses()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalGroupDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalGroupDataSource.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.datasource.local
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import kotlinx.coroutines.flow.Flow
 
@@ -47,6 +48,12 @@ interface LocalGroupDataSource {
      * Deletes a group from local storage.
      */
     suspend fun deleteGroup(groupId: String)
+
+    /**
+     * Updates the sync status of a single group.
+     * Used by repositories to track cloud sync progress (PENDING_SYNC → SYNCED / SYNC_FAILED).
+     */
+    suspend fun updateSyncStatus(groupId: String, syncStatus: SyncStatus)
 
     /**
      * Clears all groups from local storage.

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalGroupDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalGroupDataSource.kt
@@ -56,6 +56,13 @@ interface LocalGroupDataSource {
     suspend fun updateSyncStatus(groupId: String, syncStatus: SyncStatus)
 
     /**
+     * Returns IDs of groups that are waiting for server confirmation.
+     * Used by the repository after reconciliation to attempt server verification
+     * and transition PENDING_SYNC items to SYNCED.
+     */
+    suspend fun getPendingSyncGroupIds(): List<String>
+
+    /**
      * Clears all groups from local storage.
      */
     suspend fun clearAllGroups()

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalSubunitDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalSubunitDataSource.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.datasource.local
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import kotlinx.coroutines.flow.Flow
 
@@ -28,6 +29,12 @@ interface LocalSubunitDataSource {
     suspend fun getSubunitIdsByGroup(groupId: String): List<String>
 
     suspend fun getSubunitById(subunitId: String): Subunit?
+
+    /**
+     * Updates the sync status of a single subunit.
+     * Used by repositories to track cloud sync progress (PENDING_SYNC → SYNCED / SYNC_FAILED).
+     */
+    suspend fun updateSyncStatus(subunitId: String, syncStatus: SyncStatus)
 
     suspend fun clearAllSubunits()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/enums/SyncStatus.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/enums/SyncStatus.kt
@@ -1,0 +1,30 @@
+package es.pedrazamiguez.splittrip.domain.enums
+
+/**
+ * Tracks the cloud synchronization state of a locally-stored entity.
+ *
+ * Used exclusively as local-only metadata — NEVER serialized to Firestore.
+ * Room entities store this as a TEXT column; the domain model uses the enum directly.
+ *
+ * Defaults to [SYNCED] so that:
+ * - Existing data (which arrived via cloud snapshot reconciliation) is treated as synced.
+ * - Items arriving from Firestore snapshots are always marked [SYNCED].
+ */
+enum class SyncStatus {
+    /** Successfully synced to cloud. */
+    SYNCED,
+
+    /** Saved locally, cloud sync not yet attempted or in progress. */
+    PENDING_SYNC,
+
+    /** Cloud sync was attempted and failed. */
+    SYNC_FAILED;
+
+    companion object {
+        fun fromString(value: String): SyncStatus = entries.find { it.name == value }
+            ?: throw IllegalArgumentException("Unknown SyncStatus: $value")
+
+        fun fromStringOrDefault(value: String?): SyncStatus =
+            value?.let { entries.find { entry -> entry.name == it } } ?: SYNCED
+    }
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/CashWithdrawal.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/CashWithdrawal.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.domain.model
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -46,5 +47,6 @@ data class CashWithdrawal(
     val notes: String? = null,
     val receiptLocalUri: String? = null,
     val createdAt: LocalDateTime? = null,
-    val lastUpdatedAt: LocalDateTime? = null
+    val lastUpdatedAt: LocalDateTime? = null,
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Contribution.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Contribution.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.domain.model
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import java.time.LocalDateTime
 
 data class Contribution(
@@ -14,5 +15,6 @@ data class Contribution(
     val currency: String = "EUR",
     val linkedExpenseId: String? = null,
     val createdAt: LocalDateTime? = null,
-    val lastUpdatedAt: LocalDateTime? = null
+    val lastUpdatedAt: LocalDateTime? = null,
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Expense.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Expense.kt
@@ -5,6 +5,7 @@ import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -41,5 +42,6 @@ data class Expense(
     val payerType: PayerType = PayerType.GROUP,
     val payerId: String? = null,
     val createdAt: LocalDateTime? = null,
-    val lastUpdatedAt: LocalDateTime? = null
+    val lastUpdatedAt: LocalDateTime? = null,
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Group.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Group.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.model
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import java.time.LocalDateTime
 
 data class Group(
@@ -11,5 +12,6 @@ data class Group(
     val members: List<String> = emptyList(),
     val mainImagePath: String? = null,
     val createdAt: LocalDateTime? = null,
-    val lastUpdatedAt: LocalDateTime? = null
+    val lastUpdatedAt: LocalDateTime? = null,
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Subunit.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/model/Subunit.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.model
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -35,5 +36,6 @@ data class Subunit(
     val memberShares: Map<String, BigDecimal> = emptyMap(),
     val createdBy: String = "",
     val createdAt: LocalDateTime? = null,
-    val lastUpdatedAt: LocalDateTime? = null
+    val lastUpdatedAt: LocalDateTime? = null,
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/result/ExchangeRateWithStaleness.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/result/ExchangeRateWithStaleness.kt
@@ -1,0 +1,22 @@
+package es.pedrazamiguez.splittrip.domain.result
+
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Wraps an exchange rate with staleness metadata.
+ *
+ * Returned by [es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase]
+ * so that callers can display a warning when the cached rate is outdated
+ * (e.g., the device has been offline and the API could not be reached).
+ *
+ * @param rate The calculated cross-rate (1 base = X target).
+ * @param isStale True when the rate was served from an expired local cache
+ *        because the remote API was unreachable.
+ * @param lastUpdated Timestamp of the last successful rate fetch, or null if unknown.
+ */
+data class ExchangeRateWithStaleness(
+    val rate: BigDecimal,
+    val isStale: Boolean,
+    val lastUpdated: Instant? = null
+)

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/currency/GetExchangeRateUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/currency/GetExchangeRateUseCase.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.domain.usecase.currency
 
 import es.pedrazamiguez.splittrip.domain.repository.CurrencyRepository
 import es.pedrazamiguez.splittrip.domain.result.ExchangeRateResult
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import java.math.BigDecimal
 import java.math.MathContext
 
@@ -9,14 +10,29 @@ class GetExchangeRateUseCase(private val currencyRepository: CurrencyRepository)
     /**
      * Calculates the cross-rate: 1 [baseCurrencyCode] = X [targetCurrencyCode].
      * Uses USD as pivot to support OpenExchangeRates Free Tier.
+     *
+     * Returns [ExchangeRateWithStaleness] containing the rate plus a flag indicating
+     * whether the underlying data was served from an expired cache (i.e., the remote
+     * API could not be reached to refresh it).
      */
-    suspend operator fun invoke(baseCurrencyCode: String, targetCurrencyCode: String): BigDecimal? {
+    suspend operator fun invoke(
+        baseCurrencyCode: String,
+        targetCurrencyCode: String
+    ): ExchangeRateWithStaleness? {
         // Free tier only allows fetching USD base.
         val result = currencyRepository.getExchangeRates("USD")
 
-        val ratesList = when (result) {
-            is ExchangeRateResult.Fresh -> result.exchangeRates.exchangeRates
-            is ExchangeRateResult.Stale -> result.exchangeRates.exchangeRates
+        val (ratesList, isStale, lastUpdated) = when (result) {
+            is ExchangeRateResult.Fresh -> Triple(
+                result.exchangeRates.exchangeRates,
+                false,
+                result.exchangeRates.lastUpdated
+            )
+            is ExchangeRateResult.Stale -> Triple(
+                result.exchangeRates.exchangeRates,
+                true,
+                result.exchangeRates.lastUpdated
+            )
             ExchangeRateResult.Empty -> return null
         }
 
@@ -34,6 +50,12 @@ class GetExchangeRateUseCase(private val currencyRepository: CurrencyRepository)
         // Triangulation: TargetRate / BaseRate
         // Example: 1 USD = 0.9 EUR; 1 USD = 30 THB
         // 1 EUR = 30 / 0.9 = 33.33 THB
-        return usdToTarget.divide(usdToBase, MathContext.DECIMAL64)
+        val rate = usdToTarget.divide(usdToBase, MathContext.DECIMAL64)
+
+        return ExchangeRateWithStaleness(
+            rate = rate,
+            isStale = isStale,
+            lastUpdated = lastUpdated
+        )
     }
 }

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/currency/GetExchangeRateUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/currency/GetExchangeRateUseCaseTest.kt
@@ -12,6 +12,7 @@ import java.math.BigDecimal
 import java.time.Instant
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -58,7 +59,8 @@ class GetExchangeRateUseCaseTest {
             // Then
             // 35 / 0.9 ≈ 38.888...
             assertNotNull(result)
-            assertTrue(result!!.subtract(BigDecimal("38.888")).abs() < BigDecimal("0.01"))
+            assertTrue(result!!.rate.subtract(BigDecimal("38.888")).abs() < BigDecimal("0.01"))
+            assertFalse(result.isStale)
             coVerify { currencyRepository.getExchangeRates("USD") }
         }
 
@@ -82,7 +84,7 @@ class GetExchangeRateUseCaseTest {
             // Then
             // 0.9 / 35 ≈ 0.0257142...
             assertNotNull(result)
-            assertTrue(result!!.subtract(BigDecimal("0.0257")).abs() < BigDecimal("0.001"))
+            assertTrue(result!!.rate.subtract(BigDecimal("0.0257")).abs() < BigDecimal("0.001"))
         }
 
         @Test
@@ -103,7 +105,7 @@ class GetExchangeRateUseCaseTest {
 
             // Then
             // 35 / 1 = 35
-            assertEquals(BigDecimal("35"), result)
+            assertEquals(BigDecimal("35"), result!!.rate)
         }
 
         @Test
@@ -125,7 +127,7 @@ class GetExchangeRateUseCaseTest {
             // Then
             // 1 / 0.9 ≈ 1.111...
             assertNotNull(result)
-            assertTrue(result!!.subtract(BigDecimal("1.111")).abs() < BigDecimal("0.01"))
+            assertTrue(result!!.rate.subtract(BigDecimal("1.111")).abs() < BigDecimal("0.01"))
         }
 
         @Test
@@ -144,7 +146,7 @@ class GetExchangeRateUseCaseTest {
             val result = useCase(baseCurrencyCode = "USD", targetCurrencyCode = "USD")
 
             // Then
-            assertEquals(BigDecimal.ONE, result)
+            assertEquals(BigDecimal.ONE, result!!.rate)
         }
     }
 
@@ -170,7 +172,8 @@ class GetExchangeRateUseCaseTest {
             // Then
             // 33 / 0.85 ≈ 38.823...
             assertNotNull(result)
-            assertTrue(result!!.subtract(BigDecimal("38.823")).abs() < BigDecimal("0.01"))
+            assertTrue(result!!.rate.subtract(BigDecimal("38.823")).abs() < BigDecimal("0.01"))
+            assertTrue(result.isStale)
         }
     }
 

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashWithdrawalHistoryItem.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashWithdrawalHistoryItem.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.SyncStatusIndicator
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.features.balance.R
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashWithdrawalUiModel
 
@@ -57,6 +59,9 @@ private fun WithdrawalDetailColumn(withdrawal: CashWithdrawalUiModel, modifier: 
         WithdrawalLoggedByLine(withdrawal.createdByDisplayName)
         WithdrawalScopeBadge(withdrawal)
         WithdrawalDateLine(withdrawal.dateText)
+        if (withdrawal.syncStatus != SyncStatus.SYNCED) {
+            SyncStatusIndicator(syncStatus = withdrawal.syncStatus)
+        }
     }
 }
 

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/ContributionHistoryItem.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/ContributionHistoryItem.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.SyncStatusIndicator
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.features.balance.R
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.ContributionUiModel
 
@@ -65,6 +67,9 @@ private fun ContributionDetailColumn(contribution: ContributionUiModel, modifier
             ContributionScopeBadge(contribution = contribution)
         }
         ContributionDateLine(contribution.dateText)
+        if (contribution.syncStatus != SyncStatus.SYNCED) {
+            SyncStatusIndicator(syncStatus = contribution.syncStatus)
+        }
     }
 }
 

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
@@ -123,7 +123,8 @@ class BalancesUiMapper(
                 isPersonalContribution = isPersonal,
                 isGroupContribution = isGroup,
                 createdByDisplayName = createdByDisplayName,
-                isLinkedContribution = contribution.linkedExpenseId != null
+                isLinkedContribution = contribution.linkedExpenseId != null,
+                syncStatus = contribution.syncStatus
             )
         }.toImmutableList()
     }
@@ -179,7 +180,8 @@ class BalancesUiMapper(
                 isGroupWithdrawal = isGroup,
                 title = withdrawal.title,
                 notes = withdrawal.notes,
-                createdByDisplayName = createdByDisplayName
+                createdByDisplayName = createdByDisplayName,
+                syncStatus = withdrawal.syncStatus
             )
         }.toImmutableList()
     }

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashWithdrawalUiModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashWithdrawalUiModel.kt
@@ -1,5 +1,7 @@
 package es.pedrazamiguez.splittrip.features.balance.presentation.model
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
+
 /**
  * UI model representing a cash withdrawal in the activity list.
  * Pre-formatted by the mapper for direct display.
@@ -27,5 +29,7 @@ data class CashWithdrawalUiModel(
     val isGroupWithdrawal: Boolean = false,
     val title: String? = null,
     val notes: String? = null,
-    val createdByDisplayName: String? = null
+    val createdByDisplayName: String? = null,
+    /** Cloud synchronization status of this cash withdrawal. */
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/ContributionUiModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/ContributionUiModel.kt
@@ -1,5 +1,7 @@
 package es.pedrazamiguez.splittrip.features.balance.presentation.model
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
+
 /**
  * UI model representing a single contribution entry in the activity history.
  *
@@ -23,5 +25,7 @@ data class ContributionUiModel(
     val isPersonalContribution: Boolean = false,
     val isGroupContribution: Boolean = false,
     val createdByDisplayName: String? = null,
-    val isLinkedContribution: Boolean = false
+    val isLinkedContribution: Boolean = false,
+    /** Cloud synchronization status of this contribution. */
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperTest.kt
+++ b/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperTest.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.features.balance.presentation.mapper
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.model.Subunit
@@ -994,5 +995,63 @@ class BalancesUiMapperTest {
     private fun activityId(item: ActivityItemUiModel): String = when (item) {
         is ActivityItemUiModel.ContributionItem -> item.contribution.id
         is ActivityItemUiModel.CashWithdrawalItem -> item.withdrawal.id
+    }
+
+    @Nested
+    @DisplayName("SyncStatus mapping")
+    inner class SyncStatusMapping {
+
+        @Test
+        fun `contribution maps PENDING_SYNC status`() {
+            val contribution = Contribution(
+                id = "c-sync",
+                amount = 1000L,
+                currency = "EUR",
+                syncStatus = SyncStatus.PENDING_SYNC
+            )
+
+            val result = mapper.mapContributions(
+                contributions = listOf(contribution),
+                currentUserId = "u1",
+                subunits = emptyMap()
+            )
+
+            assertEquals(SyncStatus.PENDING_SYNC, result[0].syncStatus)
+        }
+
+        @Test
+        fun `contribution maps SYNCED status by default`() {
+            val contribution = Contribution(
+                id = "c-sync-default",
+                amount = 1000L,
+                currency = "EUR"
+            )
+
+            val result = mapper.mapContributions(
+                contributions = listOf(contribution),
+                currentUserId = "u1",
+                subunits = emptyMap()
+            )
+
+            assertEquals(SyncStatus.SYNCED, result[0].syncStatus)
+        }
+
+        @Test
+        fun `withdrawal maps SYNC_FAILED status`() {
+            val withdrawal = CashWithdrawal(
+                id = "w-sync",
+                amountWithdrawn = 5000L,
+                currency = "THB",
+                syncStatus = SyncStatus.SYNC_FAILED
+            )
+
+            val result = mapper.mapCashWithdrawals(
+                withdrawals = listOf(withdrawal),
+                groupCurrency = "EUR",
+                currentUserId = "u1"
+            )
+
+            assertEquals(SyncStatus.SYNC_FAILED, result[0].syncStatus)
+        }
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/ExpenseItem.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/ExpenseItem.kt
@@ -140,13 +140,17 @@ private fun ExpenseAmountBadges(expenseUiModel: ExpenseUiModel) {
 
 @Composable
 private fun ExpenseItemMetaRow(expenseUiModel: ExpenseUiModel) {
-    // ── Row 2: payment method · add-on badge  |  scheduled badge ────────
+    // ── Row 2: payment method · add-on badge  |  scheduled badge + sync ──
+    val hasTrailingBadges = expenseUiModel.scheduledBadgeText != null ||
+        expenseUiModel.syncStatus != SyncStatus.SYNCED
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Row(
+            modifier = if (hasTrailingBadges) Modifier.weight(1f) else Modifier,
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -154,7 +158,9 @@ private fun ExpenseItemMetaRow(expenseUiModel: ExpenseUiModel) {
                 Text(
                     text = expenseUiModel.paymentMethodText,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
             if (expenseUiModel.hasAddOns) {
@@ -169,14 +175,21 @@ private fun ExpenseItemMetaRow(expenseUiModel: ExpenseUiModel) {
             }
         }
 
-        if (expenseUiModel.scheduledBadgeText != null) {
-            ScheduledBadge(
-                badgeText = expenseUiModel.scheduledBadgeText,
-                isPastDue = expenseUiModel.isScheduledPastDue
-            )
-        }
-        if (expenseUiModel.syncStatus != SyncStatus.SYNCED) {
-            SyncStatusIndicator(syncStatus = expenseUiModel.syncStatus)
+        if (hasTrailingBadges) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (expenseUiModel.scheduledBadgeText != null) {
+                    ScheduledBadge(
+                        badgeText = expenseUiModel.scheduledBadgeText,
+                        isPastDue = expenseUiModel.isScheduledPastDue
+                    )
+                }
+                if (expenseUiModel.syncStatus != SyncStatus.SYNCED) {
+                    SyncStatusIndicator(syncStatus = expenseUiModel.syncStatus)
+                }
+            }
         }
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/ExpenseItem.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/ExpenseItem.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.SyncStatusIndicator
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseUiModel
 
@@ -172,6 +174,9 @@ private fun ExpenseItemMetaRow(expenseUiModel: ExpenseUiModel) {
                 badgeText = expenseUiModel.scheduledBadgeText,
                 isPastDue = expenseUiModel.isScheduledPastDue
             )
+        }
+        if (expenseUiModel.syncStatus != SyncStatus.SYNCED) {
+            SyncStatusIndicator(syncStatus = expenseUiModel.syncStatus)
         }
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/ExchangeRateStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/ExchangeRateStep.kt
@@ -33,6 +33,7 @@ fun ExchangeRateStep(
                 exchangeRateLockedHint = uiState.exchangeRateLockedHint,
                 isInsufficientCash = uiState.isInsufficientCash,
                 isGroupAmountError = !uiState.isAmountValid,
+                isExchangeRateStale = uiState.isExchangeRateStale,
                 autoFocus = true
             ),
             onExchangeRateChanged = { onEvent(AddExpenseUiEvent.ExchangeRateChanged(it)) },

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapper.kt
@@ -66,7 +66,8 @@ class ExpenseUiMapper(private val localeProvider: LocaleProvider, private val re
                 isOutOfPocket = outOfPocket,
                 fundingSourceText = scopeInfo.text,
                 isSubunitScope = scopeInfo.isSubunit,
-                isGroupScope = scopeInfo.isGroup
+                isGroupScope = scopeInfo.isGroup,
+                syncStatus = syncStatus
             )
         }
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/AddOnUiModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/AddOnUiModel.kt
@@ -53,6 +53,12 @@ data class AddOnUiModel(
     val isInsufficientCash: Boolean = false,
 
     /**
+     * True when the exchange rate was served from an expired local cache
+     * (the remote API was unreachable). Drives a warning indicator.
+     */
+    val isExchangeRateStale: Boolean = false,
+
+    /**
      * Snapshot of [displayExchangeRate] taken just before switching to CASH payment.
      * Restored when the user switches back to a non-CASH method.
      */

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/ExpenseUiModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/ExpenseUiModel.kt
@@ -1,5 +1,7 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.model
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
+
 data class ExpenseUiModel(
     val id: String = "",
     val title: String = "",
@@ -48,5 +50,10 @@ data class ExpenseUiModel(
      * True when the paired contribution's scope is GROUP.
      * Used to pick the Groups icon in the out-of-pocket badge.
      */
-    val isGroupScope: Boolean = false
+    val isGroupScope: Boolean = false,
+    /**
+     * Cloud synchronization status of this expense.
+     * Drives the [SyncStatusIndicator] visibility in the list item.
+     */
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnExchangeRateDelegate.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnExchangeRateDelegate.kt
@@ -68,7 +68,7 @@ class AddOnExchangeRateDelegate(
         rateFetchJobs[addOnId] = scope.launch {
             updateAddOn(addOnId) { it.copy(isLoadingRate = true) }
             try {
-                val rate = getExchangeRateUseCase(
+                val rateResult = getExchangeRateUseCase(
                     baseCurrencyCode = baseCurrencyCode,
                     targetCurrencyCode = targetCurrencyCode
                 )
@@ -81,17 +81,18 @@ class AddOnExchangeRateDelegate(
                     ) {
                         current.copy(isLoadingRate = false)
                     } else {
-                        val formattedRate = rate?.let {
-                            formattingHelper.formatRateForDisplay(it.toPlainString())
+                        val formattedRate = rateResult?.let {
+                            formattingHelper.formatRateForDisplay(it.rate.toPlainString())
                         } ?: current.displayExchangeRate
                         current.copy(
                             isLoadingRate = false,
-                            displayExchangeRate = formattedRate
+                            displayExchangeRate = formattedRate,
+                            isExchangeRateStale = rateResult?.isStale == true
                         )
                     }
                 }
 
-                if (rate != null) {
+                if (rateResult != null) {
                     recalculateForward(addOnId, stateFlow, updateAddOn)
                     onRateApplied()
                 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnExchangeRateDelegate.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnExchangeRateDelegate.kt
@@ -87,7 +87,8 @@ class AddOnExchangeRateDelegate(
                         current.copy(
                             isLoadingRate = false,
                             displayExchangeRate = formattedRate,
-                            isExchangeRateStale = rateResult?.isStale == true
+                            isExchangeRateStale = rateResult?.isStale
+                                ?: current.isExchangeRateStale
                         )
                     }
                 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
@@ -197,7 +197,7 @@ class CurrencyEventHandler(
             _uiState.update { it.copy(isLoadingRate = true) }
 
             try {
-                val rate = getExchangeRateUseCase(
+                val rateResult = getExchangeRateUseCase(
                     baseCurrencyCode = requestedBaseCode,
                     targetCurrencyCode = requestedTargetCode
                 )
@@ -213,14 +213,15 @@ class CurrencyEventHandler(
                         current.copy(
                             isLoadingRate = false,
                             // If rate found, update display; otherwise keep existing/default
-                            displayExchangeRate = rate?.let { exchangeRate ->
+                            displayExchangeRate = rateResult?.rate?.let { exchangeRate ->
                                 formattingHelper.formatRateForDisplay(exchangeRate.toPlainString())
-                            } ?: current.displayExchangeRate
+                            } ?: current.displayExchangeRate,
+                            isExchangeRateStale = rateResult?.isStale == true
                         )
                     }
                 }
 
-                if (rate != null) {
+                if (rateResult != null) {
                     recalculateForward()
                 }
             } catch (e: Exception) {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
@@ -216,7 +216,8 @@ class CurrencyEventHandler(
                             displayExchangeRate = rateResult?.rate?.let { exchangeRate ->
                                 formattingHelper.formatRateForDisplay(exchangeRate.toPlainString())
                             } ?: current.displayExchangeRate,
-                            isExchangeRateStale = rateResult?.isStale == true
+                            isExchangeRateStale = rateResult?.isStale
+                                ?: current.isExchangeRateStale
                         )
                     }
                 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -74,6 +74,12 @@ data class AddExpenseUiState(
      * Drives warning styling in the exchange rate hint.
      */
     val isInsufficientCash: Boolean = false,
+    /**
+     * True when the exchange rate was served from an expired local cache
+     * (the remote API was unreachable). Drives a warning banner in the
+     * exchange rate section.
+     */
+    val isExchangeRateStale: Boolean = false,
     val showDueDateSection: Boolean = false,
 
     // Due date

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapperTest.kt
@@ -6,6 +6,7 @@ import es.pedrazamiguez.splittrip.domain.enums.ExpenseCategory
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.AddOn
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.model.Expense
@@ -1254,6 +1255,29 @@ class ExpenseUiMapperTest {
             val result = mapper.map(expense)
 
             assertEquals("${'$'}12,345.67", result.formattedAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("SyncStatus mapping")
+    inner class SyncStatusMapping {
+
+        @Test
+        fun `maps SYNCED status`() {
+            val expense = Expense(id = "ss-1", syncStatus = SyncStatus.SYNCED)
+            assertEquals(SyncStatus.SYNCED, mapper.map(expense).syncStatus)
+        }
+
+        @Test
+        fun `maps PENDING_SYNC status`() {
+            val expense = Expense(id = "ss-2", syncStatus = SyncStatus.PENDING_SYNC)
+            assertEquals(SyncStatus.PENDING_SYNC, mapper.map(expense).syncStatus)
+        }
+
+        @Test
+        fun `maps SYNC_FAILED status`() {
+            val expense = Expense(id = "ss-3", syncStatus = SyncStatus.SYNC_FAILED)
+            assertEquals(SyncStatus.SYNC_FAILED, mapper.map(expense).syncStatus)
         }
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
@@ -12,6 +12,7 @@ import es.pedrazamiguez.splittrip.domain.model.Currency
 import es.pedrazamiguez.splittrip.domain.model.Group
 import es.pedrazamiguez.splittrip.domain.model.GroupExpenseConfig
 import es.pedrazamiguez.splittrip.domain.model.Subunit
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
@@ -484,7 +485,12 @@ class AddExpenseViewModelTest {
         fun `loads last used currency if available`() = runTest {
             // Given
             coEvery { getGroupExpenseConfigUseCase("group-eur", any()) } returns Result.success(configEur)
-            coEvery { getExchangeRateUseCase("EUR", "USD") } returns BigDecimal("1.08")
+            coEvery {
+                getExchangeRateUseCase("EUR", "USD")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("1.08"),
+                isStale = false
+            )
 
             // Mock that USD was the last used currency for this specific group
             every { getGroupLastUsedCurrencyUseCase("group-eur") } returns flowOf("USD")
@@ -762,7 +768,12 @@ class AddExpenseViewModelTest {
         fun `fetches exchange rate when foreign currency is selected`() = runTest {
             // Given
             coEvery { getGroupExpenseConfigUseCase("group-eur", any()) } returns Result.success(configEurWithThb)
-            coEvery { getExchangeRateUseCase("EUR", "THB") } returns BigDecimal("38.5")
+            coEvery {
+                getExchangeRateUseCase("EUR", "THB")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("38.5"),
+                isStale = false
+            )
 
             // When - Load config
             viewModel.onEvent(AddExpenseUiEvent.LoadGroupConfig("group-eur"))
@@ -784,7 +795,12 @@ class AddExpenseViewModelTest {
         fun `shows loading state while fetching rate`() = runTest {
             // Given
             coEvery { getGroupExpenseConfigUseCase("group-eur", any()) } returns Result.success(configEurWithThb)
-            coEvery { getExchangeRateUseCase("EUR", "THB") } returns BigDecimal("38.5")
+            coEvery {
+                getExchangeRateUseCase("EUR", "THB")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("38.5"),
+                isStale = false
+            )
 
             // When - Load config
             viewModel.onEvent(AddExpenseUiEvent.LoadGroupConfig("group-eur"))
@@ -843,7 +859,12 @@ class AddExpenseViewModelTest {
         fun `resets rate to 1 when switching back to group currency`() = runTest {
             // Given
             coEvery { getGroupExpenseConfigUseCase("group-eur", any()) } returns Result.success(configEurWithThb)
-            coEvery { getExchangeRateUseCase("EUR", "THB") } returns BigDecimal("38.5")
+            coEvery {
+                getExchangeRateUseCase("EUR", "THB")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("38.5"),
+                isStale = false
+            )
 
             // When - Load config and select foreign currency
             viewModel.onEvent(AddExpenseUiEvent.LoadGroupConfig("group-eur"))
@@ -868,8 +889,18 @@ class AddExpenseViewModelTest {
         fun `fetches new rate when switching between foreign currencies`() = runTest {
             // Given
             coEvery { getGroupExpenseConfigUseCase("group-eur", any()) } returns Result.success(configEurWithThb)
-            coEvery { getExchangeRateUseCase("EUR", "THB") } returns BigDecimal("38.5")
-            coEvery { getExchangeRateUseCase("EUR", "USD") } returns BigDecimal("1.08")
+            coEvery {
+                getExchangeRateUseCase("EUR", "THB")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("38.5"),
+                isStale = false
+            )
+            coEvery {
+                getExchangeRateUseCase("EUR", "USD")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("1.08"),
+                isStale = false
+            )
 
             // When - Load config and select THB
             viewModel.onEvent(AddExpenseUiEvent.LoadGroupConfig("group-eur"))
@@ -940,7 +971,12 @@ class AddExpenseViewModelTest {
             coEvery { getGroupExpenseConfigUseCase("group-eur", any()) } returns Result.success(
                 configEurWithThb
             )
-            coEvery { getExchangeRateUseCase("EUR", "THB") } returns BigDecimal("9.20")
+            coEvery {
+                getExchangeRateUseCase("EUR", "THB")
+            } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("9.20"),
+                isStale = false
+            )
 
             viewModel.onEvent(AddExpenseUiEvent.LoadGroupConfig("group-eur"))
             advanceUntilIdle()

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnExchangeRateDelegateTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnExchangeRateDelegateTest.kt
@@ -5,6 +5,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.Forma
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
 import es.pedrazamiguez.splittrip.domain.model.CashRatePreview
 import es.pedrazamiguez.splittrip.domain.model.CashRatePreviewResult
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
@@ -291,7 +292,7 @@ class AddOnExchangeRateDelegateTest {
                     baseCurrencyCode = "EUR",
                     targetCurrencyCode = "THB"
                 )
-            } returns BigDecimal("0.027")
+            } returns ExchangeRateWithStaleness(rate = BigDecimal("0.027"), isStale = false)
 
             val addOn = AddOnUiModel(
                 id = "addon-1",
@@ -364,7 +365,7 @@ class AddOnExchangeRateDelegateTest {
                     baseCurrencyCode = "EUR",
                     targetCurrencyCode = "THB"
                 )
-            } returns BigDecimal("0.027")
+            } returns ExchangeRateWithStaleness(rate = BigDecimal("0.027"), isStale = false)
 
             val addOn = AddOnUiModel(
                 id = "addon-1",

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandlerTest.kt
@@ -7,6 +7,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.Forma
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
 import es.pedrazamiguez.splittrip.domain.model.CashRatePreview
 import es.pedrazamiguez.splittrip.domain.model.CashRatePreviewResult
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
@@ -376,7 +377,7 @@ class CurrencyEventHandlerTest {
             )
             coEvery {
                 getExchangeRateUseCase(any(), any())
-            } returns BigDecimal("36.8")
+            } returns ExchangeRateWithStaleness(rate = BigDecimal("36.8"), isStale = false)
             handler.bind(uiState, actions, this)
 
             // When: user switches back to non-CASH

--- a/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/component/GroupItem.kt
+++ b/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/component/GroupItem.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import es.pedrazamiguez.splittrip.core.designsystem.R as DesignR
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.SyncStatusIndicator
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.features.group.presentation.model.GroupUiModel
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -133,22 +135,31 @@ private fun GroupItemMetaRow(groupUiModel: GroupUiModel, isSelected: Boolean) {
     }
 
     Row(
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        metaParts.forEachIndexed { index, part ->
-            if (index > 0) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            metaParts.forEachIndexed { index, part ->
+                if (index > 0) {
+                    Text(
+                        text = stringResource(DesignR.string.metadata_separator),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = metaColor
+                    )
+                }
                 Text(
-                    text = stringResource(DesignR.string.metadata_separator),
+                    text = part,
                     style = MaterialTheme.typography.bodyMedium,
                     color = metaColor
                 )
             }
-            Text(
-                text = part,
-                style = MaterialTheme.typography.bodyMedium,
-                color = metaColor
-            )
+        }
+        if (groupUiModel.syncStatus != SyncStatus.SYNCED) {
+            SyncStatusIndicator(syncStatus = groupUiModel.syncStatus)
         }
     }
 }

--- a/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/component/GroupItem.kt
+++ b/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/component/GroupItem.kt
@@ -133,6 +133,7 @@ private fun GroupItemMetaRow(groupUiModel: GroupUiModel, isSelected: Boolean) {
         if (groupUiModel.dateText.isNotEmpty()) add(groupUiModel.dateText)
         if (groupUiModel.membersCountText.isNotEmpty()) add(groupUiModel.membersCountText)
     }
+    val hasSyncIndicator = groupUiModel.syncStatus != SyncStatus.SYNCED
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -140,6 +141,11 @@ private fun GroupItemMetaRow(groupUiModel: GroupUiModel, isSelected: Boolean) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Row(
+            modifier = if (hasSyncIndicator) {
+                Modifier.weight(1f).padding(end = 8.dp)
+            } else {
+                Modifier
+            },
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -154,11 +160,13 @@ private fun GroupItemMetaRow(groupUiModel: GroupUiModel, isSelected: Boolean) {
                 Text(
                     text = part,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = metaColor
+                    color = metaColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }
-        if (groupUiModel.syncStatus != SyncStatus.SYNCED) {
+        if (hasSyncIndicator) {
             SyncStatusIndicator(syncStatus = groupUiModel.syncStatus)
         }
     }

--- a/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/mapper/impl/GroupUiMapperImpl.kt
+++ b/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/mapper/impl/GroupUiMapperImpl.kt
@@ -29,7 +29,8 @@ class GroupUiMapperImpl(private val localeProvider: LocaleProvider, private val 
                 memberCount,
                 memberCount
             ),
-            dateText = createdAt?.formatShortDate(currentLocale) ?: ""
+            dateText = createdAt?.formatShortDate(currentLocale) ?: "",
+            syncStatus = syncStatus
         )
     }
 

--- a/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/model/GroupUiModel.kt
+++ b/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/model/GroupUiModel.kt
@@ -1,10 +1,14 @@
 package es.pedrazamiguez.splittrip.features.group.presentation.model
 
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
+
 data class GroupUiModel(
     val id: String = "",
     val name: String = "",
     val description: String = "",
     val currency: String = "",
     val membersCountText: String = "",
-    val dateText: String = ""
+    val dateText: String = "",
+    /** Cloud synchronization status of this group. */
+    val syncStatus: SyncStatus = SyncStatus.SYNCED
 )

--- a/features/groups/src/test/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/mapper/impl/GroupUiMapperImplTest.kt
+++ b/features/groups/src/test/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/mapper/impl/GroupUiMapperImplTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.features.group.presentation.mapper.impl
 
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import es.pedrazamiguez.splittrip.features.group.R
 import io.mockk.every
@@ -169,6 +170,40 @@ class GroupUiMapperImplTest {
             assertEquals("1 traveler", result[0].membersCountText)
             assertEquals("3 travelers", result[1].membersCountText)
             assertEquals("0 travelers", result[2].membersCountText)
+        }
+    }
+
+    @Nested
+    inner class SyncStatusMapping {
+
+        @Test
+        fun `maps PENDING_SYNC status`() {
+            every {
+                resourceProvider.getQuantityString(R.plurals.group_members_count, 0, 0)
+            } returns "0 travelers"
+            val group = createGroup().copy(syncStatus = SyncStatus.PENDING_SYNC)
+            val result = mapper.toGroupUiModel(group)
+            assertEquals(SyncStatus.PENDING_SYNC, result.syncStatus)
+        }
+
+        @Test
+        fun `maps SYNC_FAILED status`() {
+            every {
+                resourceProvider.getQuantityString(R.plurals.group_members_count, 0, 0)
+            } returns "0 travelers"
+            val group = createGroup().copy(syncStatus = SyncStatus.SYNC_FAILED)
+            val result = mapper.toGroupUiModel(group)
+            assertEquals(SyncStatus.SYNC_FAILED, result.syncStatus)
+        }
+
+        @Test
+        fun `default maps to SYNCED`() {
+            every {
+                resourceProvider.getQuantityString(R.plurals.group_members_count, 0, 0)
+            } returns "0 travelers"
+            val group = createGroup()
+            val result = mapper.toGroupUiModel(group)
+            assertEquals(SyncStatus.SYNCED, result.syncStatus)
         }
     }
 

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/ExchangeRateStep.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/ExchangeRateStep.kt
@@ -30,6 +30,7 @@ fun ExchangeRateStep(
                 groupAmountLabel = uiState.deductedAmountLabel,
                 isLoadingRate = uiState.isLoadingRate,
                 isExchangeRateLocked = false,
+                isExchangeRateStale = uiState.isExchangeRateStale,
                 autoFocus = true
             ),
             onExchangeRateChanged = { onEvent(AddCashWithdrawalUiEvent.ExchangeRateChanged(it)) },

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/FeeExchangeRateStep.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/FeeExchangeRateStep.kt
@@ -32,6 +32,7 @@ fun FeeExchangeRateStep(
                 groupAmountLabel = uiState.feeConvertedLabel,
                 isLoadingRate = false,
                 isExchangeRateLocked = false,
+                isExchangeRateStale = uiState.isFeeExchangeRateStale,
                 autoFocus = true
             ),
             onExchangeRateChanged = { onEvent(AddCashWithdrawalUiEvent.FeeExchangeRateChanged(it)) },

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandler.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandler.kt
@@ -151,7 +151,8 @@ class WithdrawalCurrencyHandler(
                         displayExchangeRate = rateResult?.rate?.let { r ->
                             formattingHelper.formatRateForDisplay(r.toPlainString())
                         } ?: it.displayExchangeRate,
-                        isExchangeRateStale = rateResult?.isStale == true
+                        isExchangeRateStale = rateResult?.isStale
+                            ?: it.isExchangeRateStale
                     )
                 }
                 if (rateResult != null) recalculateDeducted()

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandler.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandler.kt
@@ -141,19 +141,20 @@ class WithdrawalCurrencyHandler(
         scope.launch {
             _uiState.update { it.copy(isLoadingRate = true) }
             try {
-                val rate = getExchangeRateUseCase(
+                val rateResult = getExchangeRateUseCase(
                     baseCurrencyCode = groupCurrency.code,
                     targetCurrencyCode = selectedCurrency.code
                 )
                 _uiState.update {
                     it.copy(
                         isLoadingRate = false,
-                        displayExchangeRate = rate?.let { r ->
+                        displayExchangeRate = rateResult?.rate?.let { r ->
                             formattingHelper.formatRateForDisplay(r.toPlainString())
-                        } ?: it.displayExchangeRate
+                        } ?: it.displayExchangeRate,
+                        isExchangeRateStale = rateResult?.isStale == true
                     )
                 }
-                if (rate != null) recalculateDeducted()
+                if (rateResult != null) recalculateDeducted()
             } catch (e: Exception) {
                 Timber.w(e, "Failed to fetch exchange rate")
                 _uiState.update { it.copy(isLoadingRate = false) }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalFeeHandler.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalFeeHandler.kt
@@ -159,13 +159,18 @@ class WithdrawalFeeHandler(
     private fun fetchFeeRate(groupCurrencyCode: String, feeCurrencyCode: String) {
         scope.launch {
             try {
-                val rate = getExchangeRateUseCase(
+                val rateResult = getExchangeRateUseCase(
                     baseCurrencyCode = groupCurrencyCode,
                     targetCurrencyCode = feeCurrencyCode
                 )
-                if (rate != null) {
+                if (rateResult != null) {
                     _uiState.update {
-                        it.copy(feeExchangeRate = formattingHelper.formatRateForDisplay(rate.toPlainString()))
+                        it.copy(
+                            feeExchangeRate = formattingHelper.formatRateForDisplay(
+                                rateResult.rate.toPlainString()
+                            ),
+                            isFeeExchangeRateStale = rateResult.isStale
+                        )
                     }
                     recalculateFeeConverted()
                 }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiState.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiState.kt
@@ -32,6 +32,16 @@ data class AddCashWithdrawalUiState(
     val showExchangeRateSection: Boolean = false,
     val exchangeRateLabel: String = "",
     val deductedAmountLabel: String = "",
+    /**
+     * True when the exchange rate was served from an expired local cache
+     * (the remote API was unreachable). Drives a warning banner in the
+     * exchange rate section.
+     */
+    val isExchangeRateStale: Boolean = false,
+    /**
+     * True when the fee exchange rate was served from an expired local cache.
+     */
+    val isFeeExchangeRateStale: Boolean = false,
 
     // ATM Fee (optional)
     val hasFee: Boolean = false,

--- a/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandlerTest.kt
+++ b/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandlerTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.ha
 
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.mapper.AddCashWithdrawalUiMapper
@@ -130,7 +131,10 @@ class WithdrawalCurrencyHandlerTest {
 
         @Test
         fun `selecting a foreign currency fetches exchange rate`() = runTest {
-            coEvery { getExchangeRateUseCase(any(), any()) } returns BigDecimal("37.037")
+            coEvery { getExchangeRateUseCase(any(), any()) } returns ExchangeRateWithStaleness(
+                rate = BigDecimal("37.037"),
+                isStale = false
+            )
             handler.bind(uiState, actions, this)
             handler.handleCurrencySelected("THB")
             advanceUntilIdle()


### PR DESCRIPTION
Introduce offline sync tracking and stale-exchange-rate UI. Adds a new syncStatus column to expenses, groups, contributions, cash_withdrawals and subunits via migration 24→25 (defaulting to 'SYNCED') and bumps Room schema/version (new schema file). DAOs updated with updateSyncStatus helpers for single-row transitions. Domain additions include SyncStatus enum and ExchangeRateWithStaleness result. UI changes: new SyncStatusIndicator composable and a StaleRateBanner integrated into CurrencyConversionCard (plus an isExchangeRateStale flag in its state). Also add English/Spanish string resources for sync/status and stale-rate warnings. These changes enable offline-first sync state management and surface pending/failed sync and stale-rate warnings to users.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #608 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
