### PR TITLE
[EXSHAPP-0719]: Define wizard step-skipping strategy per form: simple by default, complex when needed

### DIFF
--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardSkipStrategy.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardSkipStrategy.kt
@@ -1,0 +1,22 @@
+package es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard
+
+/**
+ * Classification of wizard skip behaviour.
+ *
+ * Used by feature-level step enums to declare whether a step is required or
+ * optional. The strategy does **not** affect [WizardNavigationBar] directly;
+ * instead, it guides the [WizardStepIndicator]'s visual treatment and the
+ * ViewModel's jump-to-review logic.
+ *
+ * | Strategy         | Behaviour                                             |
+ * |------------------|-------------------------------------------------------|
+ * | [REQUIRED]       | Must be completed before advancing.                   |
+ * | [OPTIONAL]       | May be skipped — visual cue in the step indicator.    |
+ */
+enum class WizardSkipStrategy {
+    /** Step must be completed — default for all steps. */
+    REQUIRED,
+
+    /** Step may be skipped; shown with a distinct visual style. */
+    OPTIONAL
+}

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardSkipStrategy.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardSkipStrategy.kt
@@ -1,17 +1,20 @@
 package es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard
 
 /**
- * Classification of wizard skip behaviour.
+ * Semantic classification of wizard step skip behaviour.
  *
- * Used by feature-level step enums to declare whether a step is required or
- * optional. The strategy does **not** affect [WizardNavigationBar] directly;
- * instead, it guides the [WizardStepIndicator]'s visual treatment and the
- * ViewModel's jump-to-review logic.
+ * This enum models the two strategies a wizard step can follow. Feature-level
+ * step enums express this concept through a Boolean `isOptional` constructor
+ * parameter rather than referencing this type directly. The enum exists as a
+ * shared vocabulary for documentation and for potential future use by wizard
+ * infrastructure (e.g., composable parameters, strategy-based routing).
  *
  * | Strategy         | Behaviour                                             |
  * |------------------|-------------------------------------------------------|
  * | [REQUIRED]       | Must be completed before advancing.                   |
  * | [OPTIONAL]       | May be skipped — visual cue in the step indicator.    |
+ *
+ * @see WizardStepIndicator for the visual treatment of optional steps.
  */
 enum class WizardSkipStrategy {
     /** Step must be completed — default for all steps. */

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -78,11 +79,13 @@ private const val DASH_OFF_INTERVAL = 4f
  * @param currentStepIndex     Zero-based index of the currently active step.
  * @param optionalStepIndices  Zero-based indices of steps that are optional (shown with
  *                             a dashed border when not yet completed).
- * @param skipToReviewLabel    When non-null, a "Skip to Review" text link is rendered
- *                             below the step row. Typically shown only when the current
- *                             step is optional.
- * @param onSkipToReview       Callback invoked when the skip link is tapped. Required
- *                             when [skipToReviewLabel] is non-null.
+ * @param skipToReviewLabel    When non-null **and** [onSkipToReview] is also non-null, a
+ *                             "Skip to Review" text link is rendered below the step row.
+ *                             Typically provided only when the current step is optional.
+ *                             If either value is null, the link is hidden gracefully.
+ * @param onSkipToReview       Callback invoked when the skip link is tapped. Both this
+ *                             and [skipToReviewLabel] must be non-null for the link to
+ *                             appear.
  */
 @Composable
 fun WizardStepIndicator(
@@ -156,7 +159,10 @@ fun WizardStepIndicator(
                         textAlign = TextAlign.Center,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable(onClick = onSkipToReview)
+                            .clickable(
+                                role = Role.Button,
+                                onClick = onSkipToReview
+                            )
                             .padding(vertical = 6.dp)
                     )
                 }

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
@@ -1,17 +1,21 @@
 package es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -33,6 +37,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -55,6 +63,10 @@ private val SCROLLABLE_CONNECTOR_WIDTH = 16.dp
 /** Horizontal padding applied to the step row. */
 private val HORIZONTAL_PADDING = 20.dp
 
+/** Dash interval for the dashed border on optional step circles (on / off). */
+private const val DASH_ON_INTERVAL = 4f
+private const val DASH_OFF_INTERVAL = 4f
+
 /**
  * Horizontal step indicator for a multi-step wizard.
  *
@@ -62,51 +74,92 @@ private val HORIZONTAL_PADDING = 20.dp
  * horizontally scrollable and smoothly auto-centres the current step.
  * Otherwise a static, non-scrolling row is used with weight-based connectors.
  *
- * @param stepLabels       Ordered list of localised step labels.
- * @param currentStepIndex Zero-based index of the currently active step.
+ * @param stepLabels           Ordered list of localised step labels.
+ * @param currentStepIndex     Zero-based index of the currently active step.
+ * @param optionalStepIndices  Zero-based indices of steps that are optional (shown with
+ *                             a dashed border when not yet completed).
+ * @param skipToReviewLabel    When non-null, a "Skip to Review" text link is rendered
+ *                             below the step row. Typically shown only when the current
+ *                             step is optional.
+ * @param onSkipToReview       Callback invoked when the skip link is tapped. Required
+ *                             when [skipToReviewLabel] is non-null.
  */
 @Composable
 fun WizardStepIndicator(
     stepLabels: List<String>,
     currentStepIndex: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    optionalStepIndices: Set<Int> = emptySet(),
+    skipToReviewLabel: String? = null,
+    onSkipToReview: (() -> Unit)? = null
 ) {
     Surface(
         tonalElevation = 3.dp,
         modifier = modifier.fillMaxWidth()
     ) {
-        AnimatedContent(
-            targetState = stepLabels,
-            transitionSpec = {
-                // Slide right when a step is added, slide left when one is removed.
-                val direction = if (targetState.size >= initialState.size) 1 else -1
-                (
-                    slideInHorizontally(
-                        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                        initialOffsetX = { fullWidth -> direction * fullWidth / 3 }
-                    ) + fadeIn(animationSpec = tween(durationMillis = 250))
-                    )
-                    .togetherWith(
-                        slideOutHorizontally(
+        Column {
+            AnimatedContent(
+                targetState = stepLabels,
+                transitionSpec = {
+                    // Slide right when a step is added, slide left when one is removed.
+                    val direction = if (targetState.size >= initialState.size) 1 else -1
+                    (
+                        slideInHorizontally(
                             animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                            targetOffsetX = { fullWidth -> -direction * fullWidth / 3 }
-                        ) + fadeOut(animationSpec = tween(durationMillis = 200))
-                    )
-                    .using(
-                        SizeTransform(
-                            clip = false,
-                            sizeAnimationSpec = { _, _ ->
-                                spring(stiffness = Spring.StiffnessMediumLow)
-                            }
+                            initialOffsetX = { fullWidth -> direction * fullWidth / 3 }
+                        ) + fadeIn(animationSpec = tween(durationMillis = 250))
                         )
+                        .togetherWith(
+                            slideOutHorizontally(
+                                animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                                targetOffsetX = { fullWidth -> -direction * fullWidth / 3 }
+                            ) + fadeOut(animationSpec = tween(durationMillis = 200))
+                        )
+                        .using(
+                            SizeTransform(
+                                clip = false,
+                                sizeAnimationSpec = { _, _ ->
+                                    spring(stiffness = Spring.StiffnessMediumLow)
+                                }
+                            )
+                        )
+                },
+                label = "wizardStepIndicator"
+            ) { labels ->
+                if (labels.size > MAX_VISIBLE_STEPS) {
+                    ScrollableStepIndicator(
+                        labels,
+                        currentStepIndex,
+                        optionalStepIndices
                     )
-            },
-            label = "wizardStepIndicator"
-        ) { labels ->
-            if (labels.size > MAX_VISIBLE_STEPS) {
-                ScrollableStepIndicator(labels, currentStepIndex)
-            } else {
-                StaticStepIndicator(labels, currentStepIndex)
+                } else {
+                    StaticStepIndicator(
+                        labels,
+                        currentStepIndex,
+                        optionalStepIndices
+                    )
+                }
+            }
+
+            // ── Skip-to-review link ──────────────────────────────────────
+            AnimatedVisibility(
+                visible = skipToReviewLabel != null && onSkipToReview != null,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                if (skipToReviewLabel != null && onSkipToReview != null) {
+                    Text(
+                        text = skipToReviewLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.SemiBold,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(onClick = onSkipToReview)
+                            .padding(vertical = 6.dp)
+                    )
+                }
             }
         }
     }
@@ -117,7 +170,8 @@ fun WizardStepIndicator(
 @Composable
 private fun StaticStepIndicator(
     stepLabels: List<String>,
-    currentStepIndex: Int
+    currentStepIndex: Int,
+    optionalStepIndices: Set<Int>
 ) {
     Row(
         modifier = Modifier
@@ -130,7 +184,8 @@ private fun StaticStepIndicator(
                 stepNumber = index + 1,
                 label = label,
                 isCompleted = index < currentStepIndex,
-                isCurrent = index == currentStepIndex
+                isCurrent = index == currentStepIndex,
+                isOptional = index in optionalStepIndices
             )
             if (index < stepLabels.lastIndex) {
                 WizardStepConnector(
@@ -147,7 +202,8 @@ private fun StaticStepIndicator(
 @Composable
 private fun ScrollableStepIndicator(
     stepLabels: List<String>,
-    currentStepIndex: Int
+    currentStepIndex: Int,
+    optionalStepIndices: Set<Int>
 ) {
     val density = LocalDensity.current
     val scrollState = rememberScrollState()
@@ -188,6 +244,7 @@ private fun ScrollableStepIndicator(
                     label = label,
                     isCompleted = index < currentStepIndex,
                     isCurrent = index == currentStepIndex,
+                    isOptional = index in optionalStepIndices,
                     modifier = Modifier.width(stepItemWidth)
                 )
                 if (index < stepLabels.lastIndex) {
@@ -209,6 +266,7 @@ private fun WizardStepItem(
     label: String,
     isCompleted: Boolean,
     isCurrent: Boolean,
+    isOptional: Boolean,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -218,7 +276,8 @@ private fun WizardStepItem(
         StepCircle(
             stepNumber = stepNumber,
             isCompleted = isCompleted,
-            isCurrent = isCurrent
+            isCurrent = isCurrent,
+            isOptional = isOptional
         )
         Text(
             text = label,
@@ -263,7 +322,8 @@ private fun WizardStepConnector(
 private fun StepCircle(
     stepNumber: Int,
     isCompleted: Boolean,
-    isCurrent: Boolean
+    isCurrent: Boolean,
+    isOptional: Boolean
 ) {
     val backgroundColor by animateColorAsState(
         targetValue = when {
@@ -282,9 +342,38 @@ private fun StepCircle(
         label = "stepContent"
     )
 
+    // Show dashed border for optional steps that are not yet completed
+    val showDashedBorder = isOptional && !isCompleted
+    val dashedBorderColor = if (isCurrent) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.outlineVariant
+    }
+
     Box(
         modifier = Modifier
             .size(STEP_CIRCLE_SIZE.dp)
+            .then(
+                if (showDashedBorder) {
+                    Modifier.drawBehind {
+                        drawRoundRect(
+                            color = dashedBorderColor,
+                            cornerRadius = CornerRadius(size.minDimension / 2),
+                            style = Stroke(
+                                width = 2.dp.toPx(),
+                                pathEffect = PathEffect.dashPathEffect(
+                                    floatArrayOf(
+                                        DASH_ON_INTERVAL.dp.toPx(),
+                                        DASH_OFF_INTERVAL.dp.toPx()
+                                    )
+                                )
+                            )
+                        )
+                    }
+                } else {
+                    Modifier
+                }
+            )
             .clip(CircleShape)
             .background(backgroundColor),
         contentAlignment = Alignment.Center

--- a/features/contributions/src/main/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/viewmodel/state/AddContributionStep.kt
+++ b/features/contributions/src/main/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/viewmodel/state/AddContributionStep.kt
@@ -2,8 +2,13 @@ package es.pedrazamiguez.splittrip.features.contribution.presentation.viewmodel.
 
 /**
  * Wizard steps for the Add Contribution flow.
+ *
+ * All steps are required — there are no optional steps in this short wizard.
+ *
+ * @property isOptional When `true` the step can be skipped via "Skip to Review".
+ *                      Currently all contribution steps are required.
  */
-enum class AddContributionStep {
+enum class AddContributionStep(val isOptional: Boolean = false) {
     AMOUNT,
     SCOPE,
     REVIEW

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
@@ -110,6 +110,7 @@ private fun ExpenseWizard(
     val backLabel = stringResource(R.string.expense_wizard_back)
     val nextLabel = stringResource(R.string.expense_wizard_next)
     val submitLabel = stringResource(R.string.add_expense_submit_button)
+    val skipToReviewLabel = stringResource(R.string.expense_wizard_skip_to_review)
 
     val bottomPadding = LocalBottomPadding.current
 
@@ -120,7 +121,14 @@ private fun ExpenseWizard(
         Column(modifier = Modifier.fillMaxSize()) {
             WizardStepIndicator(
                 stepLabels = orderedLabels,
-                currentStepIndex = uiState.currentStepIndex
+                currentStepIndex = uiState.currentStepIndex,
+                optionalStepIndices = uiState.optionalStepIndices,
+                skipToReviewLabel = if (uiState.isOnOptionalStep) skipToReviewLabel else null,
+                onSkipToReview = if (uiState.isOnOptionalStep) {
+                    { onEvent(AddExpenseUiEvent.JumpToReview) }
+                } else {
+                    null
+                }
             )
 
             WizardStepContent(

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
@@ -13,6 +13,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handle
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SplitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubmitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubunitSplitEventHandler
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -268,6 +269,7 @@ class AddExpenseViewModel(
             // ── Wizard Navigation ────────────────────────────────────────
             AddExpenseUiEvent.NextStep -> navigateNext()
             AddExpenseUiEvent.PreviousStep -> navigatePrevious()
+            AddExpenseUiEvent.JumpToReview -> navigateToReview()
         }
     }
 
@@ -295,12 +297,39 @@ class AddExpenseViewModel(
         }
     }
 
+    /**
+     * Jumps directly from the current optional step to the REVIEW step.
+     * Records the departure step so [navigatePrevious] can return to it.
+     */
+    private fun navigateToReview() {
+        val state = _uiState.value
+        if (!state.currentStep.isOptional) return
+        _uiState.update {
+            it.copy(
+                currentStep = AddExpenseStep.REVIEW,
+                jumpedFromStep = state.currentStep
+            )
+        }
+    }
+
     private fun navigatePrevious() {
         val state = _uiState.value
         val steps = state.applicableSteps
         val currentIndex = state.currentStepIndex
+
+        // If the user jumped to REVIEW, go back to the step they jumped from
+        if (state.jumpedFromStep != null && state.isOnReviewStep) {
+            _uiState.update {
+                it.copy(
+                    currentStep = state.jumpedFromStep,
+                    jumpedFromStep = null
+                )
+            }
+            return
+        }
+
         if (currentIndex > 0) {
-            _uiState.update { it.copy(currentStep = steps[currentIndex - 1]) }
+            _uiState.update { it.copy(currentStep = steps[currentIndex - 1], jumpedFromStep = null) }
         } else {
             // On first step — signal the Feature to pop the back stack
             viewModelScope.launch {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/AddExpenseUiEvent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/AddExpenseUiEvent.kt
@@ -114,4 +114,7 @@ sealed interface AddExpenseUiEvent {
     // ── Wizard Navigation ───────────────────────────────────────────────
     data object NextStep : AddExpenseUiEvent
     data object PreviousStep : AddExpenseUiEvent
+
+    /** Jumps directly from the current optional step to the REVIEW step. */
+    data object JumpToReview : AddExpenseUiEvent
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseStep.kt
@@ -11,17 +11,21 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state
  *   5. amount + currency (always)
  *   6. exchange rate (conditional: foreign currency selected)
  *   7. split among members (conditional: group has >1 member)
- *   8. category (always)
- *   9. vendor + notes (always)
+ *   8. category (always, optional — may be skipped)
+ *   9. vendor + notes (always, optional — may be skipped)
  *  10. payment status / scheduling (always)
- *  11. receipt (always)
- *  12. add-ons: fees, tips, discounts, surcharges (always)
+ *  11. receipt (always, optional — may be skipped)
+ *  12. add-ons: fees, tips, discounts, surcharges (always, optional — may be skipped)
  *  13. review: read-only summary (always)
  *
  * Conditional steps (CONTRIBUTION_SCOPE, EXCHANGE_RATE, SPLIT) are dynamically
  * included/excluded by [applicableSteps] based on the current form state.
+ *
+ * @property isOptional When `true` the step can be skipped via the "Skip to Review"
+ *                      link in [WizardStepIndicator]. Optional steps show a dashed
+ *                      border in the indicator until completed.
  */
-enum class AddExpenseStep {
+enum class AddExpenseStep(val isOptional: Boolean = false) {
     /** Expense title — always shown. */
     TITLE,
 
@@ -43,20 +47,20 @@ enum class AddExpenseStep {
     /** Split type + per-member allocation + sub-unit mode — only when >1 member. */
     SPLIT,
 
-    /** Category selection. */
-    CATEGORY,
+    /** Category selection — optional, may be skipped. */
+    CATEGORY(isOptional = true),
 
-    /** Vendor and optional notes. */
-    VENDOR_NOTES,
+    /** Vendor and optional notes — optional, may be skipped. */
+    VENDOR_NOTES(isOptional = true),
 
     /** Payment status + conditional due date. */
     PAYMENT_STATUS,
 
-    /** Receipt image attachment. */
-    RECEIPT,
+    /** Receipt image attachment — optional, may be skipped. */
+    RECEIPT(isOptional = true),
 
-    /** Fees, tips, discounts, surcharges. */
-    ADD_ONS,
+    /** Fees, tips, discounts, surcharges — optional, may be skipped. */
+    ADD_ONS(isOptional = true),
 
     /** Read-only summary of all entered data — always shown (final confirmation). */
     REVIEW;

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -139,7 +139,12 @@ data class AddExpenseUiState(
     val isDueDateValid: Boolean = true,
 
     // ── Wizard ──────────────────────────────────────────────────────────
-    val currentStep: AddExpenseStep = AddExpenseStep.TITLE
+    val currentStep: AddExpenseStep = AddExpenseStep.TITLE,
+    /**
+     * When non-null, the user jumped from this step to REVIEW via "Skip to Review".
+     * Pressing Back on REVIEW returns to this step instead of the previous sequential one.
+     */
+    val jumpedFromStep: AddExpenseStep? = null
 ) {
     /**
      * Returns true when the screen is ready for user interaction.
@@ -184,6 +189,21 @@ data class AddExpenseUiState(
     /** Whether the current step is the final review step. */
     val isOnReviewStep: Boolean
         get() = currentStep == AddExpenseStep.REVIEW
+
+    /** Whether the current step is optional (can be skipped). */
+    val isOnOptionalStep: Boolean
+        get() = currentStep.isOptional
+
+    /**
+     * Zero-based indices of optional steps within [applicableSteps].
+     *
+     * Passed to [WizardStepIndicator] so optional steps can render with
+     * a dashed-border visual treatment.
+     */
+    val optionalStepIndices: Set<Int>
+        get() = applicableSteps
+            .mapIndexedNotNull { index, step -> if (step.isOptional) index else null }
+            .toSet()
 
     /**
      * Returns a copy with [currentStep] clamped to the nearest applicable step.

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -146,6 +146,7 @@
     <string name="expense_wizard_step_receipt">Recibo</string>
     <string name="expense_wizard_step_add_ons">Extras</string>
     <string name="expense_wizard_step_review">Resumen</string>
+    <string name="expense_wizard_skip_to_review">Ir al resumen →</string>
 
     <!-- Review Step -->
     <string name="expense_review_title">Revisa tu gasto</string>

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="expense_wizard_step_receipt">Receipt</string>
     <string name="expense_wizard_step_add_ons">Add-ons</string>
     <string name="expense_wizard_step_review">Review</string>
+    <string name="expense_wizard_skip_to_review">Skip to Review →</string>
 
     <!-- Review Step -->
     <string name="expense_review_title">Review your expense</string>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
@@ -54,6 +54,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handle
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubmitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubmitResultDelegate
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubunitSplitEventHandler
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -1448,6 +1449,73 @@ class AddExpenseViewModelTest {
             viewModel.onEvent(AddExpenseUiEvent.PreviousStep)
 
             assertEquals(initialStep, viewModel.uiState.value.currentStep)
+        }
+
+        @Test
+        fun `JumpToReview sets currentStep to REVIEW and records jumpedFromStep`() = runTest {
+            // Navigate to an optional step (CATEGORY)
+            val steps = viewModel.uiState.value.applicableSteps
+            val categoryIndex = steps.indexOf(AddExpenseStep.CATEGORY)
+            repeat(categoryIndex) { viewModel.onEvent(AddExpenseUiEvent.NextStep) }
+            assertEquals(AddExpenseStep.CATEGORY, viewModel.uiState.value.currentStep)
+            assertTrue(viewModel.uiState.value.currentStep.isOptional)
+
+            // When — Jump to Review
+            viewModel.onEvent(AddExpenseUiEvent.JumpToReview)
+
+            // Then
+            assertEquals(AddExpenseStep.REVIEW, viewModel.uiState.value.currentStep)
+            assertEquals(AddExpenseStep.CATEGORY, viewModel.uiState.value.jumpedFromStep)
+        }
+
+        @Test
+        fun `PreviousStep from REVIEW returns to jumpedFromStep`() = runTest {
+            // Navigate to an optional step and jump
+            val steps = viewModel.uiState.value.applicableSteps
+            val categoryIndex = steps.indexOf(AddExpenseStep.CATEGORY)
+            repeat(categoryIndex) { viewModel.onEvent(AddExpenseUiEvent.NextStep) }
+            viewModel.onEvent(AddExpenseUiEvent.JumpToReview)
+            assertEquals(AddExpenseStep.REVIEW, viewModel.uiState.value.currentStep)
+
+            // When — Go back
+            viewModel.onEvent(AddExpenseUiEvent.PreviousStep)
+
+            // Then — Should return to CATEGORY, not the step before REVIEW
+            assertEquals(AddExpenseStep.CATEGORY, viewModel.uiState.value.currentStep)
+            assertNull(viewModel.uiState.value.jumpedFromStep)
+        }
+
+        @Test
+        fun `JumpToReview is ignored on non-optional step`() = runTest {
+            // TITLE is the first step and is NOT optional
+            assertEquals(AddExpenseStep.TITLE, viewModel.uiState.value.currentStep)
+            assertFalse(viewModel.uiState.value.currentStep.isOptional)
+
+            // When
+            viewModel.onEvent(AddExpenseUiEvent.JumpToReview)
+
+            // Then — Should stay on TITLE
+            assertEquals(AddExpenseStep.TITLE, viewModel.uiState.value.currentStep)
+            assertNull(viewModel.uiState.value.jumpedFromStep)
+        }
+
+        @Test
+        fun `sequential PreviousStep after jump-back clears jumpedFromStep`() = runTest {
+            // Navigate to an optional step and jump to Review
+            val steps = viewModel.uiState.value.applicableSteps
+            val categoryIndex = steps.indexOf(AddExpenseStep.CATEGORY)
+            repeat(categoryIndex) { viewModel.onEvent(AddExpenseUiEvent.NextStep) }
+            viewModel.onEvent(AddExpenseUiEvent.JumpToReview)
+
+            // Go back (jump-back to CATEGORY)
+            viewModel.onEvent(AddExpenseUiEvent.PreviousStep)
+            assertEquals(AddExpenseStep.CATEGORY, viewModel.uiState.value.currentStep)
+            assertNull(viewModel.uiState.value.jumpedFromStep)
+
+            // Go back again (sequential — should go to previous step)
+            viewModel.onEvent(AddExpenseUiEvent.PreviousStep)
+            val expectedPrev = steps[categoryIndex - 1]
+            assertEquals(expectedPrev, viewModel.uiState.value.currentStep)
         }
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiStateTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiStateTest.kt
@@ -367,6 +367,96 @@ class AddExpenseUiStateTest {
         }
     }
 
+    // ── isOnOptionalStep ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("isOnOptionalStep")
+    inner class IsOnOptionalStep {
+
+        @Test
+        fun `returns true when on an optional step (CATEGORY)`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.CATEGORY)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns true when on VENDOR_NOTES`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.VENDOR_NOTES)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns true when on RECEIPT`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.RECEIPT)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns true when on ADD_ONS`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.ADD_ONS)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on a required step (TITLE)`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.TITLE)
+            assertFalse(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on REVIEW`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.REVIEW)
+            assertFalse(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on AMOUNT`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.AMOUNT)
+            assertFalse(state.isOnOptionalStep)
+        }
+    }
+
+    // ── optionalStepIndices ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("optionalStepIndices")
+    inner class OptionalStepIndices {
+
+        @Test
+        fun `returns indices of all optional steps`() {
+            val state = AddExpenseUiState()
+            val steps = state.applicableSteps
+            val expectedIndices = steps
+                .mapIndexedNotNull { index, step -> if (step.isOptional) index else null }
+                .toSet()
+            assertEquals(expectedIndices, state.optionalStepIndices)
+            assertTrue(expectedIndices.isNotEmpty())
+        }
+
+        @Test
+        fun `optional indices point to correct steps`() {
+            val state = AddExpenseUiState()
+            val steps = state.applicableSteps
+            state.optionalStepIndices.forEach { index ->
+                assertTrue(steps[index].isOptional, "Step at index $index should be optional")
+            }
+        }
+
+        @Test
+        fun `non-optional indices are excluded`() {
+            val state = AddExpenseUiState()
+            val steps = state.applicableSteps
+            steps.forEachIndexed { index, step ->
+                if (!step.isOptional) {
+                    assertFalse(
+                        index in state.optionalStepIndices,
+                        "Non-optional step ${step.name} at index $index should not be in optionalStepIndices"
+                    )
+                }
+            }
+        }
+    }
+
     // ── isCurrentStepValid ───────────────────────────────────────────────────
 
     @Nested

--- a/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/viewmodel/state/CreateGroupStep.kt
+++ b/features/groups/src/main/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/viewmodel/state/CreateGroupStep.kt
@@ -6,8 +6,11 @@ package es.pedrazamiguez.splittrip.features.group.presentation.viewmodel.state
  * All four steps are always applicable (no conditional steps).
  *
  * INFO → CURRENCY → MEMBERS → REVIEW
+ *
+ * @property isOptional When `true` the step can be skipped via "Skip to Review".
+ *                      Currently all group creation steps are required.
  */
-enum class CreateGroupStep {
+enum class CreateGroupStep(val isOptional: Boolean = false) {
     /** Group name + optional description. */
     INFO,
 

--- a/features/subunits/src/main/kotlin/es/pedrazamiguez/splittrip/features/subunit/presentation/viewmodel/state/CreateEditSubunitStep.kt
+++ b/features/subunits/src/main/kotlin/es/pedrazamiguez/splittrip/features/subunit/presentation/viewmodel/state/CreateEditSubunitStep.kt
@@ -4,10 +4,14 @@ package es.pedrazamiguez.splittrip.features.subunit.presentation.viewmodel.state
  * Defines the wizard steps for the create/edit subunit flow.
  *
  * All four steps are always applicable (no conditional steps).
+ * All steps are required — there are no optional steps in this wizard.
  *
  * NAME → MEMBERS → SHARES → REVIEW
+ *
+ * @property isOptional When `true` the step can be skipped via "Skip to Review".
+ *                      Currently all subunit steps are required.
  */
-enum class CreateEditSubunitStep {
+enum class CreateEditSubunitStep(val isOptional: Boolean = false) {
     /** Subunit name input. */
     NAME,
 

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/screen/AddCashWithdrawalScreen.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/screen/AddCashWithdrawalScreen.kt
@@ -105,6 +105,7 @@ private fun WithdrawalWizard(
     val backLabel = stringResource(R.string.withdrawal_wizard_back)
     val nextLabel = stringResource(R.string.withdrawal_wizard_next)
     val submitLabel = stringResource(R.string.withdrawal_cash_submit)
+    val skipToReviewLabel = stringResource(R.string.withdrawal_wizard_skip_to_review)
 
     val bottomPadding = LocalBottomPadding.current
 
@@ -115,7 +116,14 @@ private fun WithdrawalWizard(
         Column(modifier = Modifier.fillMaxSize()) {
             WizardStepIndicator(
                 stepLabels = orderedLabels,
-                currentStepIndex = uiState.currentStepIndex
+                currentStepIndex = uiState.currentStepIndex,
+                optionalStepIndices = uiState.optionalStepIndices,
+                skipToReviewLabel = if (uiState.isOnOptionalStep) skipToReviewLabel else null,
+                onSkipToReview = if (uiState.isOnOptionalStep) {
+                    { onEvent(AddCashWithdrawalUiEvent.JumpToReview) }
+                } else {
+                    null
+                }
             )
 
             WizardStepContent(

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/AddCashWithdrawalViewModel.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/AddCashWithdrawalViewModel.kt
@@ -11,6 +11,7 @@ import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.han
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.handler.WithdrawalFeeHandler
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.handler.WithdrawalSubmitHandler
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.state.AddCashWithdrawalUiState
+import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.state.CashWithdrawalStep
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -126,6 +127,7 @@ class AddCashWithdrawalViewModel(
             // ── Wizard Navigation ────────────────────────────────────────
             AddCashWithdrawalUiEvent.NextStep -> navigateNext()
             AddCashWithdrawalUiEvent.PreviousStep -> navigatePrevious()
+            AddCashWithdrawalUiEvent.JumpToReview -> navigateToReview()
         }
     }
 
@@ -155,12 +157,39 @@ class AddCashWithdrawalViewModel(
         }
     }
 
+    /**
+     * Jumps directly from the current optional step to the REVIEW step.
+     * Records the departure step so [navigatePrevious] can return to it.
+     */
+    private fun navigateToReview() {
+        val state = _uiState.value
+        if (!state.currentStep.isOptional) return
+        _uiState.update {
+            it.copy(
+                currentStep = CashWithdrawalStep.REVIEW,
+                jumpedFromStep = state.currentStep
+            )
+        }
+    }
+
     private fun navigatePrevious() {
         val state = _uiState.value
         val steps = state.applicableSteps
         val currentIndex = state.currentStepIndex
+
+        // If the user jumped to REVIEW, go back to the step they jumped from
+        if (state.jumpedFromStep != null && state.isOnReviewStep) {
+            _uiState.update {
+                it.copy(
+                    currentStep = state.jumpedFromStep,
+                    jumpedFromStep = null
+                )
+            }
+            return
+        }
+
         if (currentIndex > 0) {
-            _uiState.update { it.copy(currentStep = steps[currentIndex - 1]) }
+            _uiState.update { it.copy(currentStep = steps[currentIndex - 1], jumpedFromStep = null) }
         } else {
             // On first step — signal the Feature to pop the back stack
             viewModelScope.launch {

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/event/AddCashWithdrawalUiEvent.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/event/AddCashWithdrawalUiEvent.kt
@@ -25,4 +25,7 @@ sealed interface AddCashWithdrawalUiEvent {
     // ── Wizard Navigation ───────────────────────────────────────────────
     data object NextStep : AddCashWithdrawalUiEvent
     data object PreviousStep : AddCashWithdrawalUiEvent
+
+    /** Jumps directly from the current optional step to the REVIEW step. */
+    data object JumpToReview : AddCashWithdrawalUiEvent
 }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiState.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiState.kt
@@ -69,7 +69,12 @@ data class AddCashWithdrawalUiState(
     val error: UiText? = null,
 
     // ── Wizard ──────────────────────────────────────────────────────────
-    val currentStep: CashWithdrawalStep = CashWithdrawalStep.AMOUNT
+    val currentStep: CashWithdrawalStep = CashWithdrawalStep.AMOUNT,
+    /**
+     * When non-null, the user jumped from this step to REVIEW via "Skip to Review".
+     * Pressing Back on REVIEW returns to this step instead of the previous sequential one.
+     */
+    val jumpedFromStep: CashWithdrawalStep? = null
 ) {
     val isReady: Boolean
         get() = isConfigLoaded && !configLoadFailed && !isLoading
@@ -102,6 +107,21 @@ data class AddCashWithdrawalUiState(
     /** Whether the current step is the final review step. */
     val isOnReviewStep: Boolean
         get() = currentStep == CashWithdrawalStep.REVIEW
+
+    /** Whether the current step is optional (can be skipped). */
+    val isOnOptionalStep: Boolean
+        get() = currentStep.isOptional
+
+    /**
+     * Zero-based indices of optional steps within [applicableSteps].
+     *
+     * Passed to [WizardStepIndicator] so optional steps can render with
+     * a dashed-border visual treatment.
+     */
+    val optionalStepIndices: Set<Int>
+        get() = applicableSteps
+            .mapIndexedNotNull { index, step -> if (step.isOptional) index else null }
+            .toSet()
 
     /**
      * Returns a copy with [currentStep] clamped to the nearest applicable step.

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/CashWithdrawalStep.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/CashWithdrawalStep.kt
@@ -11,8 +11,12 @@ package es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.st
  *
  * Conditional steps (EXCHANGE_RATE, ATM_FEE, FEE_EXCHANGE_RATE) are dynamically
  * included/excluded by [applicableSteps] based on the current form state.
+ *
+ * @property isOptional When `true` the step can be skipped via the "Skip to Review"
+ *                      link in [WizardStepIndicator]. Optional steps show a dashed
+ *                      border in the indicator until completed.
  */
-enum class CashWithdrawalStep {
+enum class CashWithdrawalStep(val isOptional: Boolean = false) {
     /** Amount input + currency selector — always shown. */
     AMOUNT,
 
@@ -22,8 +26,8 @@ enum class CashWithdrawalStep {
     /** Who is withdrawing: group / subunit / personal — always shown. */
     SCOPE,
 
-    /** Title, notes, and ATM fee opt-in toggle — always shown. */
-    DETAILS,
+    /** Title, notes, and ATM fee opt-in toggle — always shown, optional. */
+    DETAILS(isOptional = true),
 
     /** ATM fee amount + fee currency — only when fee is toggled on. */
     ATM_FEE,

--- a/features/withdrawals/src/main/res/values-es/strings.xml
+++ b/features/withdrawals/src/main/res/values-es/strings.xml
@@ -36,6 +36,7 @@
     <!-- Wizard Navigation -->
     <string name="withdrawal_wizard_next">Siguiente</string>
     <string name="withdrawal_wizard_back">Atrás</string>
+    <string name="withdrawal_wizard_skip_to_review">Ir al resumen →</string>
     <string name="withdrawal_wizard_step_amount">Importe</string>
     <string name="withdrawal_wizard_step_exchange_rate">Tipo</string>
     <string name="withdrawal_wizard_step_scope">Ámbito</string>

--- a/features/withdrawals/src/main/res/values/strings.xml
+++ b/features/withdrawals/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <!-- Wizard Navigation -->
     <string name="withdrawal_wizard_next">Next</string>
     <string name="withdrawal_wizard_back">Back</string>
+    <string name="withdrawal_wizard_skip_to_review">Skip to Review →</string>
     <string name="withdrawal_wizard_step_amount">Amount</string>
     <string name="withdrawal_wizard_step_exchange_rate">Rate</string>
     <string name="withdrawal_wizard_step_scope">Scope</string>

--- a/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/AddCashWithdrawalViewModelTest.kt
+++ b/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/AddCashWithdrawalViewModelTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -266,6 +267,61 @@ class AddCashWithdrawalViewModelTest {
 
             assertEquals(CashWithdrawalStep.AMOUNT, viewModel.uiState.value.currentStep)
             assertEquals(CashWithdrawalStep.SCOPE, stepAfterNext)
+        }
+
+        @Test
+        fun `JumpToReview sets currentStep to REVIEW and records jumpedFromStep`() =
+            runTest(testDispatcher) {
+                // Navigate to DETAILS (optional step): AMOUNT → SCOPE → DETAILS
+                viewModel.onEvent(AddCashWithdrawalUiEvent.NextStep) // → SCOPE
+                advanceUntilIdle()
+                viewModel.onEvent(AddCashWithdrawalUiEvent.NextStep) // → DETAILS
+                advanceUntilIdle()
+                assertEquals(CashWithdrawalStep.DETAILS, viewModel.uiState.value.currentStep)
+                assertTrue(viewModel.uiState.value.currentStep.isOptional)
+
+                // When — Jump to Review
+                viewModel.onEvent(AddCashWithdrawalUiEvent.JumpToReview)
+                advanceUntilIdle()
+
+                // Then
+                assertEquals(CashWithdrawalStep.REVIEW, viewModel.uiState.value.currentStep)
+                assertEquals(CashWithdrawalStep.DETAILS, viewModel.uiState.value.jumpedFromStep)
+            }
+
+        @Test
+        fun `PreviousStep from REVIEW returns to jumpedFromStep`() = runTest(testDispatcher) {
+            // Navigate to DETAILS and jump
+            viewModel.onEvent(AddCashWithdrawalUiEvent.NextStep) // → SCOPE
+            advanceUntilIdle()
+            viewModel.onEvent(AddCashWithdrawalUiEvent.NextStep) // → DETAILS
+            advanceUntilIdle()
+            viewModel.onEvent(AddCashWithdrawalUiEvent.JumpToReview)
+            advanceUntilIdle()
+            assertEquals(CashWithdrawalStep.REVIEW, viewModel.uiState.value.currentStep)
+
+            // When — Go back
+            viewModel.onEvent(AddCashWithdrawalUiEvent.PreviousStep)
+            advanceUntilIdle()
+
+            // Then — Should return to DETAILS, not the step before REVIEW
+            assertEquals(CashWithdrawalStep.DETAILS, viewModel.uiState.value.currentStep)
+            assertNull(viewModel.uiState.value.jumpedFromStep)
+        }
+
+        @Test
+        fun `JumpToReview is ignored on non-optional step`() = runTest(testDispatcher) {
+            // AMOUNT is the first step and is NOT optional
+            assertEquals(CashWithdrawalStep.AMOUNT, viewModel.uiState.value.currentStep)
+            assertFalse(viewModel.uiState.value.currentStep.isOptional)
+
+            // When
+            viewModel.onEvent(AddCashWithdrawalUiEvent.JumpToReview)
+            advanceUntilIdle()
+
+            // Then — Should stay on AMOUNT
+            assertEquals(CashWithdrawalStep.AMOUNT, viewModel.uiState.value.currentStep)
+            assertNull(viewModel.uiState.value.jumpedFromStep)
         }
     }
 

--- a/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiStateTest.kt
+++ b/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiStateTest.kt
@@ -372,6 +372,63 @@ class AddCashWithdrawalUiStateTest {
         }
     }
 
+    // ── isOnOptionalStep ──────────────────────────────────────────────────────
+
+    @Nested
+    inner class IsOnOptionalStep {
+
+        @Test
+        fun `returns true when on DETAILS (optional step)`() {
+            val state = AddCashWithdrawalUiState(currentStep = CashWithdrawalStep.DETAILS)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on AMOUNT (required step)`() {
+            val state = AddCashWithdrawalUiState(currentStep = CashWithdrawalStep.AMOUNT)
+            assertFalse(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on SCOPE (required step)`() {
+            val state = AddCashWithdrawalUiState(currentStep = CashWithdrawalStep.SCOPE)
+            assertFalse(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on REVIEW`() {
+            val state = AddCashWithdrawalUiState(currentStep = CashWithdrawalStep.REVIEW)
+            assertFalse(state.isOnOptionalStep)
+        }
+    }
+
+    // ── optionalStepIndices ─────────────────────────────────────────────────
+
+    @Nested
+    inner class OptionalStepIndices {
+
+        @Test
+        fun `returns index of DETAILS step only (minimal flow)`() {
+            val state = AddCashWithdrawalUiState()
+            val steps = state.applicableSteps
+            val detailsIndex = steps.indexOf(CashWithdrawalStep.DETAILS)
+            assertEquals(setOf(detailsIndex), state.optionalStepIndices)
+        }
+
+        @Test
+        fun `optional indices point to correct steps`() {
+            val state = AddCashWithdrawalUiState(
+                showExchangeRateSection = true,
+                hasFee = true,
+                showFeeExchangeRateSection = true
+            )
+            val steps = state.applicableSteps
+            state.optionalStepIndices.forEach { index ->
+                assertTrue(steps[index].isOptional, "Step at index $index should be optional")
+            }
+        }
+    }
+
     // ── isCurrentStepValid ────────────────────────────────────────────────────
 
     @Nested

--- a/wiki/core-services-catalog.md
+++ b/wiki/core-services-catalog.md
@@ -98,8 +98,9 @@ All components are `@Composable` functions following Material 3 design. They acc
 | Component | File | Purpose |
 |---|---|---|
 | `WizardStepLayout` | `wizard/WizardStepLayout.kt` | Container for a single wizard step: title, content slot, and consistent padding. **Use for:** Multi-step form screens (e.g., Add Expense wizard). |
-| `WizardStepIndicator` | `wizard/WizardStepIndicator.kt` | Animated step dots/labels showing progress through wizard steps. **Use for:** Top of wizard screens to show current step. |
+| `WizardStepIndicator` | `wizard/WizardStepIndicator.kt` | Animated step dots/labels showing progress through wizard steps. Supports optional step indices (dashed-border visual), and a "Skip to Review" link. **Use for:** Top of wizard screens to show current step. |
 | `WizardNavigationBar` | `wizard/WizardNavigationBar.kt` | Bottom bar with Back/Next/Submit buttons. Configured via `WizardNavigationBarConfig`. **Use for:** Wizard step navigation controls. |
+| `WizardSkipStrategy` | `wizard/WizardSkipStrategy.kt` | Enum classifying wizard steps as `REQUIRED` or `OPTIONAL`. Used as documentation/reference; feature step enums use `isOptional: Boolean`. |
 
 **Configuration class:**
 - `WizardNavigationBarConfig` — data class defining button labels, visibility, and enabled state for each wizard navigation button.

--- a/wiki/ux-ui-concepts.md
+++ b/wiki/ux-ui-concepts.md
@@ -218,8 +218,10 @@ Every form that collects more than a couple of fields uses a shared `WizardStepI
 2. **Conditional Steps & Clamping:** When a state change removes a conditional step (e.g., switching currency back to the group currency removes the EXCHANGE_RATE step), the `withStepClamped()` method on the UiState ensures `currentStep` falls back to the nearest valid step.
 3. **Wizard Navigation in ViewModel:** `NextStep` and `PreviousStep` events are handled inline in the ViewModel. On the first step, `PreviousStep` emits a `NavigateBack` UiAction that the Feature routes to `navController.popBackStack()`.
 4. **BackHandler:** The Feature composable intercepts the system back button via `BackHandler` and delegates to `PreviousStep`, so the wizard navigates backward before exiting.
-5. **Step-Skipping Strategy:** Future work (issue #719) will add a skip strategy for optional steps. For now, the user must go through all applicable steps.
+5. **Optional Steps & Skip-to-Review:** Steps can be marked as optional via `isOptional = true` in the step enum constructor. Optional steps render with a dashed-border circle in `WizardStepIndicator` and show a "Skip to Review →" link below the indicator. Tapping the link fires a `JumpToReview` event that jumps directly to the REVIEW step and records the departure step in `jumpedFromStep`. Pressing Back on REVIEW returns to the departure step instead of the previous sequential step. Steps that are NOT optional never show the skip link. See `AddExpenseStep` (CATEGORY, VENDOR_NOTES, RECEIPT, ADD_ONS are optional) and `CashWithdrawalStep` (DETAILS is optional).
+6. **WizardSkipStrategy Enum:** A `WizardSkipStrategy` enum in `:core:design-system` classifies steps as `REQUIRED` or `OPTIONAL` for documentation purposes. The feature-level step enums use a simpler `isOptional: Boolean` property.
 
 **Reference implementations:**
-- `AddCashWithdrawalScreen` / `CashWithdrawalStep` — the original wizard reference.
-- `AddExpenseScreen` / `AddExpenseStep` — 11 steps: TITLE → PAYMENT_METHOD → AMOUNT → EXCHANGE_RATE (conditional) → SPLIT (conditional) → CATEGORY → VENDOR_NOTES → PAYMENT_STATUS → RECEIPT → ADD_ONS → REVIEW.
+- `AddCashWithdrawalScreen` / `CashWithdrawalStep` — 7 steps with 1 optional (DETAILS).
+- `AddExpenseScreen` / `AddExpenseStep` — 13 steps: TITLE → PAYMENT_METHOD → FUNDING_SOURCE → CONTRIBUTION_SCOPE (conditional) → AMOUNT → EXCHANGE_RATE (conditional) → SPLIT (conditional) → CATEGORY (optional) → VENDOR_NOTES (optional) → PAYMENT_STATUS → RECEIPT (optional) → ADD_ONS (optional) → REVIEW.
+- `AddContributionScreen` / `AddContributionStep` — 3 steps, all required (no optional steps).


### PR DESCRIPTION
Introduce optional-step support across wizard flows and a Skip-to-Review UX. Added WizardSkipStrategy enum and enhanced WizardStepIndicator to accept optional step indices, render dashed borders for optional (incomplete) steps, and show a tappable "Skip to Review" link. Step enums now accept an isOptional flag (default false); several steps in expenses and withdrawals were marked optional. ViewModel / UiState changes: added JumpToReview event, jumpedFromStep tracking, isOnOptionalStep and optionalStepIndices helpers, and navigation logic to jump to REVIEW and return correctly. Updated strings, tests, and documentation to cover the new behaviour.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #719 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
