### PR TITLE
[SPLTRP-1034]: [Feature] Balance screen — add cash breakdown detail view (per-withdrawal, per-scope attribution)

### DIFF
--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
@@ -1,0 +1,180 @@
+package es.pedrazamiguez.splittrip.features.balance.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import es.pedrazamiguez.splittrip.features.balance.R
+import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashBreakdownUiModel
+import kotlinx.collections.immutable.ImmutableList
+
+/**
+ * Bottom sheet displaying a per-withdrawal cash attribution breakdown for a single member.
+ *
+ * Items are grouped by scope via section headers: GROUP-scoped withdrawals are shown first
+ * (with an "estimated share" disclaimer), followed by USER-scoped personal cash, and then
+ * SUBUNIT-scoped entries. The scope header re-renders whenever the [CashBreakdownUiModel.scopeLabel]
+ * changes from the previous item, producing implicit grouping without a nested data structure.
+ *
+ * This is intentionally separate from [MemberBalanceItem] to keep that file under the 600-line limit.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CashBreakdownBottomSheet(
+    breakdown: ImmutableList<CashBreakdownUiModel>,
+    formattedTotal: String,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(start = 20.dp, end = 20.dp, bottom = 32.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.balances_cash_breakdown_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            if (breakdown.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.balances_cash_breakdown_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                CashBreakdownItemList(breakdown = breakdown)
+
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                Spacer(Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.balances_cash_breakdown_total_label),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = formattedTotal,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CashBreakdownItemList(breakdown: ImmutableList<CashBreakdownUiModel>) {
+    var lastScopeLabel = ""
+    breakdown.forEach { item ->
+        // Render a section header whenever the scope group changes
+        if (item.scopeLabel != lastScopeLabel) {
+            if (lastScopeLabel.isNotEmpty()) Spacer(Modifier.height(16.dp))
+            Text(
+                text = item.scopeLabel,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+            if (item.isEstimatedShare) {
+                Text(
+                    text = stringResource(R.string.balances_cash_breakdown_estimated_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    modifier = Modifier.padding(bottom = 6.dp)
+                )
+            }
+            lastScopeLabel = item.scopeLabel
+        }
+        CashBreakdownEntryRow(item = item)
+    }
+}
+
+@Composable
+private fun CashBreakdownEntryRow(item: CashBreakdownUiModel) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        // Title row: withdrawal label · date · rate
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = item.withdrawalLabel,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (item.dateText.isNotBlank()) {
+                Text(
+                    text = "·  ${item.dateText}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (item.formattedRate.isNotBlank()) {
+                Text(
+                    text = "·  ${item.formattedRate}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        // Amount row: native remaining [≈ equivalent]
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+        ) {
+            Text(
+                text = item.formattedNativeRemaining,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (item.formattedEquivalent.isNotBlank()) {
+                Text(
+                    text = "≈  ${item.formattedEquivalent}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
@@ -44,13 +44,15 @@ fun CashBreakdownBottomSheet(
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        dragHandle = null,
+        containerColor = MaterialTheme.colorScheme.surface
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
-                .padding(start = 20.dp, end = 20.dp, bottom = 32.dp)
+                .padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 32.dp)
         ) {
             Text(
                 text = stringResource(R.string.balances_cash_breakdown_title),

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/MemberBalanceItem.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/MemberBalanceItem.kt
@@ -42,6 +42,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Cash
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.ChartBar
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.ChevronDown
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.ChevronUp
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.InfoCircle
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.User
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
 import es.pedrazamiguez.splittrip.features.balance.R
@@ -52,6 +53,7 @@ import kotlinx.collections.immutable.ImmutableList
 @Composable
 fun MemberBalanceItem(memberBalance: MemberBalanceUiModel, modifier: Modifier = Modifier) {
     var isExpanded by remember { mutableStateOf(false) }
+    var showCashBreakdown by remember { mutableStateOf(false) }
     val balanceColor = resolveBalanceColor(memberBalance.isPositiveBalance)
     val displayName = resolveDisplayName(memberBalance)
     val expandedStateDesc = resolveExpandedStateDesc(isExpanded)
@@ -75,8 +77,20 @@ fun MemberBalanceItem(memberBalance: MemberBalanceUiModel, modifier: Modifier = 
             enter = expandVertically() + fadeIn(),
             exit = shrinkVertically() + fadeOut()
         ) {
-            MemberBalanceExpandedDetail(memberBalance = memberBalance, balanceColor = balanceColor)
+            MemberBalanceExpandedDetail(
+                memberBalance = memberBalance,
+                balanceColor = balanceColor,
+                onShowCashBreakdown = { showCashBreakdown = true }
+            )
         }
+    }
+
+    if (showCashBreakdown) {
+        CashBreakdownBottomSheet(
+            breakdown = memberBalance.cashBreakdown,
+            formattedTotal = memberBalance.formattedCashInHand,
+            onDismiss = { showCashBreakdown = false }
+        )
     }
 }
 
@@ -182,7 +196,8 @@ private fun MemberBalanceSummaryRow(
 @Composable
 private fun MemberBalanceExpandedDetail(
     memberBalance: MemberBalanceUiModel,
-    balanceColor: Color
+    balanceColor: Color,
+    onShowCashBreakdown: () -> Unit
 ) {
     Column(modifier = Modifier.padding(top = 8.dp)) {
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
@@ -196,28 +211,54 @@ private fun MemberBalanceExpandedDetail(
         )
         Spacer(modifier = Modifier.height(8.dp))
 
-        DetailRow(
-            label = stringResource(R.string.balances_member_cash_in_hand),
-            value = memberBalance.formattedCashInHand,
-            icon = TablerIcons.Outline.Cash
+        // Cash-in-hand row with info button to open the cash breakdown sheet
+        CashInHandRow(
+            memberBalance = memberBalance,
+            onShowCashBreakdown = onShowCashBreakdown
         )
-        when {
-            memberBalance.hasNegativeCashInHand -> {
-                EmptyHintText(text = stringResource(R.string.balances_member_negative_cash_hint))
-            }
-            memberBalance.cashInHandByCurrency.isNotEmpty() -> {
-                CurrencyBreakdownRows(items = memberBalance.cashInHandByCurrency)
-            }
-            else -> {
-                EmptyHintText(text = stringResource(R.string.balances_member_no_cash))
-            }
-        }
 
         Spacer(modifier = Modifier.height(8.dp))
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
         Spacer(modifier = Modifier.height(8.dp))
 
         SpendingBreakdownSection(memberBalance = memberBalance)
+    }
+}
+
+@Composable
+private fun CashInHandRow(
+    memberBalance: MemberBalanceUiModel,
+    onShowCashBreakdown: () -> Unit
+) {
+    DetailRow(
+        label = stringResource(R.string.balances_member_cash_in_hand),
+        value = memberBalance.formattedCashInHand,
+        icon = TablerIcons.Outline.Cash,
+        labelSuffix = if (memberBalance.cashBreakdown.isNotEmpty()) {
+            {
+                Icon(
+                    imageVector = TablerIcons.Outline.InfoCircle,
+                    contentDescription = stringResource(R.string.balances_cash_breakdown_view_cd),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    modifier = Modifier
+                        .size(14.dp)
+                        .clickable(onClick = onShowCashBreakdown)
+                )
+            }
+        } else {
+            null
+        }
+    )
+    when {
+        memberBalance.hasNegativeCashInHand -> {
+            EmptyHintText(text = stringResource(R.string.balances_member_negative_cash_hint))
+        }
+        memberBalance.cashInHandByCurrency.isNotEmpty() -> {
+            CurrencyBreakdownRows(items = memberBalance.cashInHandByCurrency)
+        }
+        else -> {
+            EmptyHintText(text = stringResource(R.string.balances_member_no_cash))
+        }
     }
 }
 
@@ -268,7 +309,8 @@ private fun DetailRow(
     value: String,
     modifier: Modifier = Modifier,
     valueColor: Color = MaterialTheme.colorScheme.onSurface,
-    icon: ImageVector? = null
+    icon: ImageVector? = null,
+    labelSuffix: (@Composable () -> Unit)? = null
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -292,6 +334,8 @@ private fun DetailRow(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            // Optional composable placed inline after the label (e.g. an info icon)
+            labelSuffix?.invoke()
         }
         Text(
             text = value,

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/MemberBalanceItem.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/MemberBalanceItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -236,14 +237,17 @@ private fun CashInHandRow(
         icon = TablerIcons.Outline.Cash,
         labelSuffix = if (memberBalance.cashBreakdown.isNotEmpty()) {
             {
-                Icon(
-                    imageVector = TablerIcons.Outline.InfoCircle,
-                    contentDescription = stringResource(R.string.balances_cash_breakdown_view_cd),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                    modifier = Modifier
-                        .size(14.dp)
-                        .clickable(onClick = onShowCashBreakdown)
-                )
+                IconButton(
+                    onClick = onShowCashBreakdown,
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        imageVector = TablerIcons.Outline.InfoCircle,
+                        contentDescription = stringResource(R.string.balances_cash_breakdown_view_cd),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        modifier = Modifier.size(14.dp)
+                    )
+                }
             }
         } else {
             null

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
@@ -395,11 +395,13 @@ class BalancesUiMapper(
             withdrawalLabel = label,
             dateText = dateText,
             formattedRate = if (isForeign) {
+                // Swap order: native/group → reads as "X native-units per 1 group-unit"
+                // e.g. "@ 1.1813 USD/EUR" = "1.1813 USD per EUR" (everyday math, not Forex notation)
                 resourceProvider.getString(
                     R.string.balances_cash_breakdown_rate,
                     withdrawal.exchangeRate.formatForDisplay(locale, maxDecimalPlaces = 6),
-                    groupCurrency,
-                    withdrawal.currency
+                    withdrawal.currency,
+                    groupCurrency
                 )
             } else {
                 ""

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
@@ -364,46 +364,55 @@ class BalancesUiMapper(
                 if (withdrawal.amountWithdrawn == 0L || withdrawal.remainingAmount <= 0L) return@mapNotNull null
                 val nativeShare = computeUserNativeShare(withdrawal, userId, groupMemberIds, subunitsMap)
                 if (nativeShare <= 0L) return@mapNotNull null
-
-                val groupEquivalent = BigDecimal(nativeShare)
-                    .multiply(BigDecimal(withdrawal.deductedBaseAmount))
-                    .divide(BigDecimal(withdrawal.amountWithdrawn), 0, RoundingMode.HALF_UP)
-                    .toLong()
-
-                val isForeign = withdrawal.currency != groupCurrency
-                val dateText = withdrawal.createdAt?.formatShortDate(locale) ?: ""
-                val label = if (withdrawal.title.isNullOrBlank()) {
-                    resourceProvider.getString(R.string.balances_cash_breakdown_atm_fallback, dateText)
-                } else {
-                    withdrawal.title ?: ""
-                }
-                val scopeLabel = resolveCashBreakdownScopeLabel(withdrawal, subunitsMap)
-                val isGroup = withdrawal.withdrawalScope == PayerType.GROUP
-
-                CashBreakdownUiModel(
-                    withdrawalLabel = label,
-                    dateText = dateText,
-                    formattedRate = if (isForeign) {
-                        resourceProvider.getString(
-                            R.string.balances_cash_breakdown_rate,
-                            withdrawal.exchangeRate.formatForDisplay(locale, maxDecimalPlaces = 6),
-                            groupCurrency,
-                            withdrawal.currency
-                        )
-                    } else {
-                        ""
-                    },
-                    formattedNativeRemaining = formatCurrencyAmount(nativeShare, withdrawal.currency, locale),
-                    formattedEquivalent = if (isForeign) {
-                        formatCurrencyAmount(groupEquivalent, groupCurrency, locale)
-                    } else {
-                        ""
-                    },
-                    scopeLabel = scopeLabel,
-                    isEstimatedShare = isGroup
-                )
+                buildCashBreakdownEntry(withdrawal, nativeShare, groupCurrency, locale, subunitsMap)
             }
             .toImmutableList()
+    }
+
+    /**
+     * Builds a single [CashBreakdownUiModel] from an attributed native share.
+     * Extracted from [mapCashBreakdown] to keep cognitive complexity within detekt limits.
+     */
+    private fun buildCashBreakdownEntry(
+        withdrawal: CashWithdrawal,
+        nativeShare: Long,
+        groupCurrency: String,
+        locale: java.util.Locale,
+        subunitsMap: Map<String, Subunit>
+    ): CashBreakdownUiModel {
+        val groupEquivalent = BigDecimal(nativeShare)
+            .multiply(BigDecimal(withdrawal.deductedBaseAmount))
+            .divide(BigDecimal(withdrawal.amountWithdrawn), 0, RoundingMode.HALF_UP)
+            .toLong()
+        val isForeign = withdrawal.currency != groupCurrency
+        val dateText = withdrawal.createdAt?.formatShortDate(locale) ?: ""
+        val label = if (withdrawal.title.isNullOrBlank()) {
+            resourceProvider.getString(R.string.balances_cash_breakdown_atm_fallback, dateText)
+        } else {
+            withdrawal.title ?: ""
+        }
+        return CashBreakdownUiModel(
+            withdrawalLabel = label,
+            dateText = dateText,
+            formattedRate = if (isForeign) {
+                resourceProvider.getString(
+                    R.string.balances_cash_breakdown_rate,
+                    withdrawal.exchangeRate.formatForDisplay(locale, maxDecimalPlaces = 6),
+                    groupCurrency,
+                    withdrawal.currency
+                )
+            } else {
+                ""
+            },
+            formattedNativeRemaining = formatCurrencyAmount(nativeShare, withdrawal.currency, locale),
+            formattedEquivalent = if (isForeign) {
+                formatCurrencyAmount(groupEquivalent, groupCurrency, locale)
+            } else {
+                ""
+            },
+            scopeLabel = resolveCashBreakdownScopeLabel(withdrawal, subunitsMap),
+            isEstimatedShare = withdrawal.withdrawalScope == PayerType.GROUP
+        )
     }
 
     /** Resolves the user's attributed native share (in withdrawal currency cents) for display. */
