### PR TITLE
[SPLTRP-0863]: Offline-created entities still resurrect after local deletion — fundamental flaws in deletedPendingSyncIds approach

### DIFF
--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreCashWithdrawalDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreCashWithdrawalDataSourceImpl.kt
@@ -127,6 +127,20 @@ class FirestoreCashWithdrawalDataSourceImpl(
         awaitClose { listener.remove() }
     }
 
+    override suspend fun verifyWithdrawalOnServer(
+        groupId: String,
+        withdrawalId: String
+    ): Boolean {
+        val doc = firestore
+            .collection(GroupDocument.COLLECTION_PATH)
+            .document(groupId)
+            .collection(CashWithdrawalDocument.COLLECTION_PATH)
+            .document(withdrawalId)
+            .get(Source.SERVER)
+            .await()
+        return doc.exists()
+    }
+
     private fun createWithdrawalsCollection(groupId: String) = firestore
         .collection(GroupDocument.COLLECTION_PATH)
         .document(groupId)

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreContributionDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreContributionDataSourceImpl.kt
@@ -105,6 +105,20 @@ class FirestoreContributionDataSourceImpl(
         awaitClose { listener.remove() }
     }
 
+    override suspend fun verifyContributionOnServer(
+        groupId: String,
+        contributionId: String
+    ): Boolean {
+        val doc = firestore
+            .collection(GroupDocument.COLLECTION_PATH)
+            .document(groupId)
+            .collection(ContributionDocument.COLLECTION_PATH)
+            .document(contributionId)
+            .get(Source.SERVER)
+            .await()
+        return doc.exists()
+    }
+
     private fun createContributionsCollection(groupId: String) = firestore
         .collection(GroupDocument.COLLECTION_PATH)
         .document(groupId)

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreExpenseDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreExpenseDataSourceImpl.kt
@@ -106,6 +106,17 @@ class FirestoreExpenseDataSourceImpl(
         awaitClose { listener.remove() }
     }
 
