### PR TITLE
[SPLTRP-1001]: AddExpenseStep: wrong mandatory/optional classification and incorrect step ordering

### DIFF
--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseStep.kt
@@ -8,20 +8,25 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizar
  * The step sequence is:
  *   1. title (always)
  *   2. payment method (always — determines exchange-rate lock behaviour)
- *   3. funding source (always — "Group Pocket" or "My Money")
- *   4. contribution scope (conditional: funding source = "My Money")
- *   5. amount + currency (always)
- *   6. exchange rate (conditional: foreign currency selected)
- *   7. split among members (conditional: group has >1 member)
- *   8. category (always, optional — may be skipped)
+ *   3. amount + currency (always)
+ *   4. exchange rate (conditional: foreign currency selected; optional — defaults to last-used/fetched rate)
+ *   5. split among members (conditional: group has >1 member; optional — defaults to equal split)
+ *   6. category (always, optional — may be skipped)
+ *   7. funding source (always, optional — defaults to "Group Pocket")
+ *   8. contribution scope (conditional: funding source = "My Money"; mandatory when shown)
  *   9. vendor + notes (always, optional — may be skipped)
- *  10. payment status / scheduling (always)
+ *  10. payment status / scheduling (always, optional — defaults to "Paid")
  *  11. receipt (always, optional — may be skipped)
  *  12. add-ons: fees, tips, discounts, surcharges (always, optional — may be skipped)
  *  13. review: read-only summary (always)
  *
  * Conditional steps (CONTRIBUTION_SCOPE, EXCHANGE_RATE, SPLIT) are dynamically
  * included/excluded by [applicableSteps] based on the current form state.
+ *
+ * The guiding philosophy is: **"As easy or as complicated to log an expense as the user needs."**
+ * The minimum viable path is: TITLE → PAYMENT_METHOD → AMOUNT → [Skip to Review] → REVIEW.
+ * All optional steps carry sensible pre-filled defaults so they can be skipped without leaving
+ * the expense incomplete.
  *
  * @property isOptional When `true` the step can be skipped via the "Skip to Review"
  *                      link in [WizardStepIndicator]. Optional steps show a dashed