@@ -437,7 +446,7 @@ class BalancesUiMapper(
         PayerType.GROUP -> resourceProvider.getString(R.string.balances_cash_breakdown_group_scope)
         PayerType.USER -> resourceProvider.getString(R.string.balances_cash_breakdown_personal_scope)
         PayerType.SUBUNIT -> withdrawal.subunitId?.let { subunitsMap[it]?.name }
-            ?: resourceProvider.getString(R.string.balances_cash_breakdown_personal_scope)
+            ?: resourceProvider.getString(R.string.balances_cash_breakdown_unknown_subunit)
     }
 
     /**

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.core.common.extensions.toEpochMillisUtc
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatCurrencyAmount
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatForDisplay
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatShortDate
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
@@ -16,11 +17,14 @@ import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.features.balance.R
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.ActivityItemUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashBalanceUiModel
+import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashBreakdownUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashWithdrawalUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.ContributionUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.CurrencyBreakdownUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.GroupPocketBalanceUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.MemberBalanceUiModel
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -253,13 +257,19 @@ class BalancesUiMapper(
      *
      * @param groupCurrency The group's base currency code, used to determine whether
      *                      to show equivalents for per-currency breakdowns.
+     * @param withdrawals Full withdrawal list for the group, used to build [MemberBalanceUiModel.cashBreakdown].
+     * @param subunitsMap Subunit lookup map, required for SUBUNIT-scoped withdrawal attribution.
+     * @param groupMemberIds Full member id list, required to compute equal GROUP-scope shares.
      */
     fun mapMemberBalances(
         balances: List<MemberBalance>,
         currency: String,
         currentUserId: String?,
         memberProfiles: Map<String, User> = emptyMap(),
-        groupCurrency: String = currency
+        groupCurrency: String = currency,
+        withdrawals: List<CashWithdrawal> = emptyList(),
+        subunitsMap: Map<String, Subunit> = emptyMap(),
+        groupMemberIds: List<String> = emptyList()
     ): ImmutableList<MemberBalanceUiModel> {
         val locale = localeProvider.getCurrentLocale()
         return balances
@@ -303,10 +313,131 @@ class BalancesUiMapper(
                         balance.nonCashSpentByCurrency,
                         groupCurrency,
                         locale
-                    )
+                    ),
+                    cashBreakdown = if (isNegativeCash) {
+                        persistentListOf()
+                    } else {
+                        mapCashBreakdown(
+                            userId = balance.userId,
+                            withdrawals = withdrawals,
+                            subunitsMap = subunitsMap,
+                            groupMemberIds = groupMemberIds,
+                            groupCurrency = groupCurrency,
+                            locale = locale
+                        )
+                    }
                 )
             }
             .toImmutableList()
