### PR TITLE
[SPLTRP-1048]: Polish `CashBreakdownBottomSheet`: align rows with weighted layout and enforce section ordering (group → subunit → personal)

### DIFF
--- a/features/balances/src/debug/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/preview/BalancesUiPreviewHelpers.kt
+++ b/features/balances/src/debug/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/preview/BalancesUiPreviewHelpers.kt
@@ -8,7 +8,9 @@ import es.pedrazamiguez.splittrip.domain.model.GroupPocketBalance
 import es.pedrazamiguez.splittrip.domain.model.MemberBalance
 import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.features.balance.presentation.mapper.BalancesUiMapper
+import es.pedrazamiguez.splittrip.features.balance.presentation.mapper.MemberBalanceCashContext
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.ActivityItemUiModel
+import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashBreakdownUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.CashWithdrawalUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.ContributionUiModel
 import es.pedrazamiguez.splittrip.features.balance.presentation.model.GroupPocketBalanceUiModel
@@ -181,5 +183,46 @@ fun MemberBalanceListPreviewHelper(
             )
         },
         content = content
+    )
+}
+
+/**
+ * Preview helper for [es.pedrazamiguez.splittrip.features.balance.presentation.component.CashBreakdownBottomSheet].
+ *
+ * Maps [memberBalance] + [withdrawals] through [BalancesUiMapper.mapMemberBalances] with a full
+ * [MemberBalanceCashContext], then passes `cashBreakdown` and `formattedCashInHand` to [content].
+ * Defaults exercise all three scope types (GROUP, SUBUNIT, USER) so all sections appear in the preview.
+ */
+@Composable
+fun CashBreakdownPreviewHelper(
+    memberBalance: MemberBalance = PREVIEW_MEMBER_BALANCE_FOR_BREAKDOWN,
+    withdrawals: List<CashWithdrawal> = listOf(
+        PREVIEW_CASH_WITHDRAWAL_GROUP,
+        PREVIEW_CASH_WITHDRAWAL_SUBUNIT,
+        PREVIEW_CASH_WITHDRAWAL_PERSONAL
+    ),
+    groupCurrency: String = "EUR",
+    content: @Composable (breakdown: ImmutableList<CashBreakdownUiModel>, formattedTotal: String) -> Unit
+) {
+    MappedPreview(
+        domain = Triple(memberBalance, withdrawals, groupCurrency),
+        mapper = { localeProvider, resourceProvider ->
+            BalancesUiMapper(localeProvider, resourceProvider)
+        },
+        transform = { mapper, (balance, wds, currency) ->
+            val uiModel = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = balance.userId,
+                groupCurrency = currency,
+                cashContext = MemberBalanceCashContext(
+                    withdrawals = wds,
+                    subunitsMap = mapOf(PREVIEW_SUBUNIT_FOR_BREAKDOWN.id to PREVIEW_SUBUNIT_FOR_BREAKDOWN),
+                    groupMemberIds = listOf("user-1", "user-2")
+                )
+            ).first()
+            uiModel.cashBreakdown to uiModel.formattedCashInHand
+        },
+        content = { (breakdown, total) -> content(breakdown, total) }
     )
 }

--- a/features/balances/src/debug/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/preview/CashBreakdownBottomSheetPreviews.kt
+++ b/features/balances/src/debug/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/preview/CashBreakdownBottomSheetPreviews.kt
@@ -1,0 +1,30 @@
+package es.pedrazamiguez.splittrip.features.balance.presentation.preview
+
+import androidx.compose.runtime.Composable
+import es.pedrazamiguez.splittrip.core.designsystem.preview.PreviewComplete
+import es.pedrazamiguez.splittrip.features.balance.presentation.component.CashBreakdownBottomSheet
+import kotlinx.collections.immutable.persistentListOf
+
+@PreviewComplete
+@Composable
+private fun CashBreakdownBottomSheetPreview() {
+    CashBreakdownPreviewHelper { breakdown, formattedTotal ->
+        CashBreakdownBottomSheet(
+            breakdown = breakdown,
+            formattedTotal = formattedTotal,
+            onDismiss = {}
+        )
+    }
+}
+
+@PreviewComplete
+@Composable
+private fun CashBreakdownBottomSheetEmptyPreview() {
+    CashBreakdownPreviewHelper(withdrawals = emptyList()) { _, _ ->
+        CashBreakdownBottomSheet(
+            breakdown = persistentListOf(),
+            formattedTotal = "฿ 0",
+            onDismiss = {}
+        )
+    }
+}

--- a/features/balances/src/debug/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/preview/PreviewData.kt
+++ b/features/balances/src/debug/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/preview/PreviewData.kt
@@ -6,6 +6,7 @@ import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.model.CurrencyAmount
 import es.pedrazamiguez.splittrip.domain.model.GroupPocketBalance
 import es.pedrazamiguez.splittrip.domain.model.MemberBalance