@@ -38,29 +43,44 @@ enum class AddExpenseStep(
     /** Payment method selection — always shown (affects exchange-rate lock). */
     PAYMENT_METHOD,
 
-    /** Funding source — always shown ("Group Pocket" or "My Money"). */
-    FUNDING_SOURCE,
-
-    /** Contribution scope — only when funding source is "My Money" (USER). */
-    CONTRIBUTION_SCOPE,
-
     /** Amount + Currency — always shown. */
     AMOUNT,
 
-    /** Exchange rate + calculated group amount — only when foreign currency selected. */
-    EXCHANGE_RATE,
+    /**
+     * Exchange rate + calculated group amount — only when foreign currency selected.
+     * Optional: defaults to last-used or API-fetched rate when skipped.
+     */
+    EXCHANGE_RATE(isOptional = true),
 
-    /** Split type + per-member allocation + sub-unit mode — only when >1 member. */
-    SPLIT,
+    /**
+     * Split type + per-member allocation + sub-unit mode — only when >1 member.
+     * Optional: defaults to equal split among all members when skipped.
+     */
+    SPLIT(isOptional = true),
 
     /** Category selection — optional, may be skipped. */
     CATEGORY(isOptional = true),
 
+    /**
+     * Funding source — always shown ("Group Pocket" or "My Money").
+     * Optional: defaults to "Group Pocket" when skipped.
+     */
+    FUNDING_SOURCE(isOptional = true),
+
+    /**
+     * Contribution scope — only when funding source is "My Money" (USER).
+     * Mandatory when shown: the user must choose a scope explicitly.
+     */
+    CONTRIBUTION_SCOPE,
+
     /** Vendor and optional notes — optional, may be skipped. */
     VENDOR_NOTES(isOptional = true),
 
-    /** Payment status + conditional due date. */
-    PAYMENT_STATUS,
+    /**
+     * Payment status + conditional due date — always shown.
+     * Optional: defaults to "Paid" (not scheduled) when skipped.
+     */
+    PAYMENT_STATUS(isOptional = true),
 
     /** Receipt image attachment — optional, may be skipped. */
     RECEIPT(isOptional = true),
@@ -86,12 +106,12 @@ enum class AddExpenseStep(
         ): List<AddExpenseStep> = buildList {
             add(TITLE)
             add(PAYMENT_METHOD)
-            add(FUNDING_SOURCE)
-            if (showContributionScopeStep) add(CONTRIBUTION_SCOPE)
             add(AMOUNT)
             if (showExchangeRateSection) add(EXCHANGE_RATE)
             if (hasSplit) add(SPLIT)
             add(CATEGORY)
+            add(FUNDING_SOURCE)
+            if (showContributionScopeStep) add(CONTRIBUTION_SCOPE)
             add(VENDOR_NOTES)
             add(PAYMENT_STATUS)
             add(RECEIPT)

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseStepTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseStepTest.kt
@@ -1,0 +1,330 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("AddExpenseStep")
+class AddExpenseStepTest {
+
+    // ── applicableSteps ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("applicableSteps()")
+    inner class ApplicableSteps {
+
+        @Test
+        fun `returns full 13-step sequence when all conditionals are true`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = true,
+                showExchangeRateSection = true,
+                hasSplit = true
+            )
+            val expected = listOf(
+                AddExpenseStep.TITLE,
+                AddExpenseStep.PAYMENT_METHOD,
+                AddExpenseStep.AMOUNT,
+                AddExpenseStep.EXCHANGE_RATE,
+                AddExpenseStep.SPLIT,
+                AddExpenseStep.CATEGORY,
+                AddExpenseStep.FUNDING_SOURCE,
+                AddExpenseStep.CONTRIBUTION_SCOPE,
+                AddExpenseStep.VENDOR_NOTES,
+                AddExpenseStep.PAYMENT_STATUS,
+                AddExpenseStep.RECEIPT,
+                AddExpenseStep.ADD_ONS,
+                AddExpenseStep.REVIEW
+            )
+            assertEquals(expected, steps)
+        }
+
+        @Test
+        fun `returns 10-step sequence when no conditionals apply`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            val expected = listOf(
+                AddExpenseStep.TITLE,
+                AddExpenseStep.PAYMENT_METHOD,
+                AddExpenseStep.AMOUNT,
+                AddExpenseStep.CATEGORY,
+                AddExpenseStep.FUNDING_SOURCE,
+                AddExpenseStep.VENDOR_NOTES,
+                AddExpenseStep.PAYMENT_STATUS,
+                AddExpenseStep.RECEIPT,
+                AddExpenseStep.ADD_ONS,
+                AddExpenseStep.REVIEW
+            )
+            assertEquals(expected, steps)
+        }
+
+        @Test
+        fun `EXCHANGE_RATE is included when showExchangeRateSection is true`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = true,
+                hasSplit = false
+            )
+            assertTrue(steps.contains(AddExpenseStep.EXCHANGE_RATE))
+        }
+
+        @Test
+        fun `EXCHANGE_RATE is excluded when showExchangeRateSection is false`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            assertFalse(steps.contains(AddExpenseStep.EXCHANGE_RATE))
+        }
+
+        @Test
+        fun `SPLIT is included when hasSplit is true`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = true
+            )
+            assertTrue(steps.contains(AddExpenseStep.SPLIT))
+        }
+
+        @Test
+        fun `SPLIT is excluded when hasSplit is false`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            assertFalse(steps.contains(AddExpenseStep.SPLIT))
+        }
+
+        @Test
+        fun `CONTRIBUTION_SCOPE is included when showContributionScopeStep is true`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = true,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            assertTrue(steps.contains(AddExpenseStep.CONTRIBUTION_SCOPE))
+        }
+
+        @Test
+        fun `CONTRIBUTION_SCOPE is excluded when showContributionScopeStep is false`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            assertFalse(steps.contains(AddExpenseStep.CONTRIBUTION_SCOPE))
+        }
+
+        @Test
+        fun `FUNDING_SOURCE is always included`() {
+            val withNoConditionals = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            val withAllConditionals = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = true,
+                showExchangeRateSection = true,
+                hasSplit = true
+            )
+            assertTrue(withNoConditionals.contains(AddExpenseStep.FUNDING_SOURCE))
+            assertTrue(withAllConditionals.contains(AddExpenseStep.FUNDING_SOURCE))
+        }
+
+        @Test
+        fun `FUNDING_SOURCE appears after CATEGORY and before VENDOR_NOTES`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            val categoryIndex = steps.indexOf(AddExpenseStep.CATEGORY)
+            val fundingIndex = steps.indexOf(AddExpenseStep.FUNDING_SOURCE)
+            val vendorNotesIndex = steps.indexOf(AddExpenseStep.VENDOR_NOTES)
+            assertTrue(categoryIndex < fundingIndex)
+            assertTrue(fundingIndex < vendorNotesIndex)
+        }
+
+        @Test
+        fun `CONTRIBUTION_SCOPE appears between FUNDING_SOURCE and VENDOR_NOTES`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = true,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            val fundingIndex = steps.indexOf(AddExpenseStep.FUNDING_SOURCE)
+            val scopeIndex = steps.indexOf(AddExpenseStep.CONTRIBUTION_SCOPE)
+            val vendorNotesIndex = steps.indexOf(AddExpenseStep.VENDOR_NOTES)
+            assertTrue(fundingIndex < scopeIndex)
+            assertTrue(scopeIndex < vendorNotesIndex)
+        }
+
+        @Test
+        fun `FUNDING_SOURCE appears after SPLIT when split is applicable`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = true
+            )
+            val splitIndex = steps.indexOf(AddExpenseStep.SPLIT)
+            val fundingIndex = steps.indexOf(AddExpenseStep.FUNDING_SOURCE)
+            assertTrue(splitIndex < fundingIndex)
+        }
+
+        @Test
+        fun `REVIEW is always the last step`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = true,
+                showExchangeRateSection = true,
+                hasSplit = true
+            )
+            assertEquals(AddExpenseStep.REVIEW, steps.last())
+        }
+
+        @Test
+        fun `TITLE is always the first step`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = true,
+                showExchangeRateSection = true,
+                hasSplit = true
+            )
+            assertEquals(AddExpenseStep.TITLE, steps.first())
+        }
+    }
+
+    // ── isOptional ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("isOptional")
+    inner class IsOptional {
+
+        @Test
+        fun `TITLE is not optional`() {
+            assertFalse(AddExpenseStep.TITLE.isOptional)
+        }
+
+        @Test
+        fun `PAYMENT_METHOD is not optional`() {
+            assertFalse(AddExpenseStep.PAYMENT_METHOD.isOptional)
+        }
+
+        @Test
+        fun `AMOUNT is not optional`() {
+            assertFalse(AddExpenseStep.AMOUNT.isOptional)
+        }
+
+        @Test
+        fun `EXCHANGE_RATE is optional`() {
+            assertTrue(AddExpenseStep.EXCHANGE_RATE.isOptional)
+        }
+
+        @Test
+        fun `SPLIT is optional`() {
+            assertTrue(AddExpenseStep.SPLIT.isOptional)
+        }
+
+        @Test
+        fun `CATEGORY is optional`() {
+            assertTrue(AddExpenseStep.CATEGORY.isOptional)
+        }
+
+        @Test
+        fun `FUNDING_SOURCE is optional`() {
+            assertTrue(AddExpenseStep.FUNDING_SOURCE.isOptional)
+        }
+
+        @Test
+        fun `CONTRIBUTION_SCOPE is not optional`() {
+            assertFalse(AddExpenseStep.CONTRIBUTION_SCOPE.isOptional)
+        }
+
+        @Test
+        fun `VENDOR_NOTES is optional`() {
+            assertTrue(AddExpenseStep.VENDOR_NOTES.isOptional)
+        }
+
+        @Test
+        fun `PAYMENT_STATUS is optional`() {
+            assertTrue(AddExpenseStep.PAYMENT_STATUS.isOptional)
+        }
+
+        @Test
+        fun `RECEIPT is optional`() {
+            assertTrue(AddExpenseStep.RECEIPT.isOptional)
+        }
+
+        @Test
+        fun `ADD_ONS is optional`() {
+            assertTrue(AddExpenseStep.ADD_ONS.isOptional)
+        }
+
+        @Test
+        fun `REVIEW is not optional`() {
+            assertFalse(AddExpenseStep.REVIEW.isOptional)
+        }
+    }
+
+    // ── Minimum viable path ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("MinimumViablePath")
+    inner class MinimumViablePath {
+
+        @Test
+        fun `mandatory non-review steps are TITLE PAYMENT_METHOD AMOUNT and CONTRIBUTION_SCOPE`() {
+            // TITLE, PAYMENT_METHOD, AMOUNT are always-shown mandatory steps.
+            // CONTRIBUTION_SCOPE is also mandatory when shown (conditional on FUNDING_SOURCE=MY_MONEY).
+            val mandatoryNonReview = AddExpenseStep.entries.filter { !it.isOptional && !it.isReview }
+            assertEquals(4, mandatoryNonReview.size)
+            assertTrue(mandatoryNonReview.contains(AddExpenseStep.TITLE))
+            assertTrue(mandatoryNonReview.contains(AddExpenseStep.PAYMENT_METHOD))
+            assertTrue(mandatoryNonReview.contains(AddExpenseStep.AMOUNT))
+            assertTrue(mandatoryNonReview.contains(AddExpenseStep.CONTRIBUTION_SCOPE))
+        }
+
+        @Test
+        fun `REVIEW is the only step with isReview true`() {
+            val reviewSteps = AddExpenseStep.entries.filter { it.isReview }
+            assertEquals(1, reviewSteps.size)
+            assertEquals(AddExpenseStep.REVIEW, reviewSteps.first())
+        }
+
+        @Test
+        fun `all steps after AMOUNT and before REVIEW are optional except CONTRIBUTION_SCOPE`() {
+            // Every step strictly between AMOUNT and REVIEW must be optional
+            // unless it is the conditional CONTRIBUTION_SCOPE step
+            val steps = AddExpenseStep.entries.toList()
+            val amountIdx = steps.indexOf(AddExpenseStep.AMOUNT)
+            val reviewIdx = steps.indexOf(AddExpenseStep.REVIEW)
+            val middle = steps.subList(amountIdx + 1, reviewIdx)
+            val mandatoryMiddle = middle.filter { !it.isOptional }
+            // Only CONTRIBUTION_SCOPE should be mandatory in this range
+            assertEquals(listOf(AddExpenseStep.CONTRIBUTION_SCOPE), mandatoryMiddle)
+        }
+
+        @Test
+        fun `minimum path from applicableSteps contains exactly TITLE PAYMENT_METHOD AMOUNT and REVIEW`() {
+            val steps = AddExpenseStep.applicableSteps(
+                showContributionScopeStep = false,
+                showExchangeRateSection = false,
+                hasSplit = false
+            )
+            val mandatorySteps = steps.filter { !it.isOptional }
+            val expected = listOf(
+                AddExpenseStep.TITLE,
+                AddExpenseStep.PAYMENT_METHOD,
+                AddExpenseStep.AMOUNT,
+                AddExpenseStep.REVIEW
+            )
+            assertEquals(expected, mandatorySteps)
+        }
+    }
+}

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiStateTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiStateTest.kt
@@ -235,7 +235,7 @@ class AddExpenseUiStateTest {
         }
 
         @Test