+    }
+
+    /**
+     * Builds the per-withdrawal cash breakdown for a single member.
+     *
+     * Computes each withdrawal's attributed share using the same scope rules as
+     * [es.pedrazamiguez.splittrip.domain.usecase.balance.support.attributeRemainingByScope]:
+     * - GROUP → equal share among all group members (display approximation).
+     * - USER → full remaining if this member made the withdrawal, else excluded.
+     * - SUBUNIT → proportional share by [Subunit.memberShares] (BigDecimal, HALF_UP).
+     *
+     * Items are ordered: GROUP scope → USER scope → SUBUNIT scope, then by date descending
+     * within each scope group so the breakdown mirrors the pool priority used by FIFO.
+     *
+     * Exchange rate is omitted when the withdrawal currency equals the group currency
+     * (no conversion needed, no meaningful rate to display).
+     */
+    private fun mapCashBreakdown(
+        userId: String,
+        withdrawals: List<CashWithdrawal>,
+        subunitsMap: Map<String, Subunit>,
+        groupMemberIds: List<String>,
+        groupCurrency: String,
+        locale: java.util.Locale
+    ): ImmutableList<CashBreakdownUiModel> {
+        val scopeOrder = mapOf(PayerType.GROUP to 0, PayerType.USER to 1, PayerType.SUBUNIT to 2)
+        return withdrawals
+            .sortedWith(
+                compareBy<CashWithdrawal> { scopeOrder[it.withdrawalScope] ?: 3 }
+                    .thenByDescending { it.createdAt }
+            )
+            .mapNotNull { withdrawal ->
+                if (withdrawal.amountWithdrawn == 0L || withdrawal.remainingAmount <= 0L) return@mapNotNull null
+                val nativeShare = computeUserNativeShare(withdrawal, userId, groupMemberIds, subunitsMap)
+                if (nativeShare <= 0L) return@mapNotNull null
+
+                val groupEquivalent = BigDecimal(nativeShare)
+                    .multiply(BigDecimal(withdrawal.deductedBaseAmount))
+                    .divide(BigDecimal(withdrawal.amountWithdrawn), 0, RoundingMode.HALF_UP)
+                    .toLong()
+
+                val isForeign = withdrawal.currency != groupCurrency
+                val dateText = withdrawal.createdAt?.formatShortDate(locale) ?: ""
+                val label = if (withdrawal.title.isNullOrBlank()) {
+                    resourceProvider.getString(R.string.balances_cash_breakdown_atm_fallback, dateText)
+                } else {
+                    withdrawal.title ?: ""
+                }
+                val scopeLabel = resolveCashBreakdownScopeLabel(withdrawal, subunitsMap)
+                val isGroup = withdrawal.withdrawalScope == PayerType.GROUP
+
+                CashBreakdownUiModel(
+                    withdrawalLabel = label,
+                    dateText = dateText,
+                    formattedRate = if (isForeign) {
+                        resourceProvider.getString(
+                            R.string.balances_cash_breakdown_rate,
+                            withdrawal.exchangeRate.formatForDisplay(locale, maxDecimalPlaces = 6),
+                            groupCurrency,
+                            withdrawal.currency
+                        )
+                    } else {
+                        ""
+                    },
+                    formattedNativeRemaining = formatCurrencyAmount(nativeShare, withdrawal.currency, locale),
+                    formattedEquivalent = if (isForeign) {
+                        formatCurrencyAmount(groupEquivalent, groupCurrency, locale)
+                    } else {
+                        ""
+                    },
+                    scopeLabel = scopeLabel,
+                    isEstimatedShare = isGroup
+                )
+            }
+            .toImmutableList()
+    }
+
+    /** Resolves the user's attributed native share (in withdrawal currency cents) for display. */
+    private fun computeUserNativeShare(
+        withdrawal: CashWithdrawal,
+        userId: String,
+        groupMemberIds: List<String>,
+        subunitsMap: Map<String, Subunit>
+    ): Long {
+        val remaining = withdrawal.remainingAmount
+        return when (withdrawal.withdrawalScope) {
+            PayerType.USER -> if (withdrawal.withdrawnBy == userId) remaining else 0L
+            PayerType.GROUP -> {
+                if (groupMemberIds.isEmpty()) 0L else remaining / groupMemberIds.size
+            }
+            PayerType.SUBUNIT -> {
+                val subunit = withdrawal.subunitId?.let { subunitsMap[it] }
+                val share = subunit?.memberShares?.get(userId) ?: return 0L
+                BigDecimal(remaining)
+                    .multiply(share)
+                    .setScale(0, RoundingMode.HALF_UP)
+                    .toLong()
+            }
+        }
+    }
+
+    private fun resolveCashBreakdownScopeLabel(
+        withdrawal: CashWithdrawal,
+        subunitsMap: Map<String, Subunit>
+    ): String = when (withdrawal.withdrawalScope) {
+        PayerType.GROUP -> resourceProvider.getString(R.string.balances_cash_breakdown_group_scope)
+        PayerType.USER -> resourceProvider.getString(R.string.balances_cash_breakdown_personal_scope)
+        PayerType.SUBUNIT -> withdrawal.subunitId?.let { subunitsMap[it]?.name }
+            ?: resourceProvider.getString(R.string.balances_cash_breakdown_personal_scope)
     }
 
     /**

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashBreakdownUiModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashBreakdownUiModel.kt
@@ -1,0 +1,31 @@
+package es.pedrazamiguez.splittrip.features.balance.presentation.model
+
+/**
+ * UI model for a single withdrawal's attributed cash share shown in the cash breakdown sheet.
+ *
+ * Each instance maps to one [CashWithdrawal], carrying only the member's attributed portion
+ * of that withdrawal's remaining balance — not the full withdrawal amount.
+ *
+ * @param withdrawalLabel Withdrawal title or "ATM — Jan 10" fallback when title is blank.
+ * @param dateText Short date string for the withdrawal (e.g., "Jan 10").
+ * @param formattedRate Exchange rate label (e.g., "@ 0.027 EUR/THB"). Empty when the
+ *                      withdrawal currency matches the group currency.
+ * @param formattedNativeRemaining Member's attributed share in the withdrawal's native
+ *                                  currency (e.g., "฿ 47,750").
+ * @param formattedEquivalent Group-currency equivalent (e.g., "≈ 11.33 €"). Empty when
+ *                             the withdrawal currency matches the group currency.
+ * @param scopeLabel Pre-formatted scope description ("Group cash (est. share)",
+ *                   "Personal cash", or the subunit name).
+ * @param isEstimatedShare `true` for GROUP-scoped withdrawals, where the member's share
+ *                          is a proportional estimate (1/memberCount), not a fixed claim.
+ *                          Used by the UI to render an explanatory disclaimer.
+ */
+data class CashBreakdownUiModel(
+    val withdrawalLabel: String = "",
+    val dateText: String = "",
+    val formattedRate: String = "",
+    val formattedNativeRemaining: String = "",
+    val formattedEquivalent: String = "",
+    val scopeLabel: String = "",
+    val isEstimatedShare: Boolean = false
+)

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashBreakdownUiModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashBreakdownUiModel.kt
@@ -12,7 +12,8 @@ package es.pedrazamiguez.splittrip.features.balance.presentation.model
  *                      withdrawal currency matches the group currency.
  * @param formattedNativeRemaining Member's attributed share in the withdrawal's native
  *                                  currency (e.g., "฿ 47,750").