+import es.pedrazamiguez.splittrip.domain.model.Subunit
 import es.pedrazamiguez.splittrip.domain.model.User
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -94,6 +95,35 @@ val PREVIEW_CASH_WITHDRAWAL_IMPERSONATED = CashWithdrawal(
     deductedBaseAmount = 8100L,
     exchangeRate = BigDecimal("37.037"),
     createdAt = LocalDateTime.of(2026, 1, 19, 11, 0)
+)
+
+// ── Subunits ─────────────────────────────────────────────────────────────────
+
+/**
+ * Subunit fixture that matches [PREVIEW_CASH_WITHDRAWAL_SUBUNIT]'s subunitId = "subunit-1".
+ * Member shares are equal halves between "user-1" and "user-2".
+ */
+val PREVIEW_SUBUNIT_FOR_BREAKDOWN = Subunit(
+    id = "subunit-1",
+    name = "Couple Hotel Room",
+    memberShares = mapOf("user-1" to BigDecimal("0.5"), "user-2" to BigDecimal("0.5"))
+)
+
+/**
+ * Member balance fixture for cash-breakdown previews.
+ * userId = "user-1" matches [PREVIEW_CASH_WITHDRAWAL_GROUP], [PREVIEW_CASH_WITHDRAWAL_SUBUNIT],
+ * and [PREVIEW_CASH_WITHDRAWAL_PERSONAL] so all three scopes populate the breakdown sheet.
+ */
+val PREVIEW_MEMBER_BALANCE_FOR_BREAKDOWN = MemberBalance(
+    userId = "user-1",
+    contributed = 50000L,
+    withdrawn = 1700000L,
+    cashSpent = 800000L,
+    nonCashSpent = 10000L,
+    totalSpent = 810000L,
+    pocketBalance = 15000L,
+    cashInHand = 900000L,
+    cashInHandByCurrency = listOf(CurrencyAmount("THB", 900000L, 24300L))
 )
 
 // ── Contributions ───────────────────────────────────────────────────────────

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
@@ -28,8 +28,8 @@ import kotlinx.collections.immutable.ImmutableList
  * Bottom sheet displaying a per-withdrawal cash attribution breakdown for a single member.
  *
  * Items are grouped by scope via section headers: GROUP-scoped withdrawals are shown first