-        fun `CONTRIBUTION_SCOPE appears between FUNDING_SOURCE and AMOUNT`() {
+        fun `CONTRIBUTION_SCOPE appears between FUNDING_SOURCE and VENDOR_NOTES`() {
             val state = AddExpenseUiState(
                 selectedFundingSource = FundingSourceUiModel(
                     id = PayerType.USER.name,
@@ -245,9 +245,20 @@ class AddExpenseUiStateTest {
             val steps = state.applicableSteps
             val fundingIndex = steps.indexOf(AddExpenseStep.FUNDING_SOURCE)
             val scopeIndex = steps.indexOf(AddExpenseStep.CONTRIBUTION_SCOPE)
-            val amountIndex = steps.indexOf(AddExpenseStep.AMOUNT)
+            val vendorNotesIndex = steps.indexOf(AddExpenseStep.VENDOR_NOTES)
             assertTrue(fundingIndex < scopeIndex)
-            assertTrue(scopeIndex < amountIndex)
+            assertTrue(scopeIndex < vendorNotesIndex)
+        }
+
+        @Test
+        fun `FUNDING_SOURCE appears after CATEGORY and before VENDOR_NOTES`() {
+            val state = AddExpenseUiState()
+            val steps = state.applicableSteps
+            val categoryIndex = steps.indexOf(AddExpenseStep.CATEGORY)
+            val fundingIndex = steps.indexOf(AddExpenseStep.FUNDING_SOURCE)
+            val vendorNotesIndex = steps.indexOf(AddExpenseStep.VENDOR_NOTES)
+            assertTrue(categoryIndex < fundingIndex)
+            assertTrue(fundingIndex < vendorNotesIndex)
         }
     }
 
@@ -334,8 +345,8 @@ class AddExpenseUiStateTest {
 
         @Test
         fun `clamps to previous applicable step when current step is removed`() {
-            // EXCHANGE_RATE is between AMOUNT and SPLIT/CATEGORY
-            // When it's removed, it should clamp to AMOUNT (previous applicable step)
+            // EXCHANGE_RATE is between AMOUNT and SPLIT/CATEGORY in the new ordering.
+            // When it's removed, it should clamp to AMOUNT (previous applicable step).
             val state = AddExpenseUiState(
                 currentStep = AddExpenseStep.EXCHANGE_RATE,
                 showExchangeRateSection = false
@@ -398,6 +409,30 @@ class AddExpenseUiStateTest {
         }
 
         @Test
+        fun `returns true when on PAYMENT_STATUS`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.PAYMENT_STATUS)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns true when on FUNDING_SOURCE`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.FUNDING_SOURCE)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns true when on EXCHANGE_RATE`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.EXCHANGE_RATE)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns true when on SPLIT`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.SPLIT)
+            assertTrue(state.isOnOptionalStep)
+        }
+
+        @Test
         fun `returns false when on a required step (TITLE)`() {
             val state = AddExpenseUiState(currentStep = AddExpenseStep.TITLE)
             assertFalse(state.isOnOptionalStep)
@@ -412,6 +447,12 @@ class AddExpenseUiStateTest {
         @Test
         fun `returns false when on AMOUNT`() {
             val state = AddExpenseUiState(currentStep = AddExpenseStep.AMOUNT)
+            assertFalse(state.isOnOptionalStep)
+        }
+
+        @Test
+        fun `returns false when on CONTRIBUTION_SCOPE`() {
+            val state = AddExpenseUiState(currentStep = AddExpenseStep.CONTRIBUTION_SCOPE)
             assertFalse(state.isOnOptionalStep)
         }
     }


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1001 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
