### PR TITLE
[SPLTRP-1035]: [Feature] Add Expense — smart split pre-fill from personal cash pool selection + warn when sharing with others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ YELLOW := \033[1;33m
 CYAN   := \033[0;36m
 NC     := \033[0m
 
-.PHONY: help setup hooks local-props doctor check test konsist coverage build clean
+.PHONY: help setup hooks local-props doctor check ktlint test konsist coverage build clean
 
 # ─── Default: show help ───────────────────────────────────────────────────────
 help: ## Show this help message
@@ -119,11 +119,17 @@ doctor: ## Check that required files and tools are present
 	@echo ""
 
 # ─── Quality gates (mirrors CI) ───────────────────────────────────────────────
-check: konsist test coverage build ## Run all local quality gates before pushing (mirrors CI)
+check: ktlint konsist test coverage build ## Run all local quality gates before pushing (mirrors CI)
 
 test: ## Run all unit tests (no coverage report)
 	@printf "$(YELLOW)⏳  Running unit tests...$(NC)\n"
 	@$(GRADLEW) test --continue
+
+ktlint: ## Run ktlint format + check (auto-fixes what it can, fails on unfixable issues)
+	@printf "$(YELLOW)⏳  Running ktlint format...$(NC)\n"
+	@$(GRADLEW) ktlintFormat --continue || true
+	@printf "$(YELLOW)⏳  Running ktlint check...$(NC)\n"
+	@$(GRADLEW) ktlintCheck
 
 konsist: ## Run Konsist architecture tests (file-size limit, naming, dependency rules)
 	@printf "$(YELLOW)⏳  Running Konsist architecture tests...$(NC)\n"

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetAvailableWithdrawalPoolsUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetAvailableWithdrawalPoolsUseCase.kt
@@ -7,9 +7,10 @@ import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
 /**
  * Determines which withdrawal pools have available funds for a given cash expense configuration.
  *
- * For GROUP-scoped expenses, probes both the GROUP pool and the current user's personal
- * (USER-scoped) pool when a [payerId] (userId) is provided. This allows the pool-selection
- * widget to surface personal cash as a supplement when the GROUP pool alone is insufficient.
+ * For GROUP-scoped expenses, probes the GROUP pool, the current user's personal (USER-scoped)
+ * pool when a [payerId] (userId) is provided, and any SUBUNIT pools for [subunitIds] the user
+ * belongs to. This allows the pool-selection widget to surface personal and subunit cash as
+ * supplements when the GROUP pool alone is insufficient.
  *
  * For USER and SUBUNIT scopes, probes the personal/subunit pool AND the GROUP pool independently
  * using [CashWithdrawalRepository.getAvailableWithdrawalsByExactScope] (no fallback).
@@ -33,8 +34,12 @@ class GetAvailableWithdrawalPoolsUseCase(
      * @param payerId       For USER scope: the userId. For SUBUNIT scope: the subunitId.
      *                      For GROUP scope: the current userId, used to probe the user's
      *                      personal (USER-scoped) pool as a supplement to the GROUP pool.
+     * @param subunitIds    For GROUP scope: IDs of subunits the current user belongs to.
+     *                      Each subunit's pool is probed independently and surfaced as a
+     *                      selectable option when funds are available. Ignored for USER/SUBUNIT scope.
      * @return A list of [WithdrawalPoolOption] values with available cash, in priority order.
-     *         For GROUP: GROUP pool first (primary), USER pool second (supplement).
+     *         For GROUP: GROUP pool first (primary), USER pool second (supplement),
+     *         then SUBUNIT pools in the order provided by [subunitIds].
      *         For USER/SUBUNIT: personal/subunit pool first, GROUP pool second.
      *         Empty when no pool has funds.
      */
@@ -42,11 +47,13 @@ class GetAvailableWithdrawalPoolsUseCase(
         groupId: String,
         currency: String,
         payerType: PayerType,
-        payerId: String? = null
+        payerId: String? = null,
+        subunitIds: List<String> = emptyList()
     ): List<WithdrawalPoolOption> {
         // GROUP expenses: probe GROUP pool first (primary source), then the user's personal
-        // (USER-scoped) pool when a userId is provided. This enables the pool-selection widget
-        // to surface personal cash as a supplement when the GROUP pool is insufficient.
+        // (USER-scoped) pool when a userId is provided, and any SUBUNIT pools the user
+        // belongs to. This enables the pool-selection widget to surface all available
+        // cash sources so the user can pick which pool to draw from.
         if (payerType == PayerType.GROUP) {
             val groupPool = cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
                 groupId = groupId,
@@ -63,9 +70,19 @@ class GetAvailableWithdrawalPoolsUseCase(
             } else {
                 emptyList()
             }
+            val subunitPools = subunitIds.mapNotNull { subunitId ->
+                val pool = cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId = groupId,
+                    currency = currency,
+                    scope = PayerType.SUBUNIT,
+                    scopeOwnerId = subunitId
+                )
+                if (pool.isNotEmpty()) WithdrawalPoolOption(PayerType.SUBUNIT, subunitId) else null
+            }
             return buildList {
                 if (groupPool.isNotEmpty()) add(WithdrawalPoolOption(PayerType.GROUP))
                 if (userPool.isNotEmpty()) add(WithdrawalPoolOption(PayerType.USER, payerId))
+                addAll(subunitPools)
             }
         }
 

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetAvailableWithdrawalPoolsUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetAvailableWithdrawalPoolsUseCaseTest.kt
@@ -226,6 +226,122 @@ class GetAvailableWithdrawalPoolsUseCaseTest {
                 )
             }
         }
+
+        @Test
+        fun `GROUP scope probes each provided subunit pool`() = runTest {
+            val subunitId2 = "subunit-456"
+            useCase(groupId, currency, PayerType.GROUP, userId, subunitIds = listOf(subunitId, subunitId2))
+
+            coVerify(exactly = 1) {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.SUBUNIT,
+                    subunitId
+                )
+            }
+            coVerify(exactly = 1) {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.SUBUNIT,
+                    subunitId2
+                )
+            }
+        }
+
+        @Test
+        fun `GROUP scope includes SUBUNIT pool when subunit has funds`() = runTest {
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.GROUP,
+                    null
+                )
+            } returns listOf(sampleWithdrawal)
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.SUBUNIT,
+                    subunitId
+                )
+            } returns listOf(sampleWithdrawal)
+
+            val result = useCase(groupId, currency, PayerType.GROUP, userId, subunitIds = listOf(subunitId))
+
+            assertEquals(2, result.size)
+            assertEquals(WithdrawalPoolOption(PayerType.GROUP), result[0])
+            assertEquals(WithdrawalPoolOption(PayerType.SUBUNIT, subunitId), result[1])
+        }
+
+        @Test
+        fun `GROUP scope returns only SUBUNIT when GROUP and USER pools are empty but subunit has funds`() = runTest {
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.SUBUNIT,
+                    subunitId
+                )
+            } returns listOf(sampleWithdrawal)
+
+            val result = useCase(groupId, currency, PayerType.GROUP, userId, subunitIds = listOf(subunitId))
+
+            assertEquals(1, result.size)
+            assertEquals(WithdrawalPoolOption(PayerType.SUBUNIT, subunitId), result.first())
+        }
+
+        @Test
+        fun `GROUP scope with all three pools returns GROUP then USER then SUBUNIT in order`() = runTest {
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.GROUP,
+                    null
+                )
+            } returns listOf(sampleWithdrawal)
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.USER,
+                    userId
+                )
+            } returns listOf(sampleWithdrawal)
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    groupId,
+                    currency,
+                    PayerType.SUBUNIT,
+                    subunitId
+                )
+            } returns listOf(sampleWithdrawal)
+
+            val result = useCase(groupId, currency, PayerType.GROUP, userId, subunitIds = listOf(subunitId))
+
+            assertEquals(3, result.size)
+            assertEquals(PayerType.GROUP, result[0].scope)
+            assertEquals(PayerType.USER, result[1].scope)
+            assertEquals(PayerType.SUBUNIT, result[2].scope)
+            assertEquals(subunitId, result[2].ownerId)
+        }
+
+        @Test
+        fun `GROUP scope with empty subunitIds does not probe any SUBUNIT pool`() = runTest {
+            useCase(groupId, currency, PayerType.GROUP, userId, subunitIds = emptyList())
+
+            coVerify(exactly = 0) {
+                cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                    any(),
+                    any(),
+                    PayerType.SUBUNIT,
+                    any()
+                )
+            }
+        }
     }
 
     // ── USER scope ────────────────────────────────────────────────────────────

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/SplitStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/SplitStep.kt
@@ -1,7 +1,11 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.component.step.expense
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.form.FormErrorBanner
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard.WizardStepLayout
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.SplitSection
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.event.AddExpenseUiEvent
@@ -18,6 +22,12 @@ fun SplitStep(
     modifier: Modifier = Modifier
 ) {
     WizardStepLayout(modifier = modifier) {
+        // Non-blocking contextual warning: the selected cash pool is personal (USER/SUBUNIT-scoped)
+        // but the split currently includes members outside its natural scope.
+        uiState.personalCashSplitWarning?.let { warningText ->
+            FormErrorBanner(error = warningText)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
         SplitSection(uiState = uiState, onEvent = onEvent)
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
@@ -90,6 +90,21 @@ class AddExpenseViewModel(
                     currencyEventHandler.handleFundingSourceChanged(action.isGroupPocket)
             }
         }
+
+        // Wire pool-resolved callback: auto-selection path triggers split smart-default.
+        // Explicit user selection is handled directly in the WithdrawalPoolSelected branch of onEvent.
+        currencyEventHandler.setOnPoolResolvedCallback { poolScope, poolOwnerId ->
+            splitEventHandler.applyPersonalPoolSplitDefault(
+                poolScope = poolScope,
+                poolOwnerId = poolOwnerId,
+                currentUserId = _uiState.value.currentUserId
+            )
+            if (poolScope == PayerType.SUBUNIT) {
+                subunitSplitEventHandler.applySubunitPoolDefault(poolOwnerId)
+            } else {
+                subunitSplitEventHandler.disableSubunitMode()
+            }
+        }
     }
 
     // Thin router — every branch is a single delegation;
@@ -120,11 +135,19 @@ class AddExpenseViewModel(
             is AddExpenseUiEvent.GroupAmountChanged ->
                 currencyEventHandler.handleGroupAmountChanged(event.amount)
 
-            is AddExpenseUiEvent.WithdrawalPoolSelected ->
-                // Pool-aware split pre-fill (applyPersonalPoolSplitDefault) is intentionally
-                // NOT wired here — that feature is scoped to #1035 and requires additional
-                // UX (warning banner, auto-selection path) not yet implemented.
+            is AddExpenseUiEvent.WithdrawalPoolSelected -> {
                 currencyEventHandler.handleWithdrawalPoolSelected(event.scope, event.scopeOwnerId)
+                splitEventHandler.applyPersonalPoolSplitDefault(
+                    poolScope = event.scope,
+                    poolOwnerId = event.scopeOwnerId,
+                    currentUserId = _uiState.value.currentUserId
+                )
+                if (event.scope == PayerType.SUBUNIT) {
+                    subunitSplitEventHandler.applySubunitPoolDefault(event.scopeOwnerId)
+                } else {
+                    subunitSplitEventHandler.disableSubunitMode()
+                }
+            }
 
             // ── Splits ──────────────────────────────────────────────────
             is AddExpenseUiEvent.SplitTypeChanged -> {
@@ -145,14 +168,20 @@ class AddExpenseViewModel(
                 splitEventHandler.handleShareLockToggled(event.userId)
 
             // ── Subunit splits ────────────────────────────────────────────
-            is AddExpenseUiEvent.SubunitModeToggled ->
+            is AddExpenseUiEvent.SubunitModeToggled -> {
                 subunitSplitEventHandler.handleSubunitModeToggled()
+                // Mode switch changes which splits are visible → recheck warning.
+                splitEventHandler.recomputePersonalCashWarning()
+            }
 
             is AddExpenseUiEvent.EntityAccordionToggled ->
                 subunitSplitEventHandler.handleAccordionToggled(event.entityId)
 
-            is AddExpenseUiEvent.EntitySplitExcludedToggled ->
+            is AddExpenseUiEvent.EntitySplitExcludedToggled -> {
                 subunitSplitEventHandler.handleEntityExcludedToggled(event.entityId)
+                // Entity inclusion change may bring out-of-scope entities into the split.
+                splitEventHandler.recomputePersonalCashWarning()
+            }
 
             is AddExpenseUiEvent.EntitySplitAmountChanged ->
                 subunitSplitEventHandler.handleEntityAmountChanged(event.entityId, event.amount)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CashRateDelegate.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CashRateDelegate.kt
@@ -105,9 +105,12 @@ class CashRateDelegate(
         } catch (_: IllegalArgumentException) {
             PayerType.GROUP
         }
+        // Mirrors CurrencyEventHandler.currentPayerId():
+        // - USER/GROUP: pass currentUserId so the use case can probe personal supplements.
+        // - SUBUNIT: pass selectedContributionSubunitId so the use case can resolve the subunit pool.
         val payerId = when (payerType) {
-            PayerType.USER -> state.currentUserId
-            PayerType.GROUP, PayerType.SUBUNIT -> null
+            PayerType.USER, PayerType.GROUP -> state.currentUserId
+            PayerType.SUBUNIT -> state.selectedContributionSubunitId
         }
 
         val selectedPool = state.selectedWithdrawalPool

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
@@ -44,6 +44,13 @@ class CurrencyEventHandler(
     private lateinit var _actions: MutableSharedFlow<AddExpenseUiAction>
     private lateinit var scope: CoroutineScope
 
+    /**
+     * Fired after any automatic pool resolution (auto-select single pool, pre-select first of many).
+     * Set by the ViewModel during initialization via [setOnPoolResolvedCallback].
+     * Explicit user selections are handled directly in the ViewModel's [onEvent] router.
+     */
+    private var poolResolvedCallback: ((PayerType, String?) -> Unit)? = null
+
     override fun bind(
         stateFlow: MutableStateFlow<AddExpenseUiState>,
         actionsFlow: MutableSharedFlow<AddExpenseUiAction>,
@@ -371,6 +378,15 @@ class CurrencyEventHandler(
         }
     }
 
+    /**
+     * Registers a callback that fires after any automatic pool resolution (auto-select single pool
+     * or pre-select first of many). The ViewModel wires this to call
+     * [SplitEventHandler.applyPersonalPoolSplitDefault] with the resolved pool's scope and ownerId.
+     */
+    fun setOnPoolResolvedCallback(callback: (PayerType, String?) -> Unit) {
+        poolResolvedCallback = callback
+    }
+
     /** Thin wrapper — delegates to [CashRateDelegate.fetchCashRate]. */
     fun fetchCashRate() = cashRateDelegate.fetchCashRate()
 
@@ -401,7 +417,16 @@ class CurrencyEventHandler(
             payerId = payerId,
             scope = scope,
             stateFlow = _uiState,
-            onPoolResolved = cashRateDelegate::fetchCashRate
+            onPoolResolved = {
+                cashRateDelegate.fetchCashRate()
+                // Notify the ViewModel so it can apply the smart split default if the resolved
+                // pool is USER- or SUBUNIT-scoped. Reading pool from state here is safe because
+                // WithdrawalPoolSelectionDelegate always updates selectedWithdrawalPool first.
+                val pool = _uiState.value.selectedWithdrawalPool
+                if (pool != null) {
+                    poolResolvedCallback?.invoke(pool.scope, pool.ownerId)
+                }
+            }
         )
     }
 
@@ -436,11 +461,11 @@ class CurrencyEventHandler(
      *   [GetAvailableWithdrawalPoolsUseCase] so it can probe the user's personal (USER-scoped)
      *   pool as a supplement to the GROUP pool.
      * - **USER:** the current user's ID ([AddExpenseUiState.currentUserId]).
-     * - **SUBUNIT:** not yet available from state (returns null; SUBUNIT pool support
-     *   is tracked in the companion issue for SUBUNIT funding-source selection).
+     * - **SUBUNIT:** the selected contribution subunit ID ([AddExpenseUiState.selectedContributionSubunitId])
+     *   so the use case can look up cash pools owned by that specific subunit.
      */
     internal fun currentPayerId(): String? = when (currentPayerType()) {
         PayerType.USER, PayerType.GROUP -> _uiState.value.currentUserId
-        PayerType.SUBUNIT -> null
+        PayerType.SUBUNIT -> _uiState.value.selectedContributionSubunitId
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SplitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SplitEventHandler.kt
@@ -1,11 +1,13 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler
 
 import es.pedrazamiguez.splittrip.core.common.constant.AppConstants
+import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
+import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import java.math.BigDecimal
@@ -194,9 +196,9 @@ class SplitEventHandler(
      * - USER pool  → exclude everyone except the pool owner (identified by [poolOwnerId],
      *   falling back to [currentUserId] when ownerId is null).
      * - SUBUNIT pool → exclude all members whose [SplitUiModel.subunitId] ≠ [poolOwnerId].
-     * - GROUP pool or null → no-op on splits; only resets [AddExpenseUiState.isPersonalCashSplitWarning].
+     * - GROUP pool or null → no-op on splits; only resets [AddExpenseUiState.personalCashSplitWarning].
      *
-     * Also resets [AddExpenseUiState.isPersonalCashSplitWarning] to false immediately after
+     * Also resets [AddExpenseUiState.personalCashSplitWarning] to null immediately after
      * pre-fill, because the freshly applied exclusions are always pool-scope–compatible.
      */
     fun applyPersonalPoolSplitDefault(
@@ -214,7 +216,7 @@ class SplitEventHandler(
                         split.copy(isExcluded = split.userId != ownerId, isShareLocked = false)
                     }
                 }.toImmutableList()
-                _uiState.update { it.copy(splits = updatedSplits, isPersonalCashSplitWarning = false) }
+                _uiState.update { it.copy(splits = updatedSplits, personalCashSplitWarning = null) }
                 recalculateSplits()
             }
 
@@ -226,40 +228,85 @@ class SplitEventHandler(
                         split.copy(isExcluded = split.subunitId != poolOwnerId, isShareLocked = false)
                     }
                 }.toImmutableList()
-                _uiState.update { it.copy(splits = updatedSplits, isPersonalCashSplitWarning = false) }
+                _uiState.update { it.copy(splits = updatedSplits, personalCashSplitWarning = null) }
                 recalculateSplits()
             }
 
             PayerType.GROUP -> {
-                // GROUP pool is the shared default — don't change splits, just clear any warning.
-                _uiState.update { it.copy(isPersonalCashSplitWarning = false) }
+                // GROUP pool funds a shared expense — every member should participate.
+                // Clearing exclusions here handles the case where the user first selected a
+                // USER/SUBUNIT pool (which excluded non-pool members) and then switched back
+                // to GROUP cash; without the reset those exclusions would silently persist.
+                val updatedSplits = _uiState.value.splits.map { split ->
+                    if (split.isEntityRow) {
+                        split
+                    } else {
+                        split.copy(isExcluded = false, isShareLocked = false)
+                    }
+                }.toImmutableList()
+                _uiState.update { it.copy(splits = updatedSplits, personalCashSplitWarning = null) }
+                recalculateSplits()
             }
         }
     }
 
     /**
-     * Recomputes [AddExpenseUiState.isPersonalCashSplitWarning].
+     * Recomputes [AddExpenseUiState.personalCashSplitWarning].
      *
-     * True when a USER- or SUBUNIT-scoped pool is selected AND at least one included member
-     * falls outside the pool's natural scope (i.e., the user is spending personal cash for
-     * someone else). Entity/header rows are excluded from the check.
+     * Non-null when a USER- or SUBUNIT-scoped pool is selected AND at least one included member
+     * (flat mode) or entity (subunit mode) falls outside the pool's natural scope —
+     * i.e., the user is spending personal/subunit cash for someone else.
+     *
+     * - **USER pool / flat mode:** any included `split` whose `userId` ≠ pool owner.
+     * - **SUBUNIT pool / flat mode:** any included `split` whose `subunitId` ≠ pool subunit.
+     * - **SUBUNIT pool / subunit mode:** any included *entity* whose `userId` ≠ pool subunit ID.
+     * - **GROUP pool or no pool:** never warn.
+     *
+     * `internal` so [AddExpenseViewModel] can call it after entity-level exclusion toggles
+     * (which are handled by [SubunitSplitEventHandler], not this handler).
      */
-    private fun recomputePersonalCashWarning() {
+    internal fun recomputePersonalCashWarning() {
         val state = _uiState.value
         val pool = state.selectedWithdrawalPool
-        val warning = when (pool?.scope) {
-            PayerType.USER -> state.splits.any { split ->
-                !split.isExcluded && !split.isEntityRow && split.userId != pool.ownerId
+        val warning: UiText? = when (pool?.scope) {
+            PayerType.USER -> {
+                val hasOutsideMembers = state.splits.any { split ->
+                    !split.isExcluded && !split.isEntityRow && split.userId != pool.ownerId
+                }
+                if (hasOutsideMembers) {
+                    UiText.StringResource(R.string.add_expense_personal_cash_split_warning)
+                } else {
+                    null
+                }
             }
 
-            PayerType.SUBUNIT -> state.splits.any { split ->
-                !split.isExcluded && !split.isEntityRow && split.subunitId != pool.ownerId
+            PayerType.SUBUNIT -> {
+                val hasOutsideEntities = if (state.isSubunitMode) {
+                    // In subunit mode the user sees entity rows. Warn if any entity outside the
+                    // pool's subunit is included (regardless of whether it's a subunit or solo user).
+                    state.entitySplits.any { entity ->
+                        !entity.isExcluded && entity.userId != pool.ownerId
+                    }
+                } else {
+                    // Flat mode: check per-member subunit membership.
+                    state.splits.any { split ->
+                        !split.isExcluded && !split.isEntityRow && split.subunitId != pool.ownerId
+                    }
+                }
+                if (hasOutsideEntities) {
+                    UiText.StringResource(
+                        R.string.add_expense_subunit_cash_split_warning,
+                        pool.displayLabel
+                    )
+                } else {
+                    null
+                }
             }
 
             // GROUP pool or no pool — never warn.
-            else -> false
+            else -> null
         }
-        _uiState.update { it.copy(isPersonalCashSplitWarning = warning) }
+        _uiState.update { it.copy(personalCashSplitWarning = warning) }
     }
 
     // ── Private helpers ──────────────────────────────────────────────────

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SplitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SplitEventHandler.kt
@@ -196,9 +196,12 @@ class SplitEventHandler(
      * - USER pool  → exclude everyone except the pool owner (identified by [poolOwnerId],
      *   falling back to [currentUserId] when ownerId is null).
      * - SUBUNIT pool → exclude all members whose [SplitUiModel.subunitId] ≠ [poolOwnerId].
-     * - GROUP pool or null → no-op on splits; only resets [AddExpenseUiState.personalCashSplitWarning].
+     * - GROUP pool → clears all member exclusions and share locks so every member participates
+     *   in the shared group expense, then recalculates splits. This handles the case where the
+     *   user previously selected a USER/SUBUNIT pool (which excluded non-pool members) and then
+     *   switched back to GROUP cash — without the reset those exclusions would silently persist.
      *
-     * Also resets [AddExpenseUiState.personalCashSplitWarning] to null immediately after
+     * In all cases, resets [AddExpenseUiState.personalCashSplitWarning] to null immediately after
      * pre-fill, because the freshly applied exclusions are always pool-scope–compatible.
      */
     fun applyPersonalPoolSplitDefault(

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubunitSplitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubunitSplitEventHandler.kt
@@ -141,6 +141,48 @@ class SubunitSplitEventHandler(
 
     // ── Mode Toggle ─────────────────────────────────────────────────────
 
+    /**
+     * Disables subunit mode (idempotent). Called when the user selects a USER- or GROUP-scoped
+     * withdrawal pool so the split step reverts to flat mode, consistent with the pool scope.
+     *
+     * Entity exclusions are intentionally left untouched — if the user manually re-enables
+     * subunit mode later they can adjust from a clean slate via [handleSubunitModeToggled].
+     */
+    fun disableSubunitMode() {
+        if (!_uiState.value.isSubunitMode) return
+        _uiState.update { it.copy(isSubunitMode = false, splitError = null) }
+    }
+
+    /**
+     * Applies a smart default when a SUBUNIT-scoped cash pool is selected:
+     * - Enables subunit mode so the Split step shows entity-level rows.
+     * - Excludes all entity rows except the one whose [SplitUiModel.userId] matches [poolSubunitId].
+     * - Clears all share locks so redistribution starts fresh.
+     * - Recalculates entity splits to reflect the single-subunit active set.
+     *
+     * No-op when [poolSubunitId] is null or the group has no entity splits (subunit-less groups
+     * where [SubunitSplitEventHandler.initEntitySplits] was never called).
+     */
+    fun applySubunitPoolDefault(poolSubunitId: String?) {
+        if (poolSubunitId == null || _uiState.value.entitySplits.isEmpty()) return
+
+        val updatedSplits = _uiState.value.entitySplits.map { entity ->
+            entity.copy(
+                isExcluded = entity.userId != poolSubunitId,
+                isShareLocked = false
+            )
+        }.toImmutableList()
+
+        _uiState.update {
+            it.copy(
+                isSubunitMode = true,
+                entitySplits = updatedSplits,
+                splitError = null
+            )
+        }
+        recalculateEntitySplits()
+    }
+
     fun handleSubunitModeToggled() {
         val newMode = !_uiState.value.isSubunitMode
         _uiState.update { it.copy(isSubunitMode = newMode, splitError = null) }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubunitSplitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubunitSplitEventHandler.kt
@@ -145,8 +145,8 @@ class SubunitSplitEventHandler(
      * Disables subunit mode (idempotent). Called when the user selects a USER- or GROUP-scoped
      * withdrawal pool so the split step reverts to flat mode, consistent with the pool scope.
      *
-     * Entity exclusions are intentionally left untouched — if the user manually re-enables
-     * subunit mode later they can adjust from a clean slate via [handleSubunitModeToggled].
+     * Entity exclusions are intentionally preserved — if the user manually re-enables subunit
+     * mode later via [handleSubunitModeToggled], their prior exclusion choices remain in effect.
      */
     fun disableSubunitMode() {
         if (!_uiState.value.isSubunitMode) return

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/WithdrawalPoolSelectionDelegate.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/WithdrawalPoolSelectionDelegate.kt
@@ -59,8 +59,9 @@ class WithdrawalPoolSelectionDelegate(
         stateFlow: MutableStateFlow<AddExpenseUiState>,
         onPoolResolved: () -> Unit
     ) {
-        val subunitNameLookup = stateFlow.value.contributionSubunitOptions
-            .associate { it.id to it.name }
+        val subunitOptions = stateFlow.value.contributionSubunitOptions
+        val subunitNameLookup = subunitOptions.associate { it.id to it.name }
+        val subunitIds = subunitOptions.map { it.id }
 
         scope.launch {
             try {
@@ -68,7 +69,8 @@ class WithdrawalPoolSelectionDelegate(
                     groupId = groupId,
                     currency = currency,
                     payerType = payerType,
-                    payerId = payerId
+                    payerId = payerId,
+                    subunitIds = subunitIds
                 )
 
                 val uiPools = addExpenseOptionsMapper.mapWithdrawalPoolOptions(

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -106,10 +106,11 @@ data class AddExpenseUiState(
      */
     val selectedWithdrawalPool: WithdrawalPoolOptionUiModel? = null,
     /**
-     * True when a personal (USER/SUBUNIT) cash pool is selected and the current split includes
-     * members outside that pool's natural scope.
+     * Non-null when a personal (USER/SUBUNIT) cash pool is selected and the current split includes
+     * members outside that pool's natural scope. Contains the warning message to display.
+     * Null when no warning should be shown.
      */
-    val isPersonalCashSplitWarning: Boolean = false,
+    val personalCashSplitWarning: UiText? = null,
     /**
      * True when the exchange rate was served from an expired local cache
      * (the remote API was unreachable). Drives a warning banner in the

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -250,4 +250,10 @@
     <string name="add_expense_cash_pool_group">Efectivo del grupo</string>
     <string name="add_expense_cash_pool_subunit">Efectivo de %1$s</string>
     <string name="add_expense_cash_pool_subunit_generic">Efectivo de subunidad</string>
+
+    <!-- Personal cash split warning — shown in Split step when a USER/SUBUNIT-scoped pool is
+         selected but the split includes members outside the pool's natural scope -->
+    <string name="add_expense_personal_cash_split_warning">Estás gastando de tu efectivo personal — asegúrate de que es tu intención compartir este gasto con otros.</string>
+    <!-- Subunit cash split warning — %1$s is the subunit pool display label (e.g. "Caris cash") -->
+    <string name="add_expense_subunit_cash_split_warning">Estás gastando de %1$s — asegúrate de que es tu intención compartir este gasto con otros.</string>
 </resources>

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -254,6 +254,6 @@
     <!-- Personal cash split warning — shown in Split step when a USER/SUBUNIT-scoped pool is
          selected but the split includes members outside the pool's natural scope -->
     <string name="add_expense_personal_cash_split_warning">Estás gastando de tu efectivo personal — asegúrate de que es tu intención compartir este gasto con otros.</string>
-    <!-- Subunit cash split warning — %1$s is the subunit pool display label (e.g. "Caris cash") -->
-    <string name="add_expense_subunit_cash_split_warning">Estás gastando de %1$s — asegúrate de que es tu intención compartir este gasto con otros.</string>
+    <!-- Subunit cash split warning — %1$s is the subunit pool display label (e.g. "Efectivo de Caris") -->
+    <string name="add_expense_subunit_cash_split_warning">Estás usando %1$s — asegúrate de que es tu intención compartir este gasto con otros.</string>
 </resources>

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -249,4 +249,10 @@
     <string name="add_expense_cash_pool_group">Group cash</string>
     <string name="add_expense_cash_pool_subunit">%1$s cash</string>
     <string name="add_expense_cash_pool_subunit_generic">Subunit cash</string>
+
+    <!-- Personal cash split warning — shown in Split step when a USER/SUBUNIT-scoped pool is
+         selected but the split includes members outside the pool's natural scope -->
+    <string name="add_expense_personal_cash_split_warning">You\'re spending from your personal cash — make sure it\'s intentional to share this with others.</string>
+    <!-- Subunit cash split warning — %1$s is the subunit pool display label (e.g. "Caris cash") -->
+    <string name="add_expense_subunit_cash_split_warning">You\'re spending from %1$s — make sure it\'s intentional to share this with others.</string>
 </resources>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SplitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SplitEventHandlerTest.kt
@@ -1,13 +1,16 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler
 
+import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitTypeUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.WithdrawalPoolOptionUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import io.mockk.every
@@ -19,6 +22,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -133,7 +137,7 @@ class SplitEventHandlerTest {
         @Test
         fun `clears split error when changing type`() = runTest {
             uiState.value = baseState.copy(
-                splitError = es.pedrazamiguez.splittrip.core.common.presentation.UiText.DynamicString("error")
+                splitError = UiText.DynamicString("error")
             )
             handler.bind(uiState, actions, this)
 
@@ -530,6 +534,395 @@ class SplitEventHandlerTest {
             val user1 = uiState.value.splits.first { it.userId == "user-1" }
             assertEquals("50.00", user1.percentageInput)
             assertEquals(5000L, user1.amountCents)
+        }
+    }
+
+    // ── applyPersonalPoolSplitDefault ────────────────────────────────────
+
+    @Nested
+    inner class ApplyPersonalPoolSplitDefault {
+
+        private fun makeSplitWithSubunit(
+            userId: String,
+            subunitId: String? = null,
+            isExcluded: Boolean = false,
+            isEntityRow: Boolean = false
+        ) = SplitUiModel(
+            userId = userId,
+            displayName = userId,
+            subunitId = subunitId,
+            isExcluded = isExcluded,
+            isEntityRow = isEntityRow
+        )
+
+        @Test
+        fun `USER pool excludes all members except the pool owner (poolOwnerId)`() = runTest {
+            uiState.value = baseState.copy(
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1"),
+                    makeSplitWithSubunit("user-2"),
+                    makeSplitWithSubunit("user-3")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.USER,
+                poolOwnerId = "user-1",
+                currentUserId = "user-1"
+            )
+
+            val splits = uiState.value.splits
+            assertFalse(splits.first { it.userId == "user-1" }.isExcluded)
+            assertTrue(splits.first { it.userId == "user-2" }.isExcluded)
+            assertTrue(splits.first { it.userId == "user-3" }.isExcluded)
+        }
+
+        @Test
+        fun `USER pool pre-fill resets personalCashSplitWarning to null`() = runTest {
+            uiState.value = baseState.copy(
+                personalCashSplitWarning = UiText.DynamicString("active"),
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1"),
+                    makeSplitWithSubunit("user-2"),
+                    makeSplitWithSubunit("user-3")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.USER,
+                poolOwnerId = "user-1",
+                currentUserId = "user-1"
+            )
+
+            // After pre-fill the split matches the pool scope — warning must be null
+            assertNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `USER pool falls back to currentUserId when poolOwnerId is null`() = runTest {
+            uiState.value = baseState.copy(
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1"),
+                    makeSplitWithSubunit("user-2"),
+                    makeSplitWithSubunit("user-3")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.USER,
+                poolOwnerId = null,
+                currentUserId = "user-2"
+            )
+
+            val splits = uiState.value.splits
+            assertTrue(splits.first { it.userId == "user-1" }.isExcluded)
+            assertFalse(splits.first { it.userId == "user-2" }.isExcluded)
+            assertTrue(splits.first { it.userId == "user-3" }.isExcluded)
+        }
+
+        @Test
+        fun `SUBUNIT pool excludes all members whose subunitId differs from poolOwnerId`() = runTest {
+            uiState.value = baseState.copy(
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1", subunitId = "subunit-A"),
+                    makeSplitWithSubunit("user-2", subunitId = "subunit-A"),
+                    makeSplitWithSubunit("user-3", subunitId = "subunit-B")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.SUBUNIT,
+                poolOwnerId = "subunit-A",
+                currentUserId = "user-1"
+            )
+
+            val splits = uiState.value.splits
+            assertFalse(splits.first { it.userId == "user-1" }.isExcluded)
+            assertFalse(splits.first { it.userId == "user-2" }.isExcluded)
+            assertTrue(splits.first { it.userId == "user-3" }.isExcluded)
+        }
+
+        @Test
+        fun `GROUP pool resets all exclusions so the whole group participates and clears any warning`() = runTest {
+            uiState.value = baseState.copy(
+                personalCashSplitWarning = UiText.DynamicString("active"),
+                splits = persistentListOf(
+                    // user-1 was excluded by a prior USER pool pre-fill
+                    makeSplitWithSubunit("user-1", isExcluded = true),
+                    makeSplitWithSubunit("user-2"),
+                    makeSplitWithSubunit("user-3")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.GROUP,
+                poolOwnerId = null,
+                currentUserId = "user-1"
+            )
+
+            // GROUP = shared expense: every member must be included after pool switch
+            uiState.value.splits.forEach { split ->
+                assertFalse(split.isExcluded, "Expected ${split.userId} to be included for GROUP pool")
+            }
+            // Warning must have been cleared
+            assertNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `switching from USER pool to GROUP pool restores all members`() = runTest {
+            // After USER pool pre-fill: only user-1 included
+            uiState.value = baseState.copy(
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1", isExcluded = false),
+                    makeSplitWithSubunit("user-2", isExcluded = true),
+                    makeSplitWithSubunit("user-3", isExcluded = true)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.GROUP,
+                poolOwnerId = null,
+                currentUserId = "user-1"
+            )
+
+            uiState.value.splits.forEach { split ->
+                assertFalse(split.isExcluded, "Expected ${split.userId} to be included after GROUP pool switch")
+            }
+        }
+
+        @Test
+        fun `GROUP pool pre-fill also clears share locks`() = runTest {
+            uiState.value = baseState.copy(
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1", isExcluded = false),
+                    makeSplitWithSubunit("user-2", isExcluded = true),
+                    makeSplitWithSubunit("user-3", isExcluded = true)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.GROUP,
+                poolOwnerId = null,
+                currentUserId = "user-1"
+            )
+
+            uiState.value.splits.forEach { split ->
+                assertFalse(split.isShareLocked, "Lock should be cleared for ${split.userId}")
+            }
+        }
+
+        @Test
+        fun `USER pool pre-fill skips entity rows`() = runTest {
+            uiState.value = baseState.copy(
+                splits = persistentListOf(
+                    makeSplitWithSubunit("subunit-A", isEntityRow = true),
+                    makeSplitWithSubunit("user-1"),
+                    makeSplitWithSubunit("user-2")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applyPersonalPoolSplitDefault(
+                poolScope = PayerType.USER,
+                poolOwnerId = "user-1",
+                currentUserId = "user-1"
+            )
+
+            // Entity row must not have been touched
+            assertFalse(uiState.value.splits.first { it.isEntityRow }.isExcluded)
+        }
+
+        @Test
+        fun `warning appears when USER pool is active and out-of-scope member is un-excluded`() = runTest {
+            val userPool = WithdrawalPoolOptionUiModel(
+                scope = PayerType.USER,
+                ownerId = "user-1",
+                displayLabel = "My cash"
+            )
+            // Pre-fill: only user-1 included
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = userPool,
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1", isExcluded = false),
+                    makeSplitWithSubunit("user-2", isExcluded = true),
+                    makeSplitWithSubunit("user-3", isExcluded = true)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            // user-2 is un-excluded → now outside the pool scope
+            handler.handleSplitExcludedToggled("user-2")
+
+            assertNotNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `warning disappears when out-of-scope member is re-excluded`() = runTest {
+            val userPool = WithdrawalPoolOptionUiModel(
+                scope = PayerType.USER,
+                ownerId = "user-1",
+                displayLabel = "My cash"
+            )
+            // user-2 is already included (out of scope) — warning is active
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = userPool,
+                personalCashSplitWarning = es.pedrazamiguez.splittrip.core.common.presentation.UiText.DynamicString(
+                    "active"
+                ),
+                splits = persistentListOf(
+                    makeSplitWithSubunit("user-1", isExcluded = false),
+                    makeSplitWithSubunit("user-2", isExcluded = false),
+                    makeSplitWithSubunit("user-3", isExcluded = true)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            // user-2 is re-excluded → split returns to pool-compatible state
+            handler.handleSplitExcludedToggled("user-2")
+
+            assertNull(uiState.value.personalCashSplitWarning)
+        }
+    }
+
+    @Nested
+    inner class RecomputePersonalCashWarningSubunitMode {
+
+        private val subunitPool = WithdrawalPoolOptionUiModel(
+            scope = PayerType.SUBUNIT,
+            ownerId = "subunit-caris",
+            displayLabel = "Caris cash"
+        )
+
+        private fun makeEntityRow(
+            userId: String,
+            isExcluded: Boolean = false
+        ) = SplitUiModel(
+            userId = userId,
+            displayName = userId,
+            isEntityRow = true,
+            isExcluded = isExcluded
+        )
+
+        private fun makeFlatSplitWithSubunit(
+            userId: String,
+            subunitId: String? = null,
+            isExcluded: Boolean = false
+        ) = SplitUiModel(
+            userId = userId,
+            displayName = userId,
+            subunitId = subunitId,
+            isExcluded = isExcluded
+        )
+
+        @Test
+        fun `no warning when only the pool subunit is included`() = runTest {
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = subunitPool,
+                isSubunitMode = true,
+                entitySplits = persistentListOf(
+                    makeEntityRow("subunit-caris", isExcluded = false),
+                    makeEntityRow("subunit-cunis", isExcluded = true),
+                    makeEntityRow("solo-user", isExcluded = true)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.recomputePersonalCashWarning()
+
+            assertNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `warning appears when out-of-pool entity is included in subunit mode`() = runTest {
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = subunitPool,
+                isSubunitMode = true,
+                entitySplits = persistentListOf(
+                    makeEntityRow("subunit-caris", isExcluded = false),
+                    makeEntityRow("subunit-cunis", isExcluded = false), // <-- out-of-pool, enabled
+                    makeEntityRow("solo-user", isExcluded = true)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.recomputePersonalCashWarning()
+
+            assertNotNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `warning appears when solo user entity is included in subunit mode`() = runTest {
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = subunitPool,
+                isSubunitMode = true,
+                entitySplits = persistentListOf(
+                    makeEntityRow("subunit-caris", isExcluded = false),
+                    makeEntityRow("subunit-cunis", isExcluded = true),
+                    makeEntityRow("solo-user", isExcluded = false) // <-- solo outside pool
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.recomputePersonalCashWarning()
+
+            assertNotNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `warning clears when out-of-pool entity is re-excluded in subunit mode`() = runTest {
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = subunitPool,
+                isSubunitMode = true,
+                personalCashSplitWarning = es.pedrazamiguez.splittrip.core.common.presentation.UiText.DynamicString(
+                    "active"
+                ),
+                entitySplits = persistentListOf(
+                    makeEntityRow("subunit-caris", isExcluded = false),
+                    makeEntityRow("subunit-cunis", isExcluded = false)
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            // Simulate manual entity toggle: re-exclude the out-of-pool entity first
+            uiState.value = uiState.value.copy(
+                entitySplits = persistentListOf(
+                    makeEntityRow("subunit-caris", isExcluded = false),
+                    makeEntityRow("subunit-cunis", isExcluded = true) // re-excluded
+                )
+            )
+            handler.recomputePersonalCashWarning()
+
+            assertNull(uiState.value.personalCashSplitWarning)
+        }
+
+        @Test
+        fun `no warning when in flat mode even if other entities would trigger subunit warning`() = runTest {
+            // Flat mode — entity splits are irrelevant; flat splits all belong to subunit-caris members
+            uiState.value = baseState.copy(
+                selectedWithdrawalPool = subunitPool,
+                isSubunitMode = false,
+                entitySplits = persistentListOf(
+                    makeEntityRow("subunit-caris", isExcluded = false),
+                    makeEntityRow("subunit-cunis", isExcluded = false) // would warn in subunit mode
+                ),
+                splits = persistentListOf(
+                    makeFlatSplitWithSubunit("user-1", subunitId = "subunit-caris"),
+                    makeFlatSplitWithSubunit("user-2", subunitId = "subunit-caris")
+                )
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.recomputePersonalCashWarning()
+
+            // entity splits are ignored in flat mode; flat splits are pool-compatible
+            assertNull(uiState.value.personalCashSplitWarning)
         }
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubunitSplitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubunitSplitEventHandlerTest.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler
 
+import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
@@ -832,6 +833,135 @@ class SubunitSplitEventHandlerTest {
             val member2 = subunit.entityMembers.first { it.userId == coupleMember2 }
             assertEquals(7000L, member1.amountCents)
             assertEquals(3000L, member2.amountCents)
+        }
+    }
+
+    @Nested
+    inner class DisableSubunitMode {
+
+        @Test
+        fun `disables subunit mode when active`() = runTest {
+            uiState.value = baseEntityState.copy(isSubunitMode = true)
+            handler.bind(uiState, actions, this)
+
+            handler.disableSubunitMode()
+
+            assertFalse(uiState.value.isSubunitMode)
+        }
+
+        @Test
+        fun `is no-op when subunit mode is already false`() = runTest {
+            uiState.value = baseEntityState.copy(isSubunitMode = false)
+            handler.bind(uiState, actions, this)
+
+            handler.disableSubunitMode()
+
+            assertFalse(uiState.value.isSubunitMode)
+        }
+
+        @Test
+        fun `clears split error when disabling`() = runTest {
+            uiState.value = baseEntityState.copy(
+                isSubunitMode = true,
+                splitError = UiText.DynamicString("Some error")
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.disableSubunitMode()
+
+            assertEquals(null, uiState.value.splitError)
+        }
+
+        @Test
+        fun `does not reset entity splits exclusions`() = runTest {
+            val excludedEntitySplits = baseEntityState.entitySplits.map { entity ->
+                entity.copy(isExcluded = entity.userId != subunitCoupleId)
+            }.toImmutableList()
+            uiState.value = baseEntityState.copy(
+                isSubunitMode = true,
+                entitySplits = excludedEntitySplits
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.disableSubunitMode()
+
+            // Entity exclusions from the prior SUBUNIT pool selection are preserved
+            assertTrue(uiState.value.entitySplits.first { it.userId == soloMember1 }.isExcluded)
+            assertTrue(uiState.value.entitySplits.first { it.userId == soloMember2 }.isExcluded)
+            assertFalse(uiState.value.entitySplits.first { it.userId == subunitCoupleId }.isExcluded)
+        }
+    }
+
+    @Nested
+    inner class ApplySubunitPoolDefault {
+
+        @Test
+        fun `enables subunit mode`() = runTest {
+            uiState.value = baseEntityState.copy(isSubunitMode = false)
+            handler.bind(uiState, actions, this)
+
+            handler.applySubunitPoolDefault(subunitCoupleId)
+
+            assertTrue(uiState.value.isSubunitMode)
+        }
+
+        @Test
+        fun `excludes all entities except the matching subunit`() = runTest {
+            uiState.value = baseEntityState
+            handler.bind(uiState, actions, this)
+
+            handler.applySubunitPoolDefault(subunitCoupleId)
+
+            val entitySplits = uiState.value.entitySplits
+            assertTrue(entitySplits.first { it.userId == subunitCoupleId }.isExcluded.not())
+            assertTrue(entitySplits.first { it.userId == soloMember1 }.isExcluded)
+            assertTrue(entitySplits.first { it.userId == soloMember2 }.isExcluded)
+        }
+
+        @Test
+        fun `clears all share locks`() = runTest {
+            uiState.value = baseEntityState.copy(
+                entitySplits = baseEntityState.entitySplits.map { it.copy(isShareLocked = true) }
+                    .toImmutableList()
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applySubunitPoolDefault(subunitCoupleId)
+
+            assertTrue(uiState.value.entitySplits.none { it.isShareLocked })
+        }
+
+        @Test
+        fun `clears split error`() = runTest {
+            uiState.value = baseEntityState.copy(splitError = UiText.DynamicString("Some error"))
+            handler.bind(uiState, actions, this)
+
+            handler.applySubunitPoolDefault(subunitCoupleId)
+
+            assertEquals(null, uiState.value.splitError)
+        }
+
+        @Test
+        fun `is no-op when poolSubunitId is null`() = runTest {
+            uiState.value = baseEntityState.copy(isSubunitMode = false)
+            handler.bind(uiState, actions, this)
+
+            handler.applySubunitPoolDefault(null)
+
+            assertFalse(uiState.value.isSubunitMode)
+        }
+
+        @Test
+        fun `is no-op when entitySplits is empty (subunit-less group)`() = runTest {
+            uiState.value = baseEntityState.copy(
+                isSubunitMode = false,
+                entitySplits = persistentListOf()
+            )
+            handler.bind(uiState, actions, this)
+
+            handler.applySubunitPoolDefault(subunitCoupleId)
+
+            assertFalse(uiState.value.isSubunitMode)
         }
     }
 }


### PR DESCRIPTION
Add SUBUNIT-aware withdrawal pool probing and UI/logic to surface personal/subunit cash as supplements and warn when splits include out-of-scope members.

Key changes:
- domain: GetAvailableWithdrawalPoolsUseCase now probes SUBUNIT pools (accepts subunitIds) and returns SUBUNIT options after GROUP/USER.
- ViewModel/handlers: CurrencyEventHandler, CashRateDelegate and WithdrawalPoolSelectionDelegate propagated subunit IDs and selectedContributionSubunitId so SUBUNIT pools can be resolved; CurrencyEventHandler exposes a poolResolved callback to let the ViewModel apply smart split defaults after automatic pool selection.
- AddExpenseViewModel: wires pool-resolved callback and applies smart defaults on explicit pool selection (USER/SUBUNIT/GROUP), toggles subunit mode accordingly.
- Split logic: SplitEventHandler.applyPersonalPoolSplitDefault and recomputePersonalCashWarning updated to use UiText? for warnings, clear/restore exclusions and locks appropriately, and compute localized warning messages for USER and SUBUNIT pools. SubunitSplitEventHandler gains disableSubunitMode and applySubunitPoolDefault to manage entity-mode defaults.
- UI: SplitStep shows a non-blocking FormErrorBanner for personal/subunit cash split warnings; new localized string resources (EN/ES) for warnings added.
- Tests: Extensive unit tests added/updated for use case, split handlers and subunit handler to cover SUBUNIT probing, ordering, smart defaults, warning recomputation, and mode toggles.

These changes enable selecting subunit-owned cash pools, auto-applying compatible split defaults, and surfacing warnings when personal/subunit cash would be used for out-of-scope members.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1035 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