- * (with an "estimated share" disclaimer), followed by USER-scoped personal cash, and then
- * SUBUNIT-scoped entries. The scope header re-renders whenever the [CashBreakdownUiModel.scopeLabel]
+ * (with an "estimated share" disclaimer), followed by SUBUNIT-scoped entries, then
+ * USER-scoped personal cash. The scope header re-renders whenever the [CashBreakdownUiModel.scopeLabel]
  * changes from the previous item, producing implicit grouping without a nested data structure.
  *
  * This is intentionally separate from [MemberBalanceItem] to keep that file under the 600-line limit.

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/component/CashBreakdownBottomSheet.kt
@@ -124,15 +124,17 @@ private fun CashBreakdownItemList(breakdown: ImmutableList<CashBreakdownUiModel>
 
 @Composable
 private fun CashBreakdownEntryRow(item: CashBreakdownUiModel) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 4.dp)
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top
     ) {
-        // Title row: withdrawal label · date · rate
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalAlignment = Alignment.CenterVertically
+        // Left column: label stacked above date, then rate on its own line for easy scanning
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             Text(
                 text = item.withdrawalLabel,
@@ -142,24 +144,24 @@ private fun CashBreakdownEntryRow(item: CashBreakdownUiModel) {
             )
             if (item.dateText.isNotBlank()) {
                 Text(
-                    text = "·  ${item.dateText}",
-                    style = MaterialTheme.typography.bodySmall,
+                    text = item.dateText,
+                    style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             if (item.formattedRate.isNotBlank()) {
                 Text(
-                    text = "·  ${item.formattedRate}",
-                    style = MaterialTheme.typography.bodySmall,
+                    text = item.formattedRate,
+                    style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
-        // Amount row: native remaining [≈ equivalent]
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+        // Right column: native amount on top, group-currency equivalent below — visually secondary
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier.padding(start = 8.dp)
         ) {
             Text(
                 text = item.formattedNativeRemaining,
@@ -169,7 +171,7 @@ private fun CashBreakdownEntryRow(item: CashBreakdownUiModel) {
             )
             if (item.formattedEquivalent.isNotBlank()) {
                 Text(
-                    text = "≈  ${item.formattedEquivalent}",
+                    text = item.formattedEquivalent,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                 )

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapper.kt
@@ -346,7 +346,7 @@ class BalancesUiMapper(
      * - USER → full remaining if this member made the withdrawal, else excluded.
      * - SUBUNIT → proportional share by [Subunit.memberShares] (BigDecimal, HALF_UP).
      *
-     * Items are ordered: GROUP scope → USER scope → SUBUNIT scope, then by date descending
+     * Items are ordered: GROUP scope → SUBUNIT scope → USER scope, then by date descending
      * within each scope group so the breakdown mirrors the pool priority used by FIFO.
      *
      * Exchange rate is omitted when the withdrawal currency equals the group currency
@@ -360,7 +360,7 @@ class BalancesUiMapper(
         groupCurrency: String,
         locale: java.util.Locale
     ): ImmutableList<CashBreakdownUiModel> {
-        val scopeOrder = mapOf(PayerType.GROUP to 0, PayerType.USER to 1, PayerType.SUBUNIT to 2)
+        val scopeOrder = mapOf(PayerType.GROUP to 0, PayerType.SUBUNIT to 1, PayerType.USER to 2)
         return withdrawals
             .sortedWith(
                 compareBy<CashWithdrawal> { scopeOrder[it.withdrawalScope] ?: 3 }

--- a/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashBreakdownUiModel.kt
+++ b/features/balances/src/main/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/model/CashBreakdownUiModel.kt
@@ -12,9 +12,9 @@ package es.pedrazamiguez.splittrip.features.balance.presentation.model
  *                      withdrawal currency matches the group currency.
  * @param formattedNativeRemaining Member's attributed share in the withdrawal's native
  *                                  currency (e.g., "฿ 47,750").
- * @param formattedEquivalent Group-currency equivalent amount without "≈" prefix (e.g., "11.33 €").
- *                             The "≈ " prefix is added by the UI at render time. Empty when
- *                             the withdrawal currency matches the group currency.
+ * @param formattedEquivalent Group-currency equivalent amount, locale-formatted
+ *                             (e.g., "€12.82" in en-US, "12,82 €" in es-ES).
+ *                             Empty when the withdrawal currency matches the group currency.
  * @param scopeLabel Pre-formatted scope description ("Group cash (est. share)",
  *                   "Personal cash", or the subunit name).
  * @param isEstimatedShare `true` for GROUP-scoped withdrawals, where the member's share

--- a/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
+++ b/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
@@ -841,9 +841,75 @@ class BalancesUiMapperMemberBalancesTest {
 
             val breakdown = result[0].cashBreakdown
             assertEquals(2, breakdown.size)
-            // GROUP scope (scopeOrder=0) must appear before USER scope (scopeOrder=1)
+            // GROUP scope (scopeOrder=0) must appear before USER scope (scopeOrder=2)
             assertTrue(breakdown[0].isEstimatedShare) // GROUP
             assertFalse(breakdown[1].isEstimatedShare) // USER
+        }
+
+        @Test
+        fun `breakdown order is GROUP then SUBUNIT then USER regardless of input order`() {
+            val subunit = Subunit(
+                id = "sub-1",
+                name = "Couple",
+                memberShares = mapOf("user-1" to BigDecimal("0.5"), "user-2" to BigDecimal("0.5"))
+            )
+            val balance = MemberBalance(userId = "user-1", cashInHand = 150000L)
+            val userWithdrawal = CashWithdrawal(
+                id = "w1",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.USER,
+                currency = "EUR",
+                amountWithdrawn = 100000L,
+                remainingAmount = 100000L,
+                deductedBaseAmount = 100000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date,
+                title = "Personal ATM"
+            )
+            val subunitWithdrawal = CashWithdrawal(
+                id = "w2",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.SUBUNIT,
+                subunitId = "sub-1",
+                currency = "EUR",
+                amountWithdrawn = 200000L,
+                remainingAmount = 200000L,
+                deductedBaseAmount = 200000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date.minusDays(1),
+                title = "Subunit ATM"
+            )
+            val groupWithdrawal = CashWithdrawal(
+                id = "w3",
+                withdrawnBy = "user-1",
+                withdrawalScope = PayerType.GROUP,
+                currency = "EUR",
+                amountWithdrawn = 60000L,
+                remainingAmount = 60000L,
+                deductedBaseAmount = 60000L,
+                exchangeRate = BigDecimal.ONE,
+                createdAt = date.minusDays(2),
+                title = "Group ATM"
+            )
+
+            // Input deliberately in reverse of expected order: USER → SUBUNIT → GROUP
+            val result = mapper.mapMemberBalances(
+                balances = listOf(balance),
+                currency = currency,
+                currentUserId = currentUserId,
+                cashContext = MemberBalanceCashContext(
+                    withdrawals = listOf(userWithdrawal, subunitWithdrawal, groupWithdrawal),
+                    subunitsMap = mapOf("sub-1" to subunit),
+                    groupMemberIds = groupMemberIds
+                )
+            )
+
+            val breakdown = result[0].cashBreakdown
+            assertEquals(3, breakdown.size)
+            // Expected order: GROUP (scopeOrder=0) → SUBUNIT (scopeOrder=1) → USER (scopeOrder=2)
+            assertTrue(breakdown[0].isEstimatedShare) // GROUP
+            assertEquals("Couple", breakdown[1].scopeLabel) // SUBUNIT
+            assertFalse(breakdown[2].isEstimatedShare) // USER
         }
     }
 }

--- a/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
+++ b/features/balances/src/test/kotlin/es/pedrazamiguez/splittrip/features/balance/presentation/mapper/BalancesUiMapperMemberBalancesTest.kt
@@ -854,43 +854,6 @@ class BalancesUiMapperMemberBalancesTest {
                 memberShares = mapOf("user-1" to BigDecimal("0.5"), "user-2" to BigDecimal("0.5"))
             )
             val balance = MemberBalance(userId = "user-1", cashInHand = 150000L)
-            val userWithdrawal = CashWithdrawal(
-                id = "w1",
-                withdrawnBy = "user-1",
-                withdrawalScope = PayerType.USER,
-                currency = "EUR",
-                amountWithdrawn = 100000L,
-                remainingAmount = 100000L,
-                deductedBaseAmount = 100000L,
-                exchangeRate = BigDecimal.ONE,
-                createdAt = date,
-                title = "Personal ATM"
-            )
-            val subunitWithdrawal = CashWithdrawal(
-                id = "w2",
-                withdrawnBy = "user-1",
-                withdrawalScope = PayerType.SUBUNIT,
-                subunitId = "sub-1",
-                currency = "EUR",
-                amountWithdrawn = 200000L,
-                remainingAmount = 200000L,
-                deductedBaseAmount = 200000L,
-                exchangeRate = BigDecimal.ONE,
-                createdAt = date.minusDays(1),
-                title = "Subunit ATM"
-            )
-            val groupWithdrawal = CashWithdrawal(
-                id = "w3",
-                withdrawnBy = "user-1",
-                withdrawalScope = PayerType.GROUP,
-                currency = "EUR",
-                amountWithdrawn = 60000L,
-                remainingAmount = 60000L,
-                deductedBaseAmount = 60000L,
-                exchangeRate = BigDecimal.ONE,
-                createdAt = date.minusDays(2),
-                title = "Group ATM"
-            )
 
             // Input deliberately in reverse of expected order: USER → SUBUNIT → GROUP
             val result = mapper.mapMemberBalances(
@@ -898,7 +861,17 @@ class BalancesUiMapperMemberBalancesTest {
                 currency = currency,
                 currentUserId = currentUserId,
                 cashContext = MemberBalanceCashContext(
-                    withdrawals = listOf(userWithdrawal, subunitWithdrawal, groupWithdrawal),
+                    withdrawals = listOf(
+                        cashWithdrawal("w1", PayerType.USER, createdAt = date),
+                        cashWithdrawal(
+                            "w2",
+                            PayerType.SUBUNIT,
+                            subunitId = "sub-1",
+                            createdAt = date.minusDays(1),
+                            amountWithdrawn = 200000L
+                        ),
+                        cashWithdrawal("w3", PayerType.GROUP, createdAt = date.minusDays(2), amountWithdrawn = 60000L)
+                    ),
                     subunitsMap = mapOf("sub-1" to subunit),
                     groupMemberIds = groupMemberIds
                 )
@@ -913,3 +886,30 @@ class BalancesUiMapperMemberBalancesTest {
         }
     }
 }
+
+/**
+ * Creates a [CashWithdrawal] test fixture with sensible defaults, keeping individual test bodies concise.
+ *
+ * All monetary defaults (100 000 units at 1:1 rate) are intentionally round numbers so
+ * tests can assert share fractions without rounding surprises.
+ */
+private fun cashWithdrawal(
+    id: String,
+    scope: PayerType = PayerType.USER,
+    withdrawnBy: String = "user-1",
+    subunitId: String? = null,
+    amountWithdrawn: Long = 100000L,
+    currency: String = "EUR",
+    createdAt: LocalDateTime? = null
+) = CashWithdrawal(
+    id = id,
+    withdrawnBy = withdrawnBy,
+    withdrawalScope = scope,
+    subunitId = subunitId,
+    currency = currency,
+    amountWithdrawn = amountWithdrawn,
+    remainingAmount = amountWithdrawn, // Defaults to full amount; no FIFO consumption
+    deductedBaseAmount = amountWithdrawn,
+    exchangeRate = BigDecimal.ONE,
+    createdAt = createdAt
+)


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1048 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