- * @param formattedEquivalent Group-currency equivalent (e.g., "≈ 11.33 €"). Empty when
+ * @param formattedEquivalent Group-currency equivalent amount without "≈" prefix (e.g., "11.33 €").
+ *                             The "≈ " prefix is added by the UI at render time. Empty when
  *                             the withdrawal currency matches the group currency.
  * @param scopeLabel Pre-formatted scope description ("Group cash (est. share)",
  *                   "Personal cash", or the subunit name).

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/MemberBalanceUiModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/MemberBalanceUiModel.kt
@@ -13,6 +13,7 @@ import kotlinx.collections.immutable.persistentListOf
  * - [formattedTotalSpent]: all expenses (cashSpent + nonCashSpent)
  *
  * Per-currency breakdowns enable the expandable card to show multi-currency detail.
+ * [cashBreakdown] holds per-withdrawal attribution items for the cash breakdown bottom sheet.
  *
  * [displayName] holds the resolved human-readable name (not a raw userId).
  *
@@ -35,5 +36,6 @@ data class MemberBalanceUiModel(
     val hasNegativeCashInHand: Boolean = false,
     val cashInHandByCurrency: ImmutableList<CurrencyBreakdownUiModel> = persistentListOf(),
     val cashSpentByCurrency: ImmutableList<CurrencyBreakdownUiModel> = persistentListOf(),
-    val nonCashSpentByCurrency: ImmutableList<CurrencyBreakdownUiModel> = persistentListOf()
+    val nonCashSpentByCurrency: ImmutableList<CurrencyBreakdownUiModel> = persistentListOf(),
+    val cashBreakdown: ImmutableList<CashBreakdownUiModel> = persistentListOf()
 )

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/viewmodel/BalancesViewModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/viewmodel/BalancesViewModel.kt
@@ -160,7 +160,10 @@ class BalancesViewModel(
                             currency,
                             currentUserId,
                             memberProfiles,
-                            groupCurrency = currency
+                            groupCurrency = currency,
+                            withdrawals = withdrawals,
+                            subunitsMap = subunitsMap,
+                            groupMemberIds = groupMemberIds
                         ),
                         activityItems = balancesUiMapper.mapActivity(
                             contributions,

--- a/features/balances/src/main/res/values-es/strings.xml
+++ b/features/balances/src/main/res/values-es/strings.xml
@@ -85,4 +85,6 @@
     <string name="balances_cash_breakdown_rate">@ %1$s %2$s/%3$s</string>
     <string name="balances_cash_breakdown_atm_fallback">ATM — %1$s</string>
     <string name="balances_cash_breakdown_view_cd">Ver desglose de efectivo</string>
+    <!-- Fallback cuando la subunidad referenciada por una retirada ya no existe (caso límite de integridad de datos) -->
+    <string name="balances_cash_breakdown_unknown_subunit">Subunidad desconocida</string>
 </resources>

--- a/features/balances/src/main/res/values-es/strings.xml
+++ b/features/balances/src/main/res/values-es/strings.xml
@@ -74,4 +74,15 @@
     <string name="balances_delete_withdrawal_dialog_text">Se eliminará permanentemente la retirada de %1$s. Esta acción no se puede deshacer.</string>
     <string name="balances_delete_withdrawal_success">Retirada eliminada</string>
     <string name="balances_delete_withdrawal_error">Error al eliminar la retirada</string>
+
+    <!-- Cash Breakdown Bottom Sheet -->
+    <string name="balances_cash_breakdown_title">Desglose de efectivo</string>
+    <string name="balances_cash_breakdown_group_scope">Efectivo del grupo (parte estimada)</string>
+    <string name="balances_cash_breakdown_personal_scope">Efectivo personal</string>
+    <string name="balances_cash_breakdown_total_label">Total</string>
+    <string name="balances_cash_breakdown_estimated_hint">Estimado · tu parte proporcional del efectivo del grupo</string>
+    <string name="balances_cash_breakdown_empty">Sin retiradas activas</string>
+    <string name="balances_cash_breakdown_rate">@ %1$s %2$s/%3$s</string>
+    <string name="balances_cash_breakdown_atm_fallback">ATM — %1$s</string>
+    <string name="balances_cash_breakdown_view_cd">Ver desglose de efectivo</string>
 </resources>

--- a/features/balances/src/main/res/values/strings.xml
+++ b/features/balances/src/main/res/values/strings.xml
@@ -86,4 +86,6 @@
     <!-- Fallback label when a withdrawal has no title; %1$s = short date -->
     <string name="balances_cash_breakdown_atm_fallback">ATM — %1$s</string>
     <string name="balances_cash_breakdown_view_cd">View cash breakdown</string>
+    <!-- Fallback when the subunit referenced by a withdrawal is no longer found (data integrity edge case) -->
+    <string name="balances_cash_breakdown_unknown_subunit">Unknown subunit</string>
 </resources>

--- a/features/balances/src/main/res/values/strings.xml
+++ b/features/balances/src/main/res/values/strings.xml
@@ -73,4 +73,17 @@
     <string name="balances_delete_withdrawal_dialog_text">This will permanently remove the withdrawal of %1$s. This action cannot be undone.</string>
     <string name="balances_delete_withdrawal_success">Withdrawal deleted</string>
     <string name="balances_delete_withdrawal_error">Failed to delete withdrawal</string>
+
+    <!-- Cash Breakdown Bottom Sheet -->
+    <string name="balances_cash_breakdown_title">Cash breakdown</string>
+    <string name="balances_cash_breakdown_group_scope">Group cash (est. share)</string>
+    <string name="balances_cash_breakdown_personal_scope">Personal cash</string>
+    <string name="balances_cash_breakdown_total_label">Total</string>
+    <string name="balances_cash_breakdown_estimated_hint">Estimated · your proportional share of group cash</string>
+    <string name="balances_cash_breakdown_empty">No active withdrawals</string>
+    <!-- %1$s = formatted rate, %2$s = group currency, %3$s = source currency; e.g. "@ 0.027 EUR/THB" -->
+    <string name="balances_cash_breakdown_rate">@ %1$s %2$s/%3$s</string>
+    <!-- Fallback label when a withdrawal has no title; %1$s = short date -->
+    <string name="balances_cash_breakdown_atm_fallback">ATM — %1$s</string>
+    <string name="balances_cash_breakdown_view_cd">View cash breakdown</string>
 </resources>

--- a/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
+++ b/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
@@ -47,7 +47,7 @@ class BalancesUiMapperMemberBalancesTest {
         every { resourceProvider.getString(R.string.balances_cash_breakdown_atm_fallback, any()) } returns
             "ATM — Jan 10"
         every { resourceProvider.getString(R.string.balances_cash_breakdown_rate, any(), any(), any()) } returns
-            "@ 0.027 EUR/THB"
+            "@ 0.027 THB/EUR"
         mapper = BalancesUiMapper(localeProvider, resourceProvider)
     }
 
@@ -663,7 +663,7 @@ class BalancesUiMapperMemberBalancesTest {
             val breakdown = result[0].cashBreakdown
             assertEquals(1, breakdown.size)
             val item = breakdown[0]
-            assertTrue(item.formattedRate.contains("EUR/THB"))
+            assertTrue(item.formattedRate.contains("THB/EUR"))
             assertTrue(item.formattedEquivalent.isNotBlank())
         }
 

--- a/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
+++ b/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
@@ -2,13 +2,18 @@ package es.pedrazamiguez.splittrip.features.balance.presentation.mapper
 
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.model.CurrencyAmount
 import es.pedrazamiguez.splittrip.domain.model.GroupPocketBalance
 import es.pedrazamiguez.splittrip.domain.model.MemberBalance
+import es.pedrazamiguez.splittrip.domain.model.Subunit
 import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.features.balance.R
 import io.mockk.every
 import io.mockk.mockk
+import java.math.BigDecimal
+import java.time.LocalDateTime
 import java.util.Locale
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -36,6 +41,13 @@ class BalancesUiMapperMemberBalancesTest {
         every { resourceProvider.getString(R.string.balances_contribution_scope_group) } returns "Group"
         every { resourceProvider.getString(R.string.balances_withdraw_cash_scope_personal) } returns "Personal"
         every { resourceProvider.getString(R.string.balances_withdraw_cash_scope_group) } returns "Group"
+        every { resourceProvider.getString(R.string.balances_cash_breakdown_group_scope) } returns
+            "Group cash (est. share)"
+        every { resourceProvider.getString(R.string.balances_cash_breakdown_personal_scope) } returns "Personal cash"
+        every { resourceProvider.getString(R.string.balances_cash_breakdown_atm_fallback, any()) } returns
+            "ATM — Jan 10"
+        every { resourceProvider.getString(R.string.balances_cash_breakdown_rate, any(), any(), any()) } returns
+            "@ 0.027 EUR/THB"
         mapper = BalancesUiMapper(localeProvider, resourceProvider)
     }
 
@@ -507,6 +519,313 @@ class BalancesUiMapperMemberBalancesTest {
             assertNotNull(result.formattedAvailableBalance)
             // Available = 470000 - 5000 = 465000 → 4,650.00
             assertTrue(result.formattedAvailableBalance!!.contains("4,650.00"))
+        }
+    }
+
+    @Nested
+    @DisplayName("mapMemberBalances — cashBreakdown")
+    inner class MapCashBreakdown {
+
+        private val currency = "EUR"
+        private val currentUserId = "user-1"
+        private val groupMemberIds = listOf("user-1", "user-2")
+        private val date = LocalDateTime.of(2026, 1, 10, 9, 0)
+
+        @Test
+        fun `cashBreakdown is empty when no withdrawals provided`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 1000L)
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId
+            )
+
+            assertTrue(result[0].cashBreakdown.isEmpty())
+        }
+
+        @Test
+        fun `USER-scoped withdrawal attributed fully to withdrawing user`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 100000L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date,
+                title = "7-11 ATM"
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds
+            )
+
+            val breakdown = result[0].cashBreakdown
+            assertEquals(1, breakdown.size)
+            val item = breakdown[0]
+            assertEquals("7-11 ATM", item.withdrawalLabel)
+            assertFalse(item.isEstimatedShare)
+            // EUR withdrawal → no rate or equivalent shown
+            assertEquals("", item.formattedRate)
+            assertEquals("", item.formattedEquivalent)
+        }
+
+        @Test
+        fun `USER-scoped withdrawal not attributed to other user`() {
+            val balance = MemberBalance(userId = "user-2", cashInHand = 0L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds
+            )
+
+            assertTrue(result[0].cashBreakdown.isEmpty())
+        }
+
+        @Test
+        fun `GROUP-scoped withdrawal split equally and marked as estimated share`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 50000L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.GROUP,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date,
+                title = "Airport ATM"
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds // 2 members → equal split
+            )
+
+            val breakdown = result[0].cashBreakdown
+            assertEquals(1, breakdown.size)
+            val item = breakdown[0]
+            assertTrue(item.isEstimatedShare)
+            assertEquals("Airport ATM", item.withdrawalLabel)
+        }
+
+        @Test
+        fun `foreign currency withdrawal shows rate and equivalent`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 1342L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "THB",
+                amountWithdrawn = 5000L,
+                remainingAmount = 5000L,
+                deductedBaseAmount = 1342L,
+                exchangeRate = BigDecimal("0.027"),
+                createdAt = date,
+                title = "Airport ATM"
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds,
+                groupCurrency = "EUR"
+            )
+
+            val breakdown = result[0].cashBreakdown
+            assertEquals(1, breakdown.size)
+            val item = breakdown[0]
+            assertTrue(item.formattedRate.contains("EUR/THB"))
+            assertTrue(item.formattedEquivalent.isNotBlank())
+        }
+
+        @Test
+        fun `withdrawal with zero remaining is excluded from breakdown`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 0L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 0L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds
+            )
+
+            assertTrue(result[0].cashBreakdown.isEmpty())
+        }
+
+        @Test
+        fun `cashBreakdown is suppressed when cashInHand is negative`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = -500L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 50000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds
+            )
+
+            val item = result[0]
+            assertTrue(item.hasNegativeCashInHand)
+            assertTrue(item.cashBreakdown.isEmpty())
+        }
+
+        @Test
+        fun `blank title uses ATM-date fallback label`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 100000L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date,
+                title = null
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                groupMemberIds = groupMemberIds
+            )
+
+            val label = result[0].cashBreakdown[0].withdrawalLabel
+            assertTrue(label.startsWith("ATM"))
+        }
+
+        @Test
+        fun `SUBUNIT-scoped withdrawal attributed by memberShares`() {
+            val subunit = Subunit(
+                id = "sub-1",
+                name = "Couple",
+                memberShares = mapOf("user-1" to BigDecimal("0.5"), "user-2" to BigDecimal("0.5"))
+            )
+            val balance = MemberBalance(userId = "user-1", cashInHand = 50000L)
+            val withdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.SUBUNIT,
+                subunitId = "sub-1",
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(withdrawal),
+                subunitsMap = mapOf("sub-1" to subunit),
+                groupMemberIds = groupMemberIds
+            )
+
+            val breakdown = result[0].cashBreakdown
+            assertEquals(1, breakdown.size)
+            assertFalse(breakdown[0].isEstimatedShare)
+            assertEquals("Couple", breakdown[0].scopeLabel)
+        }
+
+        @Test
+        fun `GROUP items appear before USER items in breakdown order`() {
+            val balance = MemberBalance(userId = "user-1", cashInHand = 60000L)
+            val groupWithdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.GROUP,
+                currency = "EUR",
+                amountWithdrawn = 200000L,
+                remainingAmount = 200000L,
+                deductedBaseAmount = 200000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date.minusDays(1),
+                title = "Group ATM"
+            )
+            val userWithdrawal = CashWithdrawal(
+                id = "w2",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date,
+                title = "Personal ATM"
+            )
+
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                withdrawals = listOf(userWithdrawal, groupWithdrawal), // intentionally USER first
+                groupMemberIds = groupMemberIds
+            )
+
+            val breakdown = result[0].cashBreakdown
+            assertEquals(2, breakdown.size)
+            // GROUP scope (scopeOrder=0) must appear before USER scope (scopeOrder=1)
+            assertTrue(breakdown[0].isEstimatedShare) // GROUP
+            assertFalse(breakdown[1].isEstimatedShare) // USER
         }
     }
 }


### PR DESCRIPTION
Introduce a per-withdrawal cash breakdown feature: add a CashBreakdownBottomSheet composable and CashBreakdownUiModel, and extend MemberBalanceUiModel with a cashBreakdown list. Update MemberBalanceItem to show an info icon that opens the bottom sheet (extracted CashInHandRow and labelSuffix support in DetailRow). Enhance BalancesUiMapper to build per-withdrawal attribution (GROUP / USER / SUBUNIT scope rules, ordering, rate/equivalent for foreign currency) and compute user shares (including subunit proportional shares), and pass withdrawals/subunit/group member info from BalancesViewModel. Add i18n strings for the sheet and comprehensive unit tests covering mapping behavior.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1034 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
