### PR TITLE
[SPLTRP-1072]: feat: Display cash tranche scope (personal / group / subunit) in expense detail

### DIFF
--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
@@ -276,6 +276,7 @@ val expensesUiModule = module {
             getExpenseByIdUseCase = get<GetExpenseByIdUseCase>(),
             getMemberProfilesUseCase = get<GetMemberProfilesUseCase>(),
             getCashWithdrawalsFlowUseCase = get<GetCashWithdrawalsFlowUseCase>(),
+            getGroupSubunitsFlowUseCase = get<GetGroupSubunitsFlowUseCase>(),
             deleteExpenseUseCase = get<DeleteExpenseUseCase>(),
             authenticationService = get<AuthenticationService>(),
             expenseDetailUiMapper = get<ExpenseDetailUiMapper>()

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
@@ -32,6 +32,7 @@ import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedCategor
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedPaymentMethodUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.navigation.impl.ExpensesNavigationProviderImpl
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseAddOnUiMapper
@@ -276,7 +277,7 @@ val expensesUiModule = module {
             getExpenseByIdUseCase = get<GetExpenseByIdUseCase>(),
             getMemberProfilesUseCase = get<GetMemberProfilesUseCase>(),
             getCashWithdrawalsFlowUseCase = get<GetCashWithdrawalsFlowUseCase>(),
-            getGroupSubunitsFlowUseCase = get<GetGroupSubunitsFlowUseCase>(),
+            getGroupSubunitsUseCase = get<GetGroupSubunitsUseCase>(),
             deleteExpenseUseCase = get<DeleteExpenseUseCase>(),
             authenticationService = get<AuthenticationService>(),
             expenseDetailUiMapper = get<ExpenseDetailUiMapper>()

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/CashTranchesDetailSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/CashTranchesDetailSection.kt
@@ -16,6 +16,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Wallet
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.BodyText
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.CaptionText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.LabelText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.SecondaryBodyText
 import es.pedrazamiguez.splittrip.features.expense.R
@@ -47,7 +48,15 @@ internal fun CashTranchesDetailSection(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        SecondaryBodyText(text = tranche.withdrawalLabel)
+                        Column {
+                            SecondaryBodyText(text = tranche.withdrawalLabel)
+                            if (tranche.scopeText != null) {
+                                CaptionText(
+                                    text = tranche.scopeText,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
                         BodyText(text = tranche.formattedAmountConsumed)
                     }
                 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/CashTranchesDetailSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/CashTranchesDetailSection.kt
@@ -46,7 +46,7 @@ internal fun CashTranchesDetailSection(
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.Top
                     ) {
                         Column {
                             SecondaryBodyText(text = tranche.withdrawalLabel)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
@@ -34,7 +34,8 @@ class ExpenseDetailUiMapper(
         expense: Expense,
         memberProfiles: Map<String, User>,
         currentUserId: String?,
-        withdrawalLookup: Map<String, CashWithdrawal> = emptyMap()
+        withdrawalLookup: Map<String, CashWithdrawal> = emptyMap(),
+        subunitNameLookup: Map<String, String> = emptyMap()
     ): ExpenseDetailUiModel {
         val (scheduledBadgeText, isScheduledPastDue) = buildScheduledBadge(expense)
         val isForeignCurrency = expense.sourceCurrency != expense.groupCurrency
@@ -86,7 +87,12 @@ class ExpenseDetailUiMapper(
             formattedEffectiveTotal = effectiveTotal?.let {
                 formattingHelper.formatCentsWithCurrency(it, expense.groupCurrency)
             },
-            cashTranches = mapCashTranches(expense.cashTranches, expense.sourceCurrency, withdrawalLookup),
+            cashTranches = mapCashTranches(
+                expense.cashTranches,
+                expense.sourceCurrency,
+                withdrawalLookup,
+                subunitNameLookup
+            ),
             receiptUri = expense.receiptLocalUri,
             createdByText = paidByName,
             createdAtText = formattingHelper.formatShortDate(expense.createdAt),
@@ -158,7 +164,8 @@ class ExpenseDetailUiMapper(
     private fun mapCashTranches(
         tranches: List<CashTranche>,
         sourceCurrency: String,
-        withdrawalLookup: Map<String, CashWithdrawal>
+        withdrawalLookup: Map<String, CashWithdrawal>,
+        subunitNameLookup: Map<String, String>
     ): ImmutableList<CashTrancheDetailUiModel> = tranches.map { tranche ->
         val withdrawal = withdrawalLookup[tranche.withdrawalId]
         val withdrawalTitle = withdrawal?.title
@@ -172,14 +179,35 @@ class ExpenseDetailUiMapper(
                 resourceProvider.getString(R.string.add_expense_cash_tranche_atm_label_no_date)
             }
         }
+        val scopeText = resolveTrancheScopeText(withdrawal, subunitNameLookup)
         CashTrancheDetailUiModel(
             withdrawalLabel = label,
             formattedAmountConsumed = formattingHelper.formatCentsWithCurrency(
                 tranche.amountConsumed,
                 sourceCurrency
-            )
+            ),
+            scopeText = scopeText
         )
     }.toImmutableList()
+
+    private fun resolveTrancheScopeText(
+        withdrawal: CashWithdrawal?,
+        subunitNameLookup: Map<String, String>
+    ): String? {
+        if (withdrawal == null) return null
+        return when (withdrawal.withdrawalScope) {
+            PayerType.GROUP -> resourceProvider.getString(R.string.expense_detail_tranche_scope_group)
+            PayerType.USER -> resourceProvider.getString(R.string.expense_detail_tranche_scope_personal)
+            PayerType.SUBUNIT -> {
+                val name = withdrawal.subunitId?.let { subunitNameLookup[it] }
+                if (!name.isNullOrBlank()) {
+                    resourceProvider.getString(R.string.expense_detail_tranche_scope_subunit, name)
+                } else {
+                    null
+                }
+            }
+        }
+    }
 
     private fun buildScheduledBadge(expense: Expense): Pair<String?, Boolean> {
         val dueDate = expense.dueDate

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/CashTrancheDetailUiModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/CashTrancheDetailUiModel.kt
@@ -5,12 +5,14 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.model
  *
  * @param withdrawalLabel Display label for the source withdrawal
  *                        (title if available, fallback "ATM"/"Cajero").
- *                        Future: enriched with scope (personal/group/subunit)
- *                        once withdrawal lookup is available at detail-screen time.
  * @param formattedAmountConsumed Amount consumed from this withdrawal, formatted
  *                                with currency symbol (e.g. "฿ 45.00").
+ * @param scopeText Secondary caption identifying the pool scope (e.g. "Group cash",
+ *                  "Personal cash", "Cabin cash"). Null for legacy tranche records
+ *                  where the withdrawal can't be resolved — hidden in the UI.
  */
 data class CashTrancheDetailUiModel(
     val withdrawalLabel: String,
-    val formattedAmountConsumed: String
+    val formattedAmountConsumed: String,
+    val scopeText: String? = null
 )

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import es.pedrazamiguez.splittrip.core.common.constant.AppConstants
 import es.pedrazamiguez.splittrip.core.common.presentation.UiText
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDetailUiMapper
@@ -44,6 +46,7 @@ class ExpenseDetailViewModel(
     private val getExpenseByIdUseCase: GetExpenseByIdUseCase,
     private val getMemberProfilesUseCase: GetMemberProfilesUseCase,
     private val getCashWithdrawalsFlowUseCase: GetCashWithdrawalsFlowUseCase,
+    private val getGroupSubunitsFlowUseCase: GetGroupSubunitsFlowUseCase,
     private val deleteExpenseUseCase: DeleteExpenseUseCase,
     private val authenticationService: AuthenticationService,
     private val expenseDetailUiMapper: ExpenseDetailUiMapper
@@ -106,7 +109,28 @@ class ExpenseDetailViewModel(
                 emptyMap()
             }
 
-            val uiModel = expenseDetailUiMapper.map(expense, memberProfiles, currentUserId, withdrawalLookup)
+            val subunitNameLookup = if (withdrawalLookup.values.any { it.withdrawalScope == PayerType.SUBUNIT }) {
+                try {
+                    getGroupSubunitsFlowUseCase(expense.groupId)
+                        .first()
+                        .associate { it.id to it.name }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch subunits for expense $expenseId")
+                    emptyMap()
+                }
+            } else {
+                emptyMap()
+            }
+
+            val uiModel = expenseDetailUiMapper.map(
+                expense = expense,
+                memberProfiles = memberProfiles,
+                currentUserId = currentUserId,
+                withdrawalLookup = withdrawalLookup,
+                subunitNameLookup = subunitNameLookup
+            )
 
             flowOf(ExpenseDetailUiState(expense = uiModel, isLoading = false))
         }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
@@ -9,7 +9,7 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
-import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDetailUiMapper
@@ -46,7 +46,7 @@ class ExpenseDetailViewModel(
     private val getExpenseByIdUseCase: GetExpenseByIdUseCase,
     private val getMemberProfilesUseCase: GetMemberProfilesUseCase,
     private val getCashWithdrawalsFlowUseCase: GetCashWithdrawalsFlowUseCase,
-    private val getGroupSubunitsFlowUseCase: GetGroupSubunitsFlowUseCase,
+    private val getGroupSubunitsUseCase: GetGroupSubunitsUseCase,
     private val deleteExpenseUseCase: DeleteExpenseUseCase,
     private val authenticationService: AuthenticationService,
     private val expenseDetailUiMapper: ExpenseDetailUiMapper
@@ -109,10 +109,12 @@ class ExpenseDetailViewModel(
                 emptyMap()
             }
 
-            val subunitNameLookup = if (withdrawalLookup.values.any { it.withdrawalScope == PayerType.SUBUNIT }) {
+            val subunitNameLookup = if (withdrawalLookup.values.any {
+                    it.withdrawalScope == PayerType.SUBUNIT && !it.subunitId.isNullOrBlank()
+                }
+            ) {
                 try {
-                    getGroupSubunitsFlowUseCase(expense.groupId)
-                        .first()
+                    getGroupSubunitsUseCase(expense.groupId)
                         .associate { it.id to it.name }
                 } catch (e: CancellationException) {
                     throw e

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -249,6 +249,9 @@
     <string name="expense_detail_group_currency_label">Saldo del grupo</string>
     <string name="expense_detail_amount_in_currency">Importe en %1$s</string>
     <string name="expense_detail_cash_section_title">Pagado con</string>
+    <string name="expense_detail_tranche_scope_group">Efectivo del grupo</string>
+    <string name="expense_detail_tranche_scope_personal">Efectivo personal</string>
+    <string name="expense_detail_tranche_scope_subunit">Efectivo de %1$s</string>
     <string name="expense_detail_rate_label">@ %1$s</string>
     <string name="expense_detail_section_info">Info de pago</string>
     <string name="expense_detail_paid_by_label">Pagado por</string>

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -248,6 +248,9 @@
     <string name="expense_detail_group_currency_label">Group balance</string>
     <string name="expense_detail_amount_in_currency">Amount in %1$s</string>
     <string name="expense_detail_cash_section_title">Paid with</string>
+    <string name="expense_detail_tranche_scope_group">Group cash</string>
+    <string name="expense_detail_tranche_scope_personal">Personal cash</string>
+    <string name="expense_detail_tranche_scope_subunit">%1$s cash</string>
     <string name="expense_detail_rate_label">@ %1$s</string>
     <string name="expense_detail_section_info">Payment Info</string>
     <string name="expense_detail_paid_by_label">Paid by</string>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
@@ -14,6 +14,7 @@ import es.pedrazamiguez.splittrip.domain.enums.SplitType
 import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.AddOn
 import es.pedrazamiguez.splittrip.domain.model.CashTranche
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
 import es.pedrazamiguez.splittrip.domain.model.User
@@ -460,6 +461,100 @@ class ExpenseDetailUiMapperTest {
             result.cashTranches.forEach {
                 assertTrue(it.formattedAmountConsumed.isNotBlank())
             }
+        }
+
+        @Test
+        fun `scopeText is null when withdrawal not found in lookup (legacy record)`() {
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-legacy", amountConsumed = 1000L))
+            )
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            assertNull(result.cashTranches.first().scopeText)
+        }
+
+        @Test
+        fun `scopeText resolves to group label for GROUP-scoped withdrawal`() {
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-group", amountConsumed = 1000L))
+            )
+            val withdrawal = CashWithdrawal(id = "w-group", groupId = "group-456", withdrawalScope = PayerType.GROUP)
+            every { resourceProvider.getString(any()) } returns "translated_string"
+
+            val result = mapper.map(
+                expense,
+                memberProfiles,
+                currentUserId,
+                withdrawalLookup = mapOf("w-group" to withdrawal)
+            )
+
+            assertNotNull(result.cashTranches.first().scopeText)
+        }
+
+        @Test
+        fun `scopeText resolves to personal label for USER-scoped withdrawal`() {
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-user", amountConsumed = 1000L))
+            )
+            val withdrawal = CashWithdrawal(id = "w-user", groupId = "group-456", withdrawalScope = PayerType.USER)
+            every { resourceProvider.getString(any()) } returns "translated_string"
+
+            val result = mapper.map(
+                expense,
+                memberProfiles,
+                currentUserId,
+                withdrawalLookup = mapOf("w-user" to withdrawal)
+            )
+
+            assertNotNull(result.cashTranches.first().scopeText)
+        }
+
+        @Test
+        fun `scopeText resolves to subunit label when subunit name is found`() {
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-sub", amountConsumed = 1000L))
+            )
+            val withdrawal = CashWithdrawal(
+                id = "w-sub",
+                groupId = "group-456",
+                withdrawalScope = PayerType.SUBUNIT,
+                subunitId = "sub-1"
+            )
+            every { resourceProvider.getString(any(), any()) } returns "Cabin cash"
+
+            val result = mapper.map(
+                expense,
+                memberProfiles,
+                currentUserId,
+                withdrawalLookup = mapOf("w-sub" to withdrawal),
+                subunitNameLookup = mapOf("sub-1" to "Cabin")
+            )
+
+            assertNotNull(result.cashTranches.first().scopeText)
+        }
+
+        @Test
+        fun `scopeText is null for SUBUNIT-scoped withdrawal when subunit name not found`() {
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-sub", amountConsumed = 1000L))
+            )
+            val withdrawal = CashWithdrawal(
+                id = "w-sub",
+                groupId = "group-456",
+                withdrawalScope = PayerType.SUBUNIT,
+                subunitId = "sub-unknown"
+            )
+
+            val result = mapper.map(
+                expense,
+                memberProfiles,
+                currentUserId,
+                withdrawalLookup = mapOf("w-sub" to withdrawal),
+                subunitNameLookup = emptyMap()
+            )
+
+            assertNull(result.cashTranches.first().scopeText)
         }
     }
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
@@ -8,7 +8,7 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
-import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDetailUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDetailUiModel
@@ -50,7 +50,7 @@ class ExpenseDetailViewModelTest {
     private lateinit var getExpenseByIdUseCase: GetExpenseByIdUseCase
     private lateinit var getMemberProfilesUseCase: GetMemberProfilesUseCase
     private lateinit var getCashWithdrawalsFlowUseCase: GetCashWithdrawalsFlowUseCase
-    private lateinit var getGroupSubunitsFlowUseCase: GetGroupSubunitsFlowUseCase
+    private lateinit var getGroupSubunitsUseCase: GetGroupSubunitsUseCase
     private lateinit var deleteExpenseUseCase: DeleteExpenseUseCase
     private lateinit var authenticationService: AuthenticationService
     private lateinit var expenseDetailUiMapper: ExpenseDetailUiMapper
@@ -104,13 +104,13 @@ class ExpenseDetailViewModelTest {
         getExpenseByIdUseCase = mockk()
         getMemberProfilesUseCase = mockk()
         getCashWithdrawalsFlowUseCase = mockk()
-        getGroupSubunitsFlowUseCase = mockk()
+        getGroupSubunitsUseCase = mockk()
         deleteExpenseUseCase = mockk()
         authenticationService = mockk()
         expenseDetailUiMapper = mockk()
 
         every { getCashWithdrawalsFlowUseCase(any()) } returns flowOf(emptyList())
-        every { getGroupSubunitsFlowUseCase(any()) } returns flowOf(emptyList())
+        coEvery { getGroupSubunitsUseCase(any()) } returns emptyList()
 
         every { authenticationService.currentUserId() } returns testUserId
         coEvery { getMemberProfilesUseCase(any()) } returns mapOf(
@@ -379,7 +379,7 @@ class ExpenseDetailViewModelTest {
         getExpenseByIdUseCase = getExpenseByIdUseCase,
         getMemberProfilesUseCase = getMemberProfilesUseCase,
         getCashWithdrawalsFlowUseCase = getCashWithdrawalsFlowUseCase,
-        getGroupSubunitsFlowUseCase = getGroupSubunitsFlowUseCase,
+        getGroupSubunitsUseCase = getGroupSubunitsUseCase,
         deleteExpenseUseCase = deleteExpenseUseCase,
         authenticationService = authenticationService,
         expenseDetailUiMapper = expenseDetailUiMapper

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
@@ -8,6 +8,7 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDetailUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDetailUiModel
@@ -49,6 +50,7 @@ class ExpenseDetailViewModelTest {
     private lateinit var getExpenseByIdUseCase: GetExpenseByIdUseCase
     private lateinit var getMemberProfilesUseCase: GetMemberProfilesUseCase
     private lateinit var getCashWithdrawalsFlowUseCase: GetCashWithdrawalsFlowUseCase
+    private lateinit var getGroupSubunitsFlowUseCase: GetGroupSubunitsFlowUseCase
     private lateinit var deleteExpenseUseCase: DeleteExpenseUseCase
     private lateinit var authenticationService: AuthenticationService
     private lateinit var expenseDetailUiMapper: ExpenseDetailUiMapper
@@ -102,17 +104,19 @@ class ExpenseDetailViewModelTest {
         getExpenseByIdUseCase = mockk()
         getMemberProfilesUseCase = mockk()
         getCashWithdrawalsFlowUseCase = mockk()
+        getGroupSubunitsFlowUseCase = mockk()
         deleteExpenseUseCase = mockk()
         authenticationService = mockk()
         expenseDetailUiMapper = mockk()
 
         every { getCashWithdrawalsFlowUseCase(any()) } returns flowOf(emptyList())
+        every { getGroupSubunitsFlowUseCase(any()) } returns flowOf(emptyList())
 
         every { authenticationService.currentUserId() } returns testUserId
         coEvery { getMemberProfilesUseCase(any()) } returns mapOf(
             testUserId to User(userId = testUserId, displayName = "Alice", email = "alice@example.com")
         )
-        every { expenseDetailUiMapper.map(any(), any(), any()) } returns testUiModel
+        every { expenseDetailUiMapper.map(any(), any(), any(), any(), any()) } returns testUiModel
 
         viewModel = createViewModel()
     }
@@ -176,7 +180,7 @@ class ExpenseDetailViewModelTest {
             advanceUntilIdle()
 
             // Then — mapper was called once with the loaded data
-            coVerify(exactly = 1) { expenseDetailUiMapper.map(testExpense, any(), testUserId) }
+            coVerify(exactly = 1) { expenseDetailUiMapper.map(testExpense, any(), testUserId, any(), any()) }
 
             collectJob.cancel()
         }
@@ -375,6 +379,7 @@ class ExpenseDetailViewModelTest {
         getExpenseByIdUseCase = getExpenseByIdUseCase,
         getMemberProfilesUseCase = getMemberProfilesUseCase,
         getCashWithdrawalsFlowUseCase = getCashWithdrawalsFlowUseCase,
+        getGroupSubunitsFlowUseCase = getGroupSubunitsFlowUseCase,
         deleteExpenseUseCase = deleteExpenseUseCase,
         authenticationService = authenticationService,
         expenseDetailUiMapper = expenseDetailUiMapper


### PR DESCRIPTION
Show scope (group/personal/subunit) for cash tranches in expense details. Fetch group subunits in the ViewModel and pass a subunit name lookup to the mapper; extend CashTrancheDetailUiModel with scopeText and render it in the UI as a caption. Register GetGroupSubunitsFlowUseCase in the DI module, add localized strings, and extend unit tests to cover the new scope resolution behavior.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1072 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