+    override suspend fun verifyExpenseOnServer(groupId: String, expenseId: String): Boolean {
+        val doc = firestore
+            .collection(GroupDocument.COLLECTION_PATH)
+            .document(groupId)
+            .collection(ExpenseDocument.COLLECTION_PATH)
+            .document(expenseId)
+            .get(Source.SERVER)
+            .await()
+        return doc.exists()
+    }
+
     private fun createExpensesCollection(groupId: String) = firestore
         .collection(GroupDocument.COLLECTION_PATH)
         .document(groupId)

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImpl.kt
@@ -141,25 +141,45 @@ class FirestoreGroupDataSourceImpl(
     /**
      * Signals Firestore to initiate a server-side cascading group deletion.
      *
-     * Sets `deletionRequested = true` on the group document. This triggers the
-     * `onGroupDeletionRequested` Cloud Function which handles:
-     * 1. Deleting members subcollection (triggers snapshot listener on other devices)
-     * 2. Deleting all other subcollections in parallel (expenses, contributions, etc.)
-     * 3. Sending a single GROUP_DELETED notification to all former members
-     * 4. Deleting the group document itself
+     * Uses a WriteBatch to atomically:
+     * 1. Set `deletionRequested = true` on the group document — triggers the
+     *    `onGroupDeletionRequested` Cloud Function for cascade cleanup.
+     * 2. Delete the current user's member document — prevents entity resurrection.
+     *
+     * The early member-doc deletion is critical for offline create→delete flows:
+     * the snapshot listener on `group_members` uses `MetadataChanges.INCLUDE`,
+     * which fires when pending writes are confirmed. Without the member-doc
+     * deletion, the member doc persists until the Cloud Function cascades,
+     * causing a brief resurrection in the snapshot (the listener sees the member
+     * doc, loads the group, and upserts it into Room). By including the member
+     * deletion in the same batch, Firestore's latency compensation excludes the
+     * member doc from snapshot results, preventing the group from reappearing.
+     *
+     * The Cloud Function handles missing member docs gracefully (Firestore
+     * `batch.delete()` on non-existent docs is a no-op).
      */
     override suspend fun requestGroupDeletion(groupId: String) {
         val userId = authenticationService.requireUserId()
-        firestore
+        val groupDocRef = firestore
             .collection(GroupDocument.COLLECTION_PATH)
             .document(groupId)
-            .update(
-                mapOf(
-                    "deletionRequested" to true,
-                    "deletedBy" to userId,
-                    "deletedAt" to FieldValue.serverTimestamp()
+        val memberDocRef = firestore
+            .collection(GroupMemberDocument.collectionPath(groupId))
+            .document(userId)
+
+        firestore.batch()
+            .apply {
+                update(
+                    groupDocRef,
+                    mapOf(
+                        "deletionRequested" to true,
+                        "deletedBy" to userId,
+                        "deletedAt" to FieldValue.serverTimestamp()
+                    )
                 )
-            )
+                delete(memberDocRef)
+            }
+            .commit()
             .await()
     }
 

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreSubunitDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreSubunitDataSourceImpl.kt
@@ -125,6 +125,17 @@ class FirestoreSubunitDataSourceImpl(
         awaitClose { listener.remove() }
     }
 
+    override suspend fun verifySubunitOnServer(groupId: String, subunitId: String): Boolean {
+        val doc = firestore
+            .collection(GroupDocument.COLLECTION_PATH)
+            .document(groupId)
+            .collection(SubunitDocument.COLLECTION_PATH)
+            .document(subunitId)
+            .get(Source.SERVER)
+            .await()
+        return doc.exists()
+    }
+
     private fun createSubunitsCollection(groupId: String) = firestore
         .collection(GroupDocument.COLLECTION_PATH)
         .document(groupId)

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImplTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImplTest.kt
@@ -75,6 +75,8 @@ class FirestoreGroupDataSourceImplTest {
         val batch = mockk<WriteBatch>(relaxed = true)
         every { firestore.batch() } returns batch
         every { batch.set(any(), any()) } returns batch
+        every { batch.update(any(), any<Map<String, Any>>()) } returns batch
+        every { batch.delete(any()) } returns batch
         every { batch.commit() } returns Tasks.forResult(null)
         return batch
     }
@@ -588,21 +590,52 @@ class FirestoreGroupDataSourceImplTest {
     inner class RequestGroupDeletion {
 
         @Test
-        fun `updates group document with deletion fields`() = runTest {
+        fun `uses WriteBatch to atomically update group and delete member doc`() = runTest {
             // Given
             val groupDocRef = mockGroupDocumentRef(testGroupId)
-            every { groupDocRef.update(any<Map<String, Any>>()) } returns Tasks.forResult(null)
+            val memberDocRef = mockMemberCollectionRef(testGroupId, testUserId)
+            val batch = mockBatch()
 
             // When
             dataSource.requestGroupDeletion(testGroupId)
 
-            // Then - Verify update was called with correct fields
+            // Then — single batch commit with both operations
+            verify(exactly = 1) { batch.update(groupDocRef, any<Map<String, Any>>()) }
+            verify(exactly = 1) { batch.delete(memberDocRef) }
+            verify(exactly = 1) { batch.commit() }
+        }
+
+        @Test
+        fun `includes correct deletion fields in batch update`() = runTest {
+            // Given
+            mockGroupDocumentRef(testGroupId)
+            mockMemberCollectionRef(testGroupId, testUserId)
+            val batch = mockBatch()
+
+            // When
+            dataSource.requestGroupDeletion(testGroupId)
+
+            // Then — verify the update map contains the correct fields
             val mapSlot = slot<Map<String, Any>>()
-            verify(exactly = 1) { groupDocRef.update(capture(mapSlot)) }
+            verify { batch.update(any(), capture(mapSlot)) }
             val capturedMap = mapSlot.captured
             assertEquals(true, capturedMap["deletionRequested"])
             assertEquals(testUserId, capturedMap["deletedBy"])
             assertTrue(capturedMap.containsKey("deletedAt"))
+        }
+
+        @Test
+        fun `deletes current user member doc not other users`() = runTest {
+            // Given
+            val memberDocRef = mockMemberCollectionRef(testGroupId, testUserId)
+            mockGroupDocumentRef(testGroupId)
+            val batch = mockBatch()
+
+            // When
+            dataSource.requestGroupDeletion(testGroupId)
+
+            // Then — only the current user's member doc is deleted
+            verify(exactly = 1) { batch.delete(memberDocRef) }
         }
     }
 }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
@@ -78,6 +78,13 @@ interface CashWithdrawalDao {
     suspend fun getUnsyncedWithdrawalStatuses(groupId: String): List<SyncStatusEntry>
 
     /**
+     * Returns IDs of withdrawals in a group that are still waiting for server confirmation.
+     * Used after reconciliation to attempt server verification and transition to SYNCED.
+     */
+    @Query("SELECT id FROM cash_withdrawals WHERE groupId = :groupId AND syncStatus = 'PENDING_SYNC'")
+    suspend fun getPendingSyncWithdrawalIds(groupId: String): List<String>
+
+    /**
      * Deletes withdrawals whose IDs are in the provided list.
      * Used to selectively remove stale withdrawals during sync reconciliation.
      */
@@ -102,7 +109,8 @@ interface CashWithdrawalDao {
      * in the remote set, the upsert's default SYNCED status would overwrite
      * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
      * transition is handled exclusively by the repository's explicit
-     * `updateSyncStatus()` call after confirmed cloud write.
+     * `updateSyncStatus()` call after server confirmation (via
+     * `confirmPendingSyncWithdrawals()` or the sync in `addWithdrawal()`).
      */
     @Transaction
     suspend fun replaceWithdrawalsForGroup(groupId: String, withdrawals: List<CashWithdrawalEntity>) {

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/CashWithdrawalDao.kt
@@ -90,10 +90,19 @@ interface CashWithdrawalDao {
      * Uses a merge strategy instead of destructive delete+insert:
      * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
      * 2. Upsert all remote withdrawals (adds new, updates existing — sets syncStatus to SYNCED)
-     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 3. Restore ALL non-SYNCED statuses captured in step 1
      * 4. Delete only stale synced withdrawals (not in remote set AND fully synced)
      *
      * This preserves locally-created withdrawals that haven't synced to the cloud yet.
+     *
+     * **Why we always restore non-SYNCED statuses (even for items in the remote set):**
+     * Firestore's `MetadataChanges.INCLUDE` fires snapshots that include pending
+     * local writes (latency compensation). These items appear in the remote set
+     * but have NOT been confirmed by the server. If we skip restoration for items
+     * in the remote set, the upsert's default SYNCED status would overwrite
+     * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
+     * transition is handled exclusively by the repository's explicit
+     * `updateSyncStatus()` call after confirmed cloud write.
      */
     @Transaction
     suspend fun replaceWithdrawalsForGroup(groupId: String, withdrawals: List<CashWithdrawalEntity>) {
@@ -107,7 +116,13 @@ interface CashWithdrawalDao {
         // Step 2: Upsert remote withdrawals (sets syncStatus to SYNCED for all)
         insertWithdrawals(withdrawals)
 
-        // Step 3: Restore non-SYNCED statuses for items that existed before
+        // Step 3: Restore ALL non-SYNCED statuses that were captured before the upsert.
+        // The upsert sets syncStatus to SYNCED for all items (including those that were
+        // PENDING_SYNC or SYNC_FAILED). We must restore their original status because:
+        // - Firestore snapshots with MetadataChanges.INCLUDE fire for pending writes
+        //   (not yet confirmed by the server), so presence in remoteIds does NOT mean synced.
+        // - The PENDING_SYNC → SYNCED transition is handled exclusively by the repository's
+        //   explicit updateSyncStatus() call after confirmed cloud write.
         for (entry in unsyncedStatuses) {
             updateSyncStatus(entry.id, entry.syncStatus)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
@@ -57,6 +57,13 @@ interface ContributionDao {
     suspend fun getUnsyncedContributionStatuses(groupId: String): List<SyncStatusEntry>
 
     /**
+     * Returns IDs of contributions in a group that are still waiting for server confirmation.
+     * Used after reconciliation to attempt server verification and transition to SYNCED.
+     */
+    @Query("SELECT id FROM contributions WHERE groupId = :groupId AND syncStatus = 'PENDING_SYNC'")
+    suspend fun getPendingSyncContributionIds(groupId: String): List<String>
+
+    /**
      * Deletes contributions whose IDs are in the provided list.
      * Used to selectively remove stale contributions during sync reconciliation.
      */
@@ -81,7 +88,8 @@ interface ContributionDao {
      * in the remote set, the upsert's default SYNCED status would overwrite
      * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
      * transition is handled exclusively by the repository's explicit
-     * `updateSyncStatus()` call after confirmed cloud write.
+     * `updateSyncStatus()` call after server confirmation (via
+     * `confirmPendingSyncContributions()` or the sync in `addContribution()`).
      */
     @Transaction
     suspend fun replaceContributionsForGroup(groupId: String, contributions: List<ContributionEntity>) {

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ContributionDao.kt
@@ -69,10 +69,19 @@ interface ContributionDao {
      * Uses a merge strategy instead of destructive delete+insert:
      * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
      * 2. Upsert all remote contributions (adds new, updates existing — sets syncStatus to SYNCED)
-     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 3. Restore ALL non-SYNCED statuses captured in step 1
      * 4. Delete only stale synced contributions (not in remote set AND fully synced)
      *
      * This preserves locally-created contributions that haven't synced to the cloud yet.
+     *
+     * **Why we always restore non-SYNCED statuses (even for items in the remote set):**
+     * Firestore's `MetadataChanges.INCLUDE` fires snapshots that include pending
+     * local writes (latency compensation). These items appear in the remote set
+     * but have NOT been confirmed by the server. If we skip restoration for items
+     * in the remote set, the upsert's default SYNCED status would overwrite
+     * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
+     * transition is handled exclusively by the repository's explicit
+     * `updateSyncStatus()` call after confirmed cloud write.
      */
     @Transaction
     suspend fun replaceContributionsForGroup(groupId: String, contributions: List<ContributionEntity>) {
@@ -86,7 +95,13 @@ interface ContributionDao {
         // Step 2: Upsert remote contributions (sets syncStatus to SYNCED for all)
         insertContributions(contributions)
 
-        // Step 3: Restore non-SYNCED statuses for items that existed before
+        // Step 3: Restore ALL non-SYNCED statuses that were captured before the upsert.
+        // The upsert sets syncStatus to SYNCED for all items (including those that were
+        // PENDING_SYNC or SYNC_FAILED). We must restore their original status because:
+        // - Firestore snapshots with MetadataChanges.INCLUDE fire for pending writes
+        //   (not yet confirmed by the server), so presence in remoteIds does NOT mean synced.
+        // - The PENDING_SYNC → SYNCED transition is handled exclusively by the repository's
+        //   explicit updateSyncStatus() call after confirmed cloud write.
         for (entry in unsyncedStatuses) {
             updateSyncStatus(entry.id, entry.syncStatus)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
@@ -63,10 +63,19 @@ interface ExpenseDao {
      * Uses a merge strategy instead of destructive delete+insert:
      * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
      * 2. Upsert all remote expenses (adds new, updates existing — sets syncStatus to SYNCED)
-     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 3. Restore ALL non-SYNCED statuses captured in step 1
      * 4. Delete only stale synced expenses (not in remote set AND fully synced)
      *
      * This preserves locally-created expenses that haven't synced to the cloud yet.
+     *
+     * **Why we always restore non-SYNCED statuses (even for items in the remote set):**
+     * Firestore's `MetadataChanges.INCLUDE` fires snapshots that include pending
+     * local writes (latency compensation). These items appear in the remote set
+     * but have NOT been confirmed by the server. If we skip restoration for items
+     * in the remote set, the upsert's default SYNCED status would overwrite
+     * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
+     * transition is handled exclusively by the repository's explicit
+     * `updateSyncStatus()` call after confirmed cloud write.
      */
     @Transaction
     suspend fun replaceExpensesForGroup(groupId: String, expenses: List<ExpenseEntity>) {
@@ -80,7 +89,13 @@ interface ExpenseDao {
         // Step 2: Upsert remote expenses (sets syncStatus to SYNCED for all)
         insertExpenses(expenses)
 
-        // Step 3: Restore non-SYNCED statuses for items that existed before
+        // Step 3: Restore ALL non-SYNCED statuses that were captured before the upsert.
+        // The upsert sets syncStatus to SYNCED for all items (including those that were
+        // PENDING_SYNC or SYNC_FAILED). We must restore their original status because:
+        // - Firestore snapshots with MetadataChanges.INCLUDE fire for pending writes
+        //   (not yet confirmed by the server), so presence in remoteIds does NOT mean synced.
+        // - The PENDING_SYNC → SYNCED transition is handled exclusively by the repository's
+        //   explicit updateSyncStatus() call after confirmed cloud write.
         for (entry in unsyncedStatuses) {
             updateSyncStatus(entry.id, entry.syncStatus)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
@@ -51,6 +51,13 @@ interface ExpenseDao {
     suspend fun getUnsyncedExpenseStatuses(groupId: String): List<SyncStatusEntry>
 
     /**
+     * Returns IDs of expenses in a group that are still waiting for server confirmation.
+     * Used after reconciliation to attempt server verification and transition to SYNCED.
+     */
+    @Query("SELECT id FROM expenses WHERE groupId = :groupId AND syncStatus = 'PENDING_SYNC'")
+    suspend fun getPendingSyncExpenseIds(groupId: String): List<String>
+
+    /**
      * Deletes expenses whose IDs are in the provided list.
      * Used to selectively remove stale expenses during sync reconciliation.
      */
@@ -75,7 +82,8 @@ interface ExpenseDao {
      * in the remote set, the upsert's default SYNCED status would overwrite
      * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
      * transition is handled exclusively by the repository's explicit
-     * `updateSyncStatus()` call after confirmed cloud write.
+     * `updateSyncStatus()` call after server confirmation (via
+     * `confirmPendingSyncExpenses()` or the sync in `addExpense()`).
      */
     @Transaction
     suspend fun replaceExpensesForGroup(groupId: String, expenses: List<ExpenseEntity>) {

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/GroupDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/GroupDao.kt
@@ -104,17 +104,22 @@ interface GroupDao {
      * Uses a merge strategy instead of destructive delete+insert:
      * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
      * 2. Upsert all remote groups (adds new, updates existing — sets syncStatus to SYNCED)
-     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 3. Restore ALL non-SYNCED statuses captured in step 1
      * 4. Delete only stale synced groups (not in remote set AND fully synced)
      *
      * This preserves locally-created groups that haven't synced to the cloud yet:
      * - Their syncStatus (PENDING_SYNC / SYNC_FAILED) is restored after upsert
      * - They are protected from stale deletion even if not in the remote snapshot
      *
-     * The Firestore SDK's latency compensation includes pending writes in snapshots,
-     * so unsynced items typically appear in the remote set. The non-SYNCED protection
-     * adds an extra safety net for the narrow race where a snapshot fires before
-     * the Firestore SDK caches the pending write.
+     * **Why we always restore non-SYNCED statuses (even for items in the remote set):**
+     * Firestore's `MetadataChanges.INCLUDE` fires snapshots that include pending
+     * local writes (latency compensation). These items appear in the remote set
+     * but have NOT been confirmed by the server. If we skip restoration for items
+     * in the remote set, the upsert's default SYNCED status would overwrite
+     * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
+     * transition is handled exclusively by the repository's explicit
+     * `updateSyncStatus()` call after server confirmation (via
+     * `confirmPendingSyncGroups()` or the two-phase sync in `createGroup()`).
      */
     @Transaction
     suspend fun replaceAllGroups(groups: List<GroupEntity>) {
@@ -128,7 +133,13 @@ interface GroupDao {
         // Step 2: Upsert remote groups (sets syncStatus to SYNCED for all)
         insertGroups(groups)
 
-        // Step 3: Restore non-SYNCED statuses for items that existed before
+        // Step 3: Restore ALL non-SYNCED statuses that were captured before the upsert.
+        // The upsert sets syncStatus to SYNCED for all items (including those that were
+        // PENDING_SYNC or SYNC_FAILED). We must restore their original status because:
+        // - Firestore snapshots with MetadataChanges.INCLUDE fire for pending writes
+        //   (not yet confirmed by the server), so presence in remoteIds does NOT mean synced.
+        // - The PENDING_SYNC → SYNCED transition is handled exclusively by the repository
+        //   (confirmPendingSyncGroups / two-phase createGroup), not by reconciliation.
         for (entry in unsyncedStatuses) {
             updateSyncStatus(entry.id, entry.syncStatus)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
@@ -54,6 +54,13 @@ interface SubunitDao {
     suspend fun getUnsyncedSubunitStatuses(groupId: String): List<SyncStatusEntry>
 
     /**
+     * Returns IDs of subunits in a group that are still waiting for server confirmation.
+     * Used after reconciliation to attempt server verification and transition to SYNCED.
+     */
+    @Query("SELECT id FROM subunits WHERE groupId = :groupId AND syncStatus = 'PENDING_SYNC'")
+    suspend fun getPendingSyncSubunitIds(groupId: String): List<String>
+
+    /**
      * Deletes subunits whose IDs are in the provided list.
      * Used to selectively remove stale subunits during sync reconciliation.
      */
@@ -78,7 +85,8 @@ interface SubunitDao {
      * in the remote set, the upsert's default SYNCED status would overwrite
      * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
      * transition is handled exclusively by the repository's explicit
-     * `updateSyncStatus()` call after confirmed cloud write.
+     * `updateSyncStatus()` call after server confirmation (via
+     * `confirmPendingSyncSubunits()` or the sync in `createSubunit()`).
      */
     @Transaction
     suspend fun replaceSubunitsForGroup(groupId: String, subunits: List<SubunitEntity>) {

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/SubunitDao.kt
@@ -66,10 +66,19 @@ interface SubunitDao {
      * Uses a merge strategy instead of destructive delete+insert:
      * 1. Capture non-SYNCED statuses (PENDING_SYNC / SYNC_FAILED) before upsert
      * 2. Upsert all remote subunits (adds new, updates existing — sets syncStatus to SYNCED)
-     * 3. Restore non-SYNCED statuses that were captured in step 1
+     * 3. Restore ALL non-SYNCED statuses captured in step 1
      * 4. Delete only stale synced subunits (not in remote set AND fully synced)
      *
      * This preserves locally-created subunits that haven't synced to the cloud yet.
+     *
+     * **Why we always restore non-SYNCED statuses (even for items in the remote set):**
+     * Firestore's `MetadataChanges.INCLUDE` fires snapshots that include pending
+     * local writes (latency compensation). These items appear in the remote set
+     * but have NOT been confirmed by the server. If we skip restoration for items
+     * in the remote set, the upsert's default SYNCED status would overwrite
+     * PENDING_SYNC — hiding the sync indicator. The PENDING_SYNC → SYNCED
+     * transition is handled exclusively by the repository's explicit
+     * `updateSyncStatus()` call after confirmed cloud write.
      */
     @Transaction
     suspend fun replaceSubunitsForGroup(groupId: String, subunits: List<SubunitEntity>) {
@@ -83,7 +92,13 @@ interface SubunitDao {
         // Step 2: Upsert remote subunits (sets syncStatus to SYNCED for all)
         insertSubunits(subunits)
 
-        // Step 3: Restore non-SYNCED statuses for items that existed before
+        // Step 3: Restore ALL non-SYNCED statuses that were captured before the upsert.
+        // The upsert sets syncStatus to SYNCED for all items (including those that were
+        // PENDING_SYNC or SYNC_FAILED). We must restore their original status because:
+        // - Firestore snapshots with MetadataChanges.INCLUDE fire for pending writes
+        //   (not yet confirmed by the server), so presence in remoteIds does NOT mean synced.
+        // - The PENDING_SYNC → SYNCED transition is handled exclusively by the repository's
+        //   explicit updateSyncStatus() call after confirmed cloud write.
         for (entry in unsyncedStatuses) {
             updateSyncStatus(entry.id, entry.syncStatus)
         }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalCashWithdrawalDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalCashWithdrawalDataSourceImpl.kt
@@ -57,6 +57,9 @@ class LocalCashWithdrawalDataSourceImpl(private val cashWithdrawalDao: CashWithd
         cashWithdrawalDao.updateSyncStatus(withdrawalId, syncStatus.name)
     }
 
+    override suspend fun getPendingSyncWithdrawalIds(groupId: String): List<String> =
+        cashWithdrawalDao.getPendingSyncWithdrawalIds(groupId)
+
     override suspend fun clearAllWithdrawals() {
         cashWithdrawalDao.clearAllWithdrawals()
     }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalContributionDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalContributionDataSourceImpl.kt
@@ -49,6 +49,9 @@ class LocalContributionDataSourceImpl(private val contributionDao: ContributionD
         contributionDao.updateSyncStatus(contributionId, syncStatus.name)
     }
 
+    override suspend fun getPendingSyncContributionIds(groupId: String): List<String> =
+        contributionDao.getPendingSyncContributionIds(groupId)
+
     override suspend fun deleteByLinkedExpenseId(groupId: String, linkedExpenseId: String) {
         contributionDao.deleteByLinkedExpenseId(groupId, linkedExpenseId)
     }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalExpenseDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalExpenseDataSourceImpl.kt
@@ -98,6 +98,9 @@ class LocalExpenseDataSourceImpl(
         expenseDao.updateSyncStatus(expenseId, syncStatus.name)
     }
 
+    override suspend fun getPendingSyncExpenseIds(groupId: String): List<String> =
+        expenseDao.getPendingSyncExpenseIds(groupId)
+
     override suspend fun clearAllExpenses() {
         expenseDao.clearAllExpenses()
     }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalSubunitDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalSubunitDataSourceImpl.kt
@@ -47,6 +47,9 @@ class LocalSubunitDataSourceImpl(private val subunitDao: SubunitDao) : LocalSubu
         subunitDao.updateSyncStatus(subunitId, syncStatus.name)
     }
 
+    override suspend fun getPendingSyncSubunitIds(groupId: String): List<String> =
+        subunitDao.getPendingSyncSubunitIds(groupId)
+
     override suspend fun clearAllSubunits() {
         subunitDao.clearAllSubunits()
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
@@ -170,6 +170,11 @@ class CashWithdrawalRepositoryImpl(
      * We use [replaceWithdrawalsForGroup] with a merge reconciliation strategy
      * (upsert remote + selective delete of stale) to safely reconcile the
      * local DB with the cloud snapshot.
+     *
+     * After reconciliation, [confirmPendingSyncWithdrawals] attempts to verify
+     * any PENDING_SYNC items against the server. This handles the
+     * PENDING_SYNC → SYNCED transition when the device comes back online
+     * after an app restart.
      */
     private suspend fun subscribeToCloudChanges(groupId: String) {
         try {
@@ -181,12 +186,37 @@ class CashWithdrawalRepositoryImpl(
                             groupId,
                             remoteWithdrawals
                         )
+                        confirmPendingSyncWithdrawals(groupId)
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling cash withdrawals from cloud snapshot")
                     }
                 }
         } catch (e: Exception) {
             Timber.w(e, "Error subscribing to cloud cash withdrawal changes, using local cache")
+        }
+    }
+
+    /**
+     * Attempts to confirm PENDING_SYNC withdrawals by verifying their existence on the server.
+     *
+     * Called after each reconciliation cycle. When the device is online and Firestore
+     * has confirmed the pending write, the server verification succeeds and the
+     * withdrawal transitions to SYNCED. When offline, the verification throws and the
+     * withdrawal remains PENDING_SYNC.
+     */
+    private suspend fun confirmPendingSyncWithdrawals(groupId: String) {
+        val pendingIds = localCashWithdrawalDataSource.getPendingSyncWithdrawalIds(groupId)
+        if (pendingIds.isEmpty()) return
+
+        for (id in pendingIds) {
+            try {
+                if (cloudCashWithdrawalDataSource.verifyWithdrawalOnServer(groupId, id)) {
+                    localCashWithdrawalDataSource.updateSyncStatus(id, SyncStatus.SYNCED)
+                    Timber.d("Confirmed cash withdrawal sync: $id")
+                }
+            } catch (e: Exception) {
+                Timber.d(e, "Cannot confirm cash withdrawal $id — server unreachable")
+            }
         }
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
@@ -34,13 +34,6 @@ class CashWithdrawalRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
-    /**
-     * Tracks IDs of cash withdrawals deleted locally while in PENDING_SYNC state.
-     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
-     * these entities during reconciliation.
-     */
-    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     override suspend fun addWithdrawal(groupId: String, withdrawal: CashWithdrawal) {
         val withdrawalId = withdrawal.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -151,19 +144,12 @@ class CashWithdrawalRepositoryImpl(
     }
 
     override suspend fun deleteWithdrawal(groupId: String, withdrawalId: String) {
-        val withdrawal = localCashWithdrawalDataSource.getWithdrawalById(withdrawalId)
-        val wasPendingSync = withdrawal?.syncStatus == SyncStatus.PENDING_SYNC
-
         // Delete from local first - UI updates instantly via Flow
         localCashWithdrawalDataSource.deleteWithdrawal(withdrawalId)
 
-        if (wasPendingSync) {
-            deletedPendingSyncIds.add(withdrawalId)
-            Timber.d("Cash withdrawal deleted locally (was PENDING_SYNC, skipping cloud): $withdrawalId")
-            return
-        }
-
-        // Sync deletion to cloud in background
+        // Always queue cloud deletion, even for PENDING_SYNC entities.
+        // Firestore SDK guarantees write ordering: the queued SET (from addWithdrawal)
+        // executes before this DELETE when connectivity is restored.
         syncScope.launch {
             try {
                 cloudCashWithdrawalDataSource.deleteWithdrawal(groupId, withdrawalId)
@@ -190,21 +176,11 @@ class CashWithdrawalRepositoryImpl(
             cloudCashWithdrawalDataSource.getWithdrawalsByGroupIdFlow(groupId)
                 .collect { remoteWithdrawals ->
                     try {
-                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
-                            remoteWithdrawals.filter { it.id !in deletedPendingSyncIds }
-                        } else {
-                            remoteWithdrawals
-                        }
-                        Timber.d("Real-time sync: ${filtered.size} cash withdrawals for group $groupId")
+                        Timber.d("Real-time sync: ${remoteWithdrawals.size} cash withdrawals for group $groupId")
                         localCashWithdrawalDataSource.replaceWithdrawalsForGroup(
                             groupId,
-                            filtered
+                            remoteWithdrawals
                         )
-
-                        if (deletedPendingSyncIds.isNotEmpty()) {
-                            val remoteIds = remoteWithdrawals.map { it.id }.toSet()
-                            deletedPendingSyncIds.removeAll(remoteIds)
-                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling cash withdrawals from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
@@ -144,6 +144,11 @@ class ContributionRepositoryImpl(
      * We use [replaceContributionsForGroup] with a merge reconciliation strategy
      * (upsert remote + selective delete of stale) to safely reconcile the
      * local DB with the cloud snapshot.
+     *
+     * After reconciliation, [confirmPendingSyncContributions] attempts to verify
+     * any PENDING_SYNC items against the server. This handles the
+     * PENDING_SYNC → SYNCED transition when the device comes back online
+     * after an app restart.
      */
     private suspend fun subscribeToCloudChanges(groupId: String) {
         try {
@@ -155,12 +160,37 @@ class ContributionRepositoryImpl(
                             groupId,
                             remoteContributions
                         )
+                        confirmPendingSyncContributions(groupId)
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling contributions from cloud snapshot")
                     }
                 }
         } catch (e: Exception) {
             Timber.w(e, "Error subscribing to cloud contribution changes, using local cache")
+        }
+    }
+
+    /**
+     * Attempts to confirm PENDING_SYNC contributions by verifying their existence on the server.
+     *
+     * Called after each reconciliation cycle. When the device is online and Firestore
+     * has confirmed the pending write, the server verification succeeds and the
+     * contribution transitions to SYNCED. When offline, the verification throws and the
+     * contribution remains PENDING_SYNC.
+     */
+    private suspend fun confirmPendingSyncContributions(groupId: String) {
+        val pendingIds = localContributionDataSource.getPendingSyncContributionIds(groupId)
+        if (pendingIds.isEmpty()) return
+
+        for (id in pendingIds) {
+            try {
+                if (cloudContributionDataSource.verifyContributionOnServer(groupId, id)) {
+                    localContributionDataSource.updateSyncStatus(id, SyncStatus.SYNCED)
+                    Timber.d("Confirmed contribution sync: $id")
+                }
+            } catch (e: Exception) {
+                Timber.d(e, "Cannot confirm contribution $id — server unreachable")
+            }
         }
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImpl.kt
@@ -34,13 +34,6 @@ class ContributionRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
-    /**
-     * Tracks IDs of contributions deleted locally while in PENDING_SYNC state.
-     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
-     * these entities during reconciliation.
-     */
-    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     override suspend fun addContribution(groupId: String, contribution: Contribution) {
         val contributionId = contribution.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -92,19 +85,12 @@ class ContributionRepositoryImpl(
             }
 
     override suspend fun deleteContribution(groupId: String, contributionId: String) {
-        val contribution = localContributionDataSource.findContributionById(contributionId)
-        val wasPendingSync = contribution?.syncStatus == SyncStatus.PENDING_SYNC
-
         // Delete from local first - UI updates instantly via Flow
         localContributionDataSource.deleteContribution(contributionId)
 
-        if (wasPendingSync) {
-            deletedPendingSyncIds.add(contributionId)
-            Timber.d("Contribution deleted locally (was PENDING_SYNC, skipping cloud): $contributionId")
-            return
-        }
-
-        // Sync deletion to cloud in background
+        // Always queue cloud deletion, even for PENDING_SYNC entities.
+        // Firestore SDK guarantees write ordering: the queued SET (from addContribution)
+        // executes before this DELETE when connectivity is restored.
         syncScope.launch {
             try {
                 cloudContributionDataSource.deleteContribution(groupId, contributionId)
@@ -164,21 +150,11 @@ class ContributionRepositoryImpl(
             cloudContributionDataSource.getContributionsByGroupIdFlow(groupId)
                 .collect { remoteContributions ->
                     try {
-                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
-                            remoteContributions.filter { it.id !in deletedPendingSyncIds }
-                        } else {
-                            remoteContributions
-                        }
-                        Timber.d("Real-time sync: ${filtered.size} contributions for group $groupId")
+                        Timber.d("Real-time sync: ${remoteContributions.size} contributions for group $groupId")
                         localContributionDataSource.replaceContributionsForGroup(
                             groupId,
-                            filtered
+                            remoteContributions
                         )
-
-                        if (deletedPendingSyncIds.isNotEmpty()) {
-                            val remoteIds = remoteContributions.map { it.id }.toSet()
-                            deletedPendingSyncIds.removeAll(remoteIds)
-                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling contributions from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -34,13 +34,6 @@ class ExpenseRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
-    /**
-     * Tracks IDs of expenses deleted locally while in PENDING_SYNC state.
-     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
-     * these entities during reconciliation.
-     */
-    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     override suspend fun addExpense(groupId: String, expense: Expense) {
         val expenseId = expense.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -74,19 +67,12 @@ class ExpenseRepositoryImpl(
     override suspend fun getExpenseById(expenseId: String): Expense? = localExpenseDataSource.getExpenseById(expenseId)
 
     override suspend fun deleteExpense(groupId: String, expenseId: String) {
-        val expense = localExpenseDataSource.getExpenseById(expenseId)
-        val wasPendingSync = expense?.syncStatus == SyncStatus.PENDING_SYNC
-
         // Delete from local first - UI updates instantly via Flow
         localExpenseDataSource.deleteExpense(expenseId)
 
-        if (wasPendingSync) {
-            deletedPendingSyncIds.add(expenseId)
-            Timber.d("Expense deleted locally (was PENDING_SYNC, skipping cloud): $expenseId")
-            return
-        }
-
-        // Sync deletion to cloud in background
+        // Always queue cloud deletion, even for PENDING_SYNC entities.
+        // Firestore SDK guarantees write ordering: the queued SET (from addExpense)
+        // executes before this DELETE when connectivity is restored.
         syncScope.launch {
             try {
                 cloudExpenseDataSource.deleteExpense(groupId, expenseId)
@@ -139,18 +125,8 @@ class ExpenseRepositoryImpl(
             cloudExpenseDataSource.getExpensesByGroupIdFlow(groupId)
                 .collect { remoteExpenses ->
                     try {
-                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
-                            remoteExpenses.filter { it.id !in deletedPendingSyncIds }
-                        } else {
-                            remoteExpenses
-                        }
-                        Timber.d("Real-time sync: ${filtered.size} expenses for group $groupId")
-                        localExpenseDataSource.replaceExpensesForGroup(groupId, filtered)
-
-                        if (deletedPendingSyncIds.isNotEmpty()) {
-                            val remoteIds = remoteExpenses.map { it.id }.toSet()
-                            deletedPendingSyncIds.removeAll(remoteIds)
-                        }
+                        Timber.d("Real-time sync: ${remoteExpenses.size} expenses for group $groupId")
+                        localExpenseDataSource.replaceExpensesForGroup(groupId, remoteExpenses)
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling expenses from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -117,6 +117,12 @@ class ExpenseRepositoryImpl(
      * - Modifications by other users → items are updated locally
      * - Locally-created expenses not yet synced → preserved (not deleted)
      *
+     * After reconciliation, [confirmPendingSyncExpenses] attempts to verify
+     * any PENDING_SYNC items against the server. This handles the
+     * PENDING_SYNC → SYNCED transition when the device comes back online
+     * after an app restart (where the syncScope coroutine that would normally
+     * call updateSyncStatus(SYNCED) was killed before completing).
+     *
      * The Room Flow re-emits automatically after each reconciliation,
      * keeping the UI in sync across all devices in near real-time.
      */
@@ -127,12 +133,43 @@ class ExpenseRepositoryImpl(
                     try {
                         Timber.d("Real-time sync: ${remoteExpenses.size} expenses for group $groupId")
                         localExpenseDataSource.replaceExpensesForGroup(groupId, remoteExpenses)
+                        confirmPendingSyncExpenses(groupId)
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling expenses from cloud snapshot")
                     }
                 }
         } catch (e: Exception) {
             Timber.w(e, "Error subscribing to cloud expense changes, using local cache")
+        }
+    }
+
+    /**
+     * Attempts to confirm PENDING_SYNC expenses by verifying their existence on the server.
+     *
+     * Called after each reconciliation cycle. When the device is online and Firestore
+     * has confirmed the pending write, the server verification succeeds and the
+     * expense transitions to SYNCED. When offline, the verification throws and the
+     * expense remains PENDING_SYNC.
+     *
+     * This mechanism handles the case where the app is killed before the syncScope
+     * coroutine in addExpense() can call updateSyncStatus(SYNCED). On app restart,
+     * the snapshot listener fires, reconciliation restores PENDING_SYNC (Step 3),
+     * and this method then verifies and transitions confirmed items to SYNCED.
+     */
+    private suspend fun confirmPendingSyncExpenses(groupId: String) {
+        val pendingIds = localExpenseDataSource.getPendingSyncExpenseIds(groupId)
+        if (pendingIds.isEmpty()) return
+
+        for (id in pendingIds) {
+            try {
+                if (cloudExpenseDataSource.verifyExpenseOnServer(groupId, id)) {
+                    localExpenseDataSource.updateSyncStatus(id, SyncStatus.SYNCED)
+                    Timber.d("Confirmed expense sync: $id")
+                }
+            } catch (e: Exception) {
+                // Server unreachable — keep as PENDING_SYNC
+                Timber.d(e, "Cannot confirm expense $id — server unreachable")
+            }
         }
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
@@ -7,7 +7,6 @@ import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Group
 import es.pedrazamiguez.splittrip.domain.repository.GroupRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,14 +41,6 @@ class GroupRepositoryImpl(
      * WhileSubscribed resubscriptions).
      */
     private var cloudSubscriptionJob: Job? = null
-
-    /**
-     * Tracks IDs of groups deleted locally while in PENDING_SYNC state (never synced to server).
-     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
-     * these entities during reconciliation. Safe as in-memory only: if the process dies,
-     * the Firestore SDK's pending write cache also dies, eliminating the resurrection vector.
-     */
-    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     /**
      * Returns a Flow of groups from local storage.
@@ -178,26 +169,14 @@ class GroupRepositoryImpl(
      *    d. Delete the group document
      */
     override suspend fun deleteGroup(groupId: String) {
-        // Check sync status before deleting — if PENDING_SYNC, the group was never
-        // synced to the server, so there's nothing to delete remotely.
-        val group = localGroupDataSource.getGroupById(groupId)
-        val wasPendingSync = group?.syncStatus == SyncStatus.PENDING_SYNC
-
         // 1. Delete from Room immediately — FK CASCADE handles child entities.
         // UI updates instantly via the observed Room Flow.
         localGroupDataSource.deleteGroup(groupId)
 
-        if (wasPendingSync) {
-            // Track the ID to prevent resurrection via snapshot reconciliation.
-            // The Firestore SDK's pending write cache from createGroup() may still
-            // include this group — the snapshot listener would re-insert it without
-            // this protection.
-            deletedPendingSyncIds.add(groupId)
-            Timber.d("Group deleted locally (was PENDING_SYNC, skipping cloud): $groupId")
-            return
-        }
-
         // 2. Signal Firestore to initiate server-side cascading delete.
+        // Always queue the cloud deletion, even for PENDING_SYNC entities.
+        // Firestore SDK guarantees write ordering: the queued SET (from createGroup)
+        // executes before this deletion request when connectivity is restored.
         syncScope.launch {
             try {
                 cloudGroupDataSource.requestGroupDeletion(groupId)
@@ -237,29 +216,12 @@ class GroupRepositoryImpl(
             cloudGroupDataSource.getAllGroupsFlow()
                 .collect { remoteGroups ->
                     try {
-                        // Filter out groups that were deleted locally while PENDING_SYNC.
-                        // These may appear in the snapshot due to the Firestore SDK's
-                        // pending write cache from the original createGroup() call.
-                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
-                            remoteGroups.filter { it.id !in deletedPendingSyncIds }
-                        } else {
-                            remoteGroups
-                        }
-
-                        val filteredCount = remoteGroups.size - filtered.size
                         Timber.d(
-                            "Real-time sync: %d groups received (%d filtered)",
-                            filtered.size,
-                            filteredCount
+                            "Real-time sync: %d groups received",
+                            remoteGroups.size
                         )
-                        localGroupDataSource.replaceAllGroups(filtered)
+                        localGroupDataSource.replaceAllGroups(remoteGroups)
                         confirmPendingSyncGroups()
-
-                        // Clean up: IDs from this snapshot cycle have been excluded
-                        if (deletedPendingSyncIds.isNotEmpty()) {
-                            val remoteIds = remoteGroups.map { it.id }.toSet()
-                            deletedPendingSyncIds.removeAll(remoteIds)
-                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling groups from cloud snapshot")
                     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImpl.kt
@@ -160,11 +160,16 @@ class GroupRepositoryImpl(
      * Flow:
      * 1. Delete group from Room — FK CASCADE handles all child entities locally.
      *    UI updates instantly.
-     * 2. Signal Firestore via `requestGroupDeletion()` which sets
-     *    `deletionRequested = true` on the group document. This triggers the
-     *    Cloud Function to:
-     *    a. Delete members subcollection (fires snapshot listener on other devices)
-     *    b. Delete all other subcollections in parallel (with notification suppression)
+     * 2. Signal Firestore via `requestGroupDeletion()` which atomically
+     *    (WriteBatch) sets `deletionRequested = true` on the group document
+     *    AND deletes the current user's member document. The member-doc
+     *    deletion prevents entity resurrection: the snapshot listener on
+     *    `group_members` (with `MetadataChanges.INCLUDE`) would otherwise
+     *    see the still-existing member doc when the creation batch is
+     *    confirmed on reconnect, briefly re-inserting the group into Room.
+     *    The Cloud Function then handles the full cascade:
+     *    a. Delete remaining members subcollection
+     *    b. Delete all other subcollections in parallel
      *    c. Send a single GROUP_DELETED notification
      *    d. Delete the group document
      */
@@ -174,9 +179,11 @@ class GroupRepositoryImpl(
         localGroupDataSource.deleteGroup(groupId)
 
         // 2. Signal Firestore to initiate server-side cascading delete.
+        // requestGroupDeletion() uses a WriteBatch that atomically sets
+        // deletionRequested=true AND deletes the current user's member doc.
+        // The member-doc deletion is critical to prevent brief entity resurrection
+        // when MetadataChanges.INCLUDE fires the group_members snapshot listener.
         // Always queue the cloud deletion, even for PENDING_SYNC entities.
-        // Firestore SDK guarantees write ordering: the queued SET (from createGroup)
-        // executes before this deletion request when connectivity is restored.
         syncScope.launch {
             try {
                 cloudGroupDataSource.requestGroupDeletion(groupId)

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
@@ -143,6 +143,11 @@ class SubunitRepositoryImpl(
      * We use [replaceSubunitsForGroup] with a merge reconciliation strategy
      * (upsert remote + selective delete of stale) to safely reconcile the
      * local DB with the cloud snapshot.
+     *
+     * After reconciliation, [confirmPendingSyncSubunits] attempts to verify
+     * any PENDING_SYNC items against the server. This handles the
+     * PENDING_SYNC → SYNCED transition when the device comes back online
+     * after an app restart.
      */
     private suspend fun subscribeToCloudChanges(groupId: String) {
         try {
@@ -154,12 +159,37 @@ class SubunitRepositoryImpl(
                             groupId,
                             remoteSubunits
                         )
+                        confirmPendingSyncSubunits(groupId)
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling subunits from cloud snapshot")
                     }
                 }
         } catch (e: Exception) {
             Timber.w(e, "Error subscribing to cloud subunit changes, using local cache")
+        }
+    }
+
+    /**
+     * Attempts to confirm PENDING_SYNC subunits by verifying their existence on the server.
+     *
+     * Called after each reconciliation cycle. When the device is online and Firestore
+     * has confirmed the pending write, the server verification succeeds and the
+     * subunit transitions to SYNCED. When offline, the verification throws and the
+     * subunit remains PENDING_SYNC.
+     */
+    private suspend fun confirmPendingSyncSubunits(groupId: String) {
+        val pendingIds = localSubunitDataSource.getPendingSyncSubunitIds(groupId)
+        if (pendingIds.isEmpty()) return
+
+        for (id in pendingIds) {
+            try {
+                if (cloudSubunitDataSource.verifySubunitOnServer(groupId, id)) {
+                    localSubunitDataSource.updateSyncStatus(id, SyncStatus.SYNCED)
+                    Timber.d("Confirmed subunit sync: $id")
+                }
+            } catch (e: Exception) {
+                Timber.d(e, "Cannot confirm subunit $id — server unreachable")
+            }
         }
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImpl.kt
@@ -35,13 +35,6 @@ class SubunitRepositoryImpl(
      */
     private val cloudSubscriptionJobs = ConcurrentHashMap<String, Job>()
 
-    /**
-     * Tracks IDs of subunits deleted locally while in PENDING_SYNC state.
-     * Prevents the Firestore snapshot listener's pending write cache from resurrecting
-     * these entities during reconciliation.
-     */
-    private val deletedPendingSyncIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     override suspend fun createSubunit(groupId: String, subunit: Subunit): String {
         val subunitId = subunit.id.ifBlank { UUID.randomUUID().toString() }
         val currentUserId = authenticationService.currentUserId() ?: ""
@@ -100,19 +93,12 @@ class SubunitRepositoryImpl(
     }
 
     override suspend fun deleteSubunit(groupId: String, subunitId: String) {
-        val subunit = localSubunitDataSource.getSubunitById(subunitId)
-        val wasPendingSync = subunit?.syncStatus == SyncStatus.PENDING_SYNC
-
         // Delete from local first - UI updates instantly via Flow
         localSubunitDataSource.deleteSubunit(subunitId)
 
-        if (wasPendingSync) {
-            deletedPendingSyncIds.add(subunitId)
-            Timber.d("Subunit deleted locally (was PENDING_SYNC, skipping cloud): $subunitId")
-            return
-        }
-
-        // Sync deletion to cloud in background
+        // Always queue cloud deletion, even for PENDING_SYNC entities.
+        // Firestore SDK guarantees write ordering: the queued SET (from createSubunit)
+        // executes before this DELETE when connectivity is restored.
         syncScope.launch {
             try {
                 cloudSubunitDataSource.deleteSubunit(groupId, subunitId)
@@ -163,21 +149,11 @@ class SubunitRepositoryImpl(
             cloudSubunitDataSource.getSubunitsByGroupIdFlow(groupId)
                 .collect { remoteSubunits ->
                     try {
-                        val filtered = if (deletedPendingSyncIds.isNotEmpty()) {
-                            remoteSubunits.filter { it.id !in deletedPendingSyncIds }
-                        } else {
-                            remoteSubunits
-                        }
-                        Timber.d("Real-time sync: ${filtered.size} subunits for group $groupId")
+                        Timber.d("Real-time sync: ${remoteSubunits.size} subunits for group $groupId")
                         localSubunitDataSource.replaceSubunitsForGroup(
                             groupId,
-                            filtered
+                            remoteSubunits
                         )
-
-                        if (deletedPendingSyncIds.isNotEmpty()) {
-                            val remoteIds = remoteSubunits.map { it.id }.toSet()
-                            deletedPendingSyncIds.removeAll(remoteIds)
-                        }
                     } catch (e: Exception) {
                         Timber.w(e, "Error reconciling subunits from cloud snapshot")
                     }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
@@ -268,22 +268,21 @@ class CashWithdrawalRepositoryImplTest {
         }
 
         @Test
-        fun `skips cloud deletion when withdrawal is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — withdrawal was created offline, never synced
+        fun `queues cloud deletion even when withdrawal is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — withdrawal was created offline, never synced. Firestore SDK has the
+            // create write cached; queuing a deletion ensures it executes after the create.
             val withdrawalId = "pending-w"
-            val pendingWithdrawal = testWithdrawal.copy(
-                id = withdrawalId,
-                syncStatus = SyncStatus.PENDING_SYNC
-            )
-            coEvery { localDataSource.getWithdrawalById(withdrawalId) } returns pendingWithdrawal
             coEvery { localDataSource.deleteWithdrawal(withdrawalId) } just Runs
+            coEvery { cloudDataSource.deleteWithdrawal(any(), any()) } just Runs
 
             // When
             repository.deleteWithdrawal(testGroupId, withdrawalId)
             advanceUntilIdle()
 
-            // Then — should NOT attempt any cloud operation
-            coVerify(exactly = 0) { cloudDataSource.deleteWithdrawal(any(), any()) }
+            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            coVerify(exactly = 1) {
+                cloudDataSource.deleteWithdrawal(testGroupId, withdrawalId)
+            }
             // Local delete should still happen
             coVerify(exactly = 1) { localDataSource.deleteWithdrawal(withdrawalId) }
         }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
@@ -268,10 +268,10 @@ class CashWithdrawalRepositoryImplTest {
         }
 
         @Test
-        fun `queues cloud deletion even when withdrawal is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — withdrawal was created offline, never synced. Firestore SDK has the
-            // create write cached; queuing a deletion ensures it executes after the create.
-            val withdrawalId = "pending-w"
+        fun `always queues cloud deletion regardless of sync status`() = runTest(testDispatcher) {
+            // Given — deleteWithdrawal() no longer checks sync status; it always queues
+            // the cloud deletion so Firestore SDK handles write ordering.
+            val withdrawalId = "any-w"
             coEvery { localDataSource.deleteWithdrawal(withdrawalId) } just Runs
             coEvery { cloudDataSource.deleteWithdrawal(any(), any()) } just Runs
 
@@ -279,11 +279,10 @@ class CashWithdrawalRepositoryImplTest {
             repository.deleteWithdrawal(testGroupId, withdrawalId)
             advanceUntilIdle()
 
-            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            // Then — cloud deletion is always queued
             coVerify(exactly = 1) {
                 cloudDataSource.deleteWithdrawal(testGroupId, withdrawalId)
             }
-            // Local delete should still happen
             coVerify(exactly = 1) { localDataSource.deleteWithdrawal(withdrawalId) }
         }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
@@ -342,4 +342,64 @@ class CashWithdrawalRepositoryImplTest {
             coVerify(exactly = 1) { localDataSource.deleteWithdrawal("w-1") }
         }
     }
+
+    @Nested
+    inner class ConfirmPendingSyncWithdrawals {
+
+        @Test
+        fun `transitions PENDING_SYNC withdrawals to SYNCED when server confirms`() = runTest(testDispatcher) {
+            // Given — cloud returns withdrawals, local has pending sync IDs
+            val localWithdrawals = listOf(testWithdrawal)
+            every { localDataSource.getWithdrawalsByGroupIdFlow(testGroupId) } returns flowOf(emptyList())
+            every { cloudDataSource.getWithdrawalsByGroupIdFlow(testGroupId) } returns flowOf(localWithdrawals)
+            coEvery { localDataSource.replaceWithdrawalsForGroup(any(), any()) } just Runs
+            coEvery { localDataSource.getPendingSyncWithdrawalIds(testGroupId) } returns listOf("pending-1")
+            coEvery { cloudDataSource.verifyWithdrawalOnServer(testGroupId, "pending-1") } returns true
+            coEvery { localDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When — trigger the flow to start the cloud subscription
+            repository.getGroupWithdrawalsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — pending withdrawal should be confirmed as SYNCED
+            coVerify { localDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED) }
+        }
+
+        @Test
+        fun `keeps PENDING_SYNC when server verification fails`() = runTest(testDispatcher) {
+            // Given
+            every { localDataSource.getWithdrawalsByGroupIdFlow(testGroupId) } returns flowOf(emptyList())
+            every { cloudDataSource.getWithdrawalsByGroupIdFlow(testGroupId) } returns flowOf(listOf(testWithdrawal))
+            coEvery { localDataSource.replaceWithdrawalsForGroup(any(), any()) } just Runs
+            coEvery { localDataSource.getPendingSyncWithdrawalIds(testGroupId) } returns listOf("pending-1")
+            coEvery {
+                cloudDataSource.verifyWithdrawalOnServer(testGroupId, "pending-1")
+            } throws RuntimeException("Server unreachable")
+
+            // When
+            repository.getGroupWithdrawalsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should NOT update sync status
+            coVerify(exactly = 0) {
+                localDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `skips when no pending withdrawals exist`() = runTest(testDispatcher) {
+            // Given
+            every { localDataSource.getWithdrawalsByGroupIdFlow(testGroupId) } returns flowOf(emptyList())
+            every { cloudDataSource.getWithdrawalsByGroupIdFlow(testGroupId) } returns flowOf(listOf(testWithdrawal))
+            coEvery { localDataSource.replaceWithdrawalsForGroup(any(), any()) } just Runs
+            coEvery { localDataSource.getPendingSyncWithdrawalIds(testGroupId) } returns emptyList()
+
+            // When
+            repository.getGroupWithdrawalsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should not attempt any verification
+            coVerify(exactly = 0) { cloudDataSource.verifyWithdrawalOnServer(any(), any()) }
+        }
+    }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
@@ -368,10 +368,10 @@ class ContributionRepositoryImplTest {
         }
 
         @Test
-        fun `queues cloud deletion even when contribution is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — contribution was created offline, never synced. Firestore SDK has the
-            // create write cached; queuing a deletion ensures it executes after the create.
-            val contributionId = "pending-contrib"
+        fun `always queues cloud deletion regardless of sync status`() = runTest(testDispatcher) {
+            // Given — deleteContribution() no longer checks sync status; it always queues
+            // the cloud deletion so Firestore SDK handles write ordering.
+            val contributionId = "any-contrib"
             coEvery {
                 localContributionDataSource.deleteContribution(contributionId)
             } just Runs
@@ -383,11 +383,10 @@ class ContributionRepositoryImplTest {
             repository.deleteContribution(testGroupId, contributionId)
             advanceUntilIdle()
 
-            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            // Then — cloud deletion is always queued
             coVerify(exactly = 1) {
                 cloudContributionDataSource.deleteContribution(testGroupId, contributionId)
             }
-            // Local delete should still happen
             coVerify(exactly = 1) {
                 localContributionDataSource.deleteContribution(contributionId)
             }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
@@ -593,4 +593,94 @@ class ContributionRepositoryImplTest {
             assertNull(result)
         }
     }
+
+    @Nested
+    @DisplayName("ConfirmPendingSyncContributions")
+    inner class ConfirmPendingSyncContributions {
+
+        @Test
+        fun `transitions PENDING_SYNC contributions to SYNCED when server confirms`() = runTest(testDispatcher) {
+            // Given — cloud returns contributions, local has pending sync IDs
+            every {
+                localContributionDataSource.getContributionsByGroupIdFlow(testGroupId)
+            } returns flowOf(emptyList())
+            every {
+                cloudContributionDataSource.getContributionsByGroupIdFlow(testGroupId)
+            } returns flowOf(cloudContributions)
+            coEvery {
+                localContributionDataSource.replaceContributionsForGroup(any(), any())
+            } just Runs
+            coEvery {
+                localContributionDataSource.getPendingSyncContributionIds(testGroupId)
+            } returns listOf("pending-1")
+            coEvery {
+                cloudContributionDataSource.verifyContributionOnServer(testGroupId, "pending-1")
+            } returns true
+            coEvery { localContributionDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When — trigger the flow to start the cloud subscription
+            repository.getGroupContributionsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — pending contribution should be confirmed as SYNCED
+            coVerify {
+                localContributionDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `keeps PENDING_SYNC when server verification fails`() = runTest(testDispatcher) {
+            // Given
+            every {
+                localContributionDataSource.getContributionsByGroupIdFlow(testGroupId)
+            } returns flowOf(emptyList())
+            every {
+                cloudContributionDataSource.getContributionsByGroupIdFlow(testGroupId)
+            } returns flowOf(cloudContributions)
+            coEvery {
+                localContributionDataSource.replaceContributionsForGroup(any(), any())
+            } just Runs
+            coEvery {
+                localContributionDataSource.getPendingSyncContributionIds(testGroupId)
+            } returns listOf("pending-1")
+            coEvery {
+                cloudContributionDataSource.verifyContributionOnServer(testGroupId, "pending-1")
+            } throws RuntimeException("Server unreachable")
+
+            // When
+            repository.getGroupContributionsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should NOT update sync status
+            coVerify(exactly = 0) {
+                localContributionDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `skips when no pending contributions exist`() = runTest(testDispatcher) {
+            // Given
+            every {
+                localContributionDataSource.getContributionsByGroupIdFlow(testGroupId)
+            } returns flowOf(emptyList())
+            every {
+                cloudContributionDataSource.getContributionsByGroupIdFlow(testGroupId)
+            } returns flowOf(cloudContributions)
+            coEvery {
+                localContributionDataSource.replaceContributionsForGroup(any(), any())
+            } just Runs
+            coEvery {
+                localContributionDataSource.getPendingSyncContributionIds(testGroupId)
+            } returns emptyList()
+
+            // When
+            repository.getGroupContributionsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should not attempt any verification
+            coVerify(exactly = 0) {
+                cloudContributionDataSource.verifyContributionOnServer(any(), any())
+            }
+        }
+    }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ContributionRepositoryImplTest.kt
@@ -368,27 +368,24 @@ class ContributionRepositoryImplTest {
         }
 
         @Test
-        fun `skips cloud deletion when contribution is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — contribution was created offline, never synced
+        fun `queues cloud deletion even when contribution is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — contribution was created offline, never synced. Firestore SDK has the
+            // create write cached; queuing a deletion ensures it executes after the create.
             val contributionId = "pending-contrib"
-            val pendingContribution = testContribution.copy(
-                id = contributionId,
-                syncStatus = SyncStatus.PENDING_SYNC
-            )
-            coEvery {
-                localContributionDataSource.findContributionById(contributionId)
-            } returns pendingContribution
             coEvery {
                 localContributionDataSource.deleteContribution(contributionId)
+            } just Runs
+            coEvery {
+                cloudContributionDataSource.deleteContribution(any(), any())
             } just Runs
 
             // When
             repository.deleteContribution(testGroupId, contributionId)
             advanceUntilIdle()
 
-            // Then — should NOT attempt any cloud operation
-            coVerify(exactly = 0) {
-                cloudContributionDataSource.deleteContribution(any(), any())
+            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            coVerify(exactly = 1) {
+                cloudContributionDataSource.deleteContribution(testGroupId, contributionId)
             }
             // Local delete should still happen
             coVerify(exactly = 1) {

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -627,10 +627,10 @@ class ExpenseRepositoryImplTest {
         }
 
         @Test
-        fun `queues cloud deletion even when expense is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — expense was created offline, never synced. Firestore SDK has the
-            // create write cached; queuing a deletion ensures it executes after the create.
-            val expenseId = "pending-expense"
+        fun `always queues cloud deletion regardless of sync status`() = runTest(testDispatcher) {
+            // Given — deleteExpense() no longer checks sync status; it always queues
+            // the cloud deletion so Firestore SDK handles write ordering.
+            val expenseId = "any-expense"
             coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
             coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
 
@@ -638,11 +638,10 @@ class ExpenseRepositoryImplTest {
             repository.deleteExpense(testGroupId, expenseId)
             advanceUntilIdle()
 
-            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            // Then — cloud deletion is always queued
             coVerify(exactly = 1) {
                 cloudExpenseDataSource.deleteExpense(testGroupId, expenseId)
             }
-            // Local delete should still happen
             coVerify(exactly = 1) { localExpenseDataSource.deleteExpense(expenseId) }
         }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -685,4 +685,63 @@ class ExpenseRepositoryImplTest {
             }
         }
     }
+
+    @Nested
+    inner class ConfirmPendingSyncExpenses {
+
+        @Test
+        fun `transitions PENDING_SYNC expenses to SYNCED when server confirms`() = runTest(testDispatcher) {
+            // Given — cloud returns expenses, local has pending sync IDs
+            every { localExpenseDataSource.getExpensesByGroupIdFlow(testGroupId) } returns flowOf(emptyList())
+            every { cloudExpenseDataSource.getExpensesByGroupIdFlow(testGroupId) } returns flowOf(cloudExpenses)
+            coEvery { localExpenseDataSource.replaceExpensesForGroup(any(), any()) } just Runs
+            coEvery { localExpenseDataSource.getPendingSyncExpenseIds(testGroupId) } returns listOf("pending-1")
+            coEvery { cloudExpenseDataSource.verifyExpenseOnServer(testGroupId, "pending-1") } returns true
+            coEvery { localExpenseDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When — trigger the flow to start the cloud subscription
+            repository.getGroupExpensesFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — pending expense should be confirmed as SYNCED
+            coVerify { localExpenseDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED) }
+        }
+
+        @Test
+        fun `keeps PENDING_SYNC when server verification fails`() = runTest(testDispatcher) {
+            // Given
+            every { localExpenseDataSource.getExpensesByGroupIdFlow(testGroupId) } returns flowOf(emptyList())
+            every { cloudExpenseDataSource.getExpensesByGroupIdFlow(testGroupId) } returns flowOf(cloudExpenses)
+            coEvery { localExpenseDataSource.replaceExpensesForGroup(any(), any()) } just Runs
+            coEvery { localExpenseDataSource.getPendingSyncExpenseIds(testGroupId) } returns listOf("pending-1")
+            coEvery {
+                cloudExpenseDataSource.verifyExpenseOnServer(testGroupId, "pending-1")
+            } throws RuntimeException("Server unreachable")
+
+            // When
+            repository.getGroupExpensesFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should NOT update sync status
+            coVerify(exactly = 0) {
+                localExpenseDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `skips when no pending expenses exist`() = runTest(testDispatcher) {
+            // Given
+            every { localExpenseDataSource.getExpensesByGroupIdFlow(testGroupId) } returns flowOf(emptyList())
+            every { cloudExpenseDataSource.getExpensesByGroupIdFlow(testGroupId) } returns flowOf(cloudExpenses)
+            coEvery { localExpenseDataSource.replaceExpensesForGroup(any(), any()) } just Runs
+            coEvery { localExpenseDataSource.getPendingSyncExpenseIds(testGroupId) } returns emptyList()
+
+            // When
+            repository.getGroupExpensesFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should not attempt any verification
+            coVerify(exactly = 0) { cloudExpenseDataSource.verifyExpenseOnServer(any(), any()) }
+        }
+    }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -627,22 +627,21 @@ class ExpenseRepositoryImplTest {
         }
 
         @Test
-        fun `skips cloud deletion when expense is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — expense was created offline, never synced
+        fun `queues cloud deletion even when expense is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — expense was created offline, never synced. Firestore SDK has the
+            // create write cached; queuing a deletion ensures it executes after the create.
             val expenseId = "pending-expense"
-            val pendingExpense = testExpense.copy(
-                id = expenseId,
-                syncStatus = SyncStatus.PENDING_SYNC
-            )
-            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns pendingExpense
             coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
 
             // When
             repository.deleteExpense(testGroupId, expenseId)
             advanceUntilIdle()
 
-            // Then — should NOT attempt any cloud operation
-            coVerify(exactly = 0) { cloudExpenseDataSource.deleteExpense(any(), any()) }
+            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            coVerify(exactly = 1) {
+                cloudExpenseDataSource.deleteExpense(testGroupId, expenseId)
+            }
             // Local delete should still happen
             coVerify(exactly = 1) { localExpenseDataSource.deleteExpense(expenseId) }
         }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
@@ -85,11 +85,9 @@ class GroupRepositoryImplTest {
         }
 
         @Test
-        fun `requests cloud deletion even when group is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — group was created offline, never synced. Firestore SDK has the
-            // create write cached; queuing a deletion ensures it executes after the create.
-            val pendingGroup = testGroup.copy(syncStatus = SyncStatus.PENDING_SYNC)
-            coEvery { localGroupDataSource.getGroupById(testGroupId) } returns pendingGroup
+        fun `always requests cloud deletion regardless of sync status`() = runTest(testDispatcher) {
+            // Given — deleteGroup() no longer checks sync status; it always queues
+            // the cloud deletion request so Firestore SDK handles write ordering.
             coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
             coEvery { cloudGroupDataSource.requestGroupDeletion(testGroupId) } just Runs
 
@@ -97,9 +95,8 @@ class GroupRepositoryImplTest {
             repository.deleteGroup(testGroupId)
             advanceUntilIdle()
 
-            // Then — cloud deletion should be requested (Firestore SDK handles write ordering)
+            // Then — cloud deletion is always requested
             coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
-            // Local delete should still happen
             coVerify(exactly = 1) { localGroupDataSource.deleteGroup(testGroupId) }
         }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/GroupRepositoryImplTest.kt
@@ -85,19 +85,20 @@ class GroupRepositoryImplTest {
         }
 
         @Test
-        fun `skips cloud deletion when group is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — group was created offline, never synced
+        fun `requests cloud deletion even when group is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — group was created offline, never synced. Firestore SDK has the
+            // create write cached; queuing a deletion ensures it executes after the create.
             val pendingGroup = testGroup.copy(syncStatus = SyncStatus.PENDING_SYNC)
             coEvery { localGroupDataSource.getGroupById(testGroupId) } returns pendingGroup
             coEvery { localGroupDataSource.deleteGroup(testGroupId) } just Runs
+            coEvery { cloudGroupDataSource.requestGroupDeletion(testGroupId) } just Runs
 
             // When
             repository.deleteGroup(testGroupId)
             advanceUntilIdle()
 
-            // Then — should NOT attempt any cloud operation
-            coVerify(exactly = 0) { cloudGroupDataSource.requestGroupDeletion(any()) }
-            coVerify(exactly = 0) { cloudGroupDataSource.deleteGroup(any()) }
+            // Then — cloud deletion should be requested (Firestore SDK handles write ordering)
+            coVerify(exactly = 1) { cloudGroupDataSource.requestGroupDeletion(testGroupId) }
             // Local delete should still happen
             coVerify(exactly = 1) { localGroupDataSource.deleteGroup(testGroupId) }
         }
@@ -612,48 +613,6 @@ class GroupRepositoryImplTest {
 
             // Then — should not attempt any verification
             coVerify(exactly = 0) { cloudGroupDataSource.verifyGroupOnServer(any()) }
-        }
-    }
-
-    @Nested
-    inner class SubscribeToCloudChangesFiltering {
-
-        @Test
-        fun `filters out deleted PENDING_SYNC groups from cloud snapshot`() = runTest(testDispatcher) {
-            // Given — a group was created locally and then deleted while PENDING_SYNC
-            val pendingGroup = testGroup.copy(
-                id = "pending-deleted-group",
-                syncStatus = SyncStatus.PENDING_SYNC
-            )
-            coEvery { localGroupDataSource.getGroupById("pending-deleted-group") } returns pendingGroup
-            coEvery { localGroupDataSource.deleteGroup("pending-deleted-group") } just Runs
-
-            // Delete the PENDING_SYNC group first to populate deletedPendingSyncIds
-            repository.deleteGroup("pending-deleted-group")
-            advanceUntilIdle()
-
-            // Now set up the cloud subscription that includes the deleted group in its snapshot
-            val remoteGroups = listOf(
-                testGroup.copy(id = "pending-deleted-group"),
-                testGroup.copy(id = "normal-group")
-            )
-            every { localGroupDataSource.getGroupsFlow() } returns flowOf(emptyList())
-            every { cloudGroupDataSource.getAllGroupsFlow() } returns flowOf(remoteGroups)
-            coEvery { localGroupDataSource.replaceAllGroups(any()) } just Runs
-            coEvery { localGroupDataSource.getPendingSyncGroupIds() } returns emptyList()
-
-            // When — trigger cloud subscription
-            repository.getAllGroupsFlow().first()
-            advanceUntilIdle()
-
-            // Then — replaceAllGroups should receive the filtered list (without the deleted group)
-            coVerify {
-                localGroupDataSource.replaceAllGroups(
-                    match { groups ->
-                        groups.size == 1 && groups[0].id == "normal-group"
-                    }
-                )
-            }
         }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
@@ -398,25 +398,20 @@ class SubunitRepositoryImplTest {
         }
 
         @Test
-        fun `skips cloud deletion when subunit is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — subunit was created offline, never synced
+        fun `queues cloud deletion even when subunit is PENDING_SYNC`() = runTest(testDispatcher) {
+            // Given — subunit was created offline, never synced. Firestore SDK has the
+            // create write cached; queuing a deletion ensures it executes after the create.
             val subunitId = "pending-sub"
-            val pendingSubunit = testSubunit.copy(
-                id = subunitId,
-                syncStatus = SyncStatus.PENDING_SYNC
-            )
-            coEvery {
-                localSubunitDataSource.getSubunitById(subunitId)
-            } returns pendingSubunit
             coEvery { localSubunitDataSource.deleteSubunit(subunitId) } just Runs
+            coEvery { cloudSubunitDataSource.deleteSubunit(any(), any()) } just Runs
 
             // When
             repository.deleteSubunit(testGroupId, subunitId)
             advanceUntilIdle()
 
-            // Then — should NOT attempt any cloud operation
-            coVerify(exactly = 0) {
-                cloudSubunitDataSource.deleteSubunit(any(), any())
+            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            coVerify(exactly = 1) {
+                cloudSubunitDataSource.deleteSubunit(testGroupId, subunitId)
             }
             // Local delete should still happen
             coVerify(exactly = 1) {

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
@@ -398,10 +398,10 @@ class SubunitRepositoryImplTest {
         }
 
         @Test
-        fun `queues cloud deletion even when subunit is PENDING_SYNC`() = runTest(testDispatcher) {
-            // Given — subunit was created offline, never synced. Firestore SDK has the
-            // create write cached; queuing a deletion ensures it executes after the create.
-            val subunitId = "pending-sub"
+        fun `always queues cloud deletion regardless of sync status`() = runTest(testDispatcher) {
+            // Given — deleteSubunit() no longer checks sync status; it always queues
+            // the cloud deletion so Firestore SDK handles write ordering.
+            val subunitId = "any-sub"
             coEvery { localSubunitDataSource.deleteSubunit(subunitId) } just Runs
             coEvery { cloudSubunitDataSource.deleteSubunit(any(), any()) } just Runs
 
@@ -409,11 +409,10 @@ class SubunitRepositoryImplTest {
             repository.deleteSubunit(testGroupId, subunitId)
             advanceUntilIdle()
 
-            // Then — cloud deletion should be queued (Firestore SDK handles write ordering)
+            // Then — cloud deletion is always queued
             coVerify(exactly = 1) {
                 cloudSubunitDataSource.deleteSubunit(testGroupId, subunitId)
             }
-            // Local delete should still happen
             coVerify(exactly = 1) {
                 localSubunitDataSource.deleteSubunit(subunitId)
             }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/SubunitRepositoryImplTest.kt
@@ -667,4 +667,94 @@ class SubunitRepositoryImplTest {
             assertTrue(result.isEmpty())
         }
     }
+
+    @Nested
+    @DisplayName("ConfirmPendingSyncSubunits")
+    inner class ConfirmPendingSyncSubunits {
+
+        @Test
+        fun `transitions PENDING_SYNC subunits to SYNCED when server confirms`() = runTest(testDispatcher) {
+            // Given — cloud returns subunits, local has pending sync IDs
+            every {
+                localSubunitDataSource.getSubunitsByGroupIdFlow(testGroupId)
+            } returns flowOf(emptyList())
+            every {
+                cloudSubunitDataSource.getSubunitsByGroupIdFlow(testGroupId)
+            } returns flowOf(cloudSubunits)
+            coEvery {
+                localSubunitDataSource.replaceSubunitsForGroup(any(), any())
+            } just Runs
+            coEvery {
+                localSubunitDataSource.getPendingSyncSubunitIds(testGroupId)
+            } returns listOf("pending-1")
+            coEvery {
+                cloudSubunitDataSource.verifySubunitOnServer(testGroupId, "pending-1")
+            } returns true
+            coEvery { localSubunitDataSource.updateSyncStatus(any(), any()) } just Runs
+
+            // When — trigger the flow to start the cloud subscription
+            repository.getGroupSubunitsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — pending subunit should be confirmed as SYNCED
+            coVerify {
+                localSubunitDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `keeps PENDING_SYNC when server verification fails`() = runTest(testDispatcher) {
+            // Given
+            every {
+                localSubunitDataSource.getSubunitsByGroupIdFlow(testGroupId)
+            } returns flowOf(emptyList())
+            every {
+                cloudSubunitDataSource.getSubunitsByGroupIdFlow(testGroupId)
+            } returns flowOf(cloudSubunits)
+            coEvery {
+                localSubunitDataSource.replaceSubunitsForGroup(any(), any())
+            } just Runs
+            coEvery {
+                localSubunitDataSource.getPendingSyncSubunitIds(testGroupId)
+            } returns listOf("pending-1")
+            coEvery {
+                cloudSubunitDataSource.verifySubunitOnServer(testGroupId, "pending-1")
+            } throws RuntimeException("Server unreachable")
+
+            // When
+            repository.getGroupSubunitsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should NOT update sync status
+            coVerify(exactly = 0) {
+                localSubunitDataSource.updateSyncStatus("pending-1", SyncStatus.SYNCED)
+            }
+        }
+
+        @Test
+        fun `skips when no pending subunits exist`() = runTest(testDispatcher) {
+            // Given
+            every {
+                localSubunitDataSource.getSubunitsByGroupIdFlow(testGroupId)
+            } returns flowOf(emptyList())
+            every {
+                cloudSubunitDataSource.getSubunitsByGroupIdFlow(testGroupId)
+            } returns flowOf(cloudSubunits)
+            coEvery {
+                localSubunitDataSource.replaceSubunitsForGroup(any(), any())
+            } just Runs
+            coEvery {
+                localSubunitDataSource.getPendingSyncSubunitIds(testGroupId)
+            } returns emptyList()
+
+            // When
+            repository.getGroupSubunitsFlow(testGroupId).first()
+            advanceUntilIdle()
+
+            // Then — should not attempt any verification
+            coVerify(exactly = 0) {
+                cloudSubunitDataSource.verifySubunitOnServer(any(), any())
+            }
+        }
+    }
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudCashWithdrawalDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudCashWithdrawalDataSource.kt
@@ -21,4 +21,18 @@ interface CloudCashWithdrawalDataSource {
      * Emits local cache first, then server data as it arrives.
      */
     fun getWithdrawalsByGroupIdFlow(groupId: String): Flow<List<CashWithdrawal>>
+
+    /**
+     * Verifies that a withdrawal document exists on the Firestore server (not just local cache).
+     * Forces a server round-trip — throws if the device is offline.
+     *
+     * Used by repositories to confirm that a locally-created withdrawal has been
+     * successfully persisted to the server, enabling the PENDING_SYNC → SYNCED transition.
+     *
+     * @param groupId The ID of the group containing the withdrawal.
+     * @param withdrawalId The ID of the withdrawal to verify.
+     * @return true if the withdrawal exists on the server.
+     * @throws Exception if the server is unreachable (e.g., airplane mode).
+     */
+    suspend fun verifyWithdrawalOnServer(groupId: String, withdrawalId: String): Boolean
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudContributionDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudContributionDataSource.kt
@@ -19,4 +19,18 @@ interface CloudContributionDataSource {
      * Emits local cache first, then server data as it arrives.
      */
     fun getContributionsByGroupIdFlow(groupId: String): Flow<List<Contribution>>
+
+    /**
+     * Verifies that a contribution document exists on the Firestore server (not just local cache).
+     * Forces a server round-trip — throws if the device is offline.
+     *
+     * Used by repositories to confirm that a locally-created contribution has been
+     * successfully persisted to the server, enabling the PENDING_SYNC → SYNCED transition.
+     *
+     * @param groupId The ID of the group containing the contribution.
+     * @param contributionId The ID of the contribution to verify.
+     * @return true if the contribution exists on the server.
+     * @throws Exception if the server is unreachable (e.g., airplane mode).
+     */
+    suspend fun verifyContributionOnServer(groupId: String, contributionId: String): Boolean
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudExpenseDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudExpenseDataSource.kt
@@ -21,4 +21,18 @@ interface CloudExpenseDataSource {
      * Emits local cache first, then server data as it arrives.
      */
     fun getExpensesByGroupIdFlow(groupId: String): Flow<List<Expense>>
+
+    /**
+     * Verifies that an expense document exists on the Firestore server (not just local cache).
+     * Forces a server round-trip — throws if the device is offline.
+     *
+     * Used by repositories to confirm that a locally-created expense has been
+     * successfully persisted to the server, enabling the PENDING_SYNC → SYNCED transition.
+     *
+     * @param groupId The ID of the group containing the expense.
+     * @param expenseId The ID of the expense to verify.
+     * @return true if the expense exists on the server.
+     * @throws Exception if the server is unreachable (e.g., airplane mode).
+     */
+    suspend fun verifyExpenseOnServer(groupId: String, expenseId: String): Boolean
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudGroupDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudGroupDataSource.kt
@@ -11,18 +11,21 @@ interface CloudGroupDataSource {
     /**
      * Signals Firestore to initiate a server-side cascading group deletion.
      *
-     * This sets `deletionRequested = true` on the group document, which triggers
-     * the `onGroupDeletionRequested` Cloud Function to delete all subcollections
-     * (members, expenses, contributions, cash_withdrawals, subunits) and finally
-     * the group document itself — server-side with best-effort retries,
-     * avoiding notification spam from individual subcollection deletions.
+     * Atomically (via WriteBatch):
+     * 1. Sets `deletionRequested = true` on the group document — triggers the
+     *    `onGroupDeletionRequested` Cloud Function to delete all subcollections
+     *    and the group document itself.
+     * 2. Deletes the current user's member document — prevents entity resurrection
+     *    when the `group_members` snapshot listener (with `MetadataChanges.INCLUDE`)
+     *    fires after the group creation batch is confirmed on reconnect.
      *
      * The operation is idempotent: calling this on a group that already has
      * `deletionRequested = true` is a safe no-op for the Cloud Function trigger
-     * (its guard condition prevents re-execution).
+     * (its guard condition prevents re-execution). The Cloud Function handles
+     * missing member docs gracefully.
      *
      * @param groupId The ID of the group to request deletion for.
-     * @throws Exception if the Firestore update fails (e.g. offline). The caller
+     * @throws Exception if the Firestore batch commit fails. The caller
      *   should schedule a retry via [GroupDeletionRetryScheduler].
      */
     suspend fun requestGroupDeletion(groupId: String)

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudSubunitDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudSubunitDataSource.kt
@@ -20,4 +20,18 @@ interface CloudSubunitDataSource {
      * Reactive stream of subunits for real-time sync via Firestore snapshot listener.
      */
     fun getSubunitsByGroupIdFlow(groupId: String): Flow<List<Subunit>>
+
+    /**
+     * Verifies that a subunit document exists on the Firestore server (not just local cache).
+     * Forces a server round-trip — throws if the device is offline.
+     *
+     * Used by repositories to confirm that a locally-created subunit has been
+     * successfully persisted to the server, enabling the PENDING_SYNC → SYNCED transition.
+     *
+     * @param groupId The ID of the group containing the subunit.
+     * @param subunitId The ID of the subunit to verify.
+     * @return true if the subunit exists on the server.
+     * @throws Exception if the server is unreachable (e.g., airplane mode).
+     */
+    suspend fun verifySubunitOnServer(groupId: String, subunitId: String): Boolean
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalCashWithdrawalDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalCashWithdrawalDataSource.kt
@@ -44,5 +44,12 @@ interface LocalCashWithdrawalDataSource {
      */
     suspend fun updateSyncStatus(withdrawalId: String, syncStatus: SyncStatus)
 
+    /**
+     * Returns IDs of withdrawals in a group that are waiting for server confirmation.
+     * Used by the repository after reconciliation to attempt server verification
+     * and transition PENDING_SYNC items to SYNCED.
+     */
+    suspend fun getPendingSyncWithdrawalIds(groupId: String): List<String>
+
     suspend fun clearAllWithdrawals()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalContributionDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalContributionDataSource.kt
@@ -33,6 +33,13 @@ interface LocalContributionDataSource {
      */
     suspend fun updateSyncStatus(contributionId: String, syncStatus: SyncStatus)
 
+    /**
+     * Returns IDs of contributions in a group that are waiting for server confirmation.
+     * Used by the repository after reconciliation to attempt server verification
+     * and transition PENDING_SYNC items to SYNCED.
+     */
+    suspend fun getPendingSyncContributionIds(groupId: String): List<String>
+
     suspend fun clearAllContributions()
 
     /**

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalExpenseDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalExpenseDataSource.kt
@@ -33,5 +33,12 @@ interface LocalExpenseDataSource {
      */
     suspend fun updateSyncStatus(expenseId: String, syncStatus: SyncStatus)
 
+    /**
+     * Returns IDs of expenses in a group that are waiting for server confirmation.
+     * Used by the repository after reconciliation to attempt server verification
+     * and transition PENDING_SYNC items to SYNCED.
+     */
+    suspend fun getPendingSyncExpenseIds(groupId: String): List<String>
+
     suspend fun clearAllExpenses()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalSubunitDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalSubunitDataSource.kt
@@ -36,5 +36,12 @@ interface LocalSubunitDataSource {
      */
     suspend fun updateSyncStatus(subunitId: String, syncStatus: SyncStatus)
 
+    /**
+     * Returns IDs of subunits in a group that are waiting for server confirmation.
+     * Used by the repository after reconciliation to attempt server verification
+     * and transition PENDING_SYNC items to SYNCED.
+     */
+    suspend fun getPendingSyncSubunitIds(groupId: String): List<String>
+
     suspend fun clearAllSubunits()
 }


### PR DESCRIPTION
Stop tracking in-memory deletedPendingSyncIds and the associated snapshot-filtering logic across repositories (Group, Expense, Contribution, Subunit, CashWithdrawal). Instead, always queue cloud delete requests even for PENDING_SYNC entities and rely on Firestore SDK write ordering to ensure a create SET executes before a subsequent DELETE. Simplified real-time reconciliation by removing exclusion/filter cleanup code and a now-unused import. Updated unit tests to expect cloud deletions to be requested for PENDING_SYNC items and removed tests that relied on the deletedPendingSyncIds behavior.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #863 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
