### PR TITLE
[SPLTRP-1078]: Bug: INCLUDED DISCOUNT percentage add-on stores wrong `groupAmountCents` — off-by-~10% due to incorrect percentage base

### DIFF
--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/AddOnCalculationService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/AddOnCalculationService.kt
@@ -56,6 +56,37 @@ class AddOnCalculationService(
         sourceAmountCents = sourceAmountCents
     )
 
+    /**
+     * Resolves the absolute discount amount in minor units for an INCLUDED DISCOUNT
+     * add-on whose user input is a PERCENTAGE.
+     *
+     * The generic [resolveAddOnAmountCents] formula (`source × pct / 100`) is wrong
+     * for this combination because the source amount the user entered is the
+     * **post-discount** price. The pre-discount base cost is
+     * `source / (1 − pct/100)`, so the embedded discount equals
+     * `source / (1 − pct/100) − source`, which simplifies to
+     * `source × pct / (100 − pct)`.
+     *
+     * @param sourceAmountCents   Paid (post-discount) amount in the add-on's currency minor units.
+     * @param discountPercentage  The discount percentage (e.g., `10` for 10 %).
+     * @return The embedded discount in minor units; `0` when [sourceAmountCents] is non-positive
+     *         or when [discountPercentage] is ≥ 100 (degenerate case — no positive base cost exists).
+     */
+    fun calculateIncludedDiscountPercentageCents(
+        sourceAmountCents: Long,
+        discountPercentage: BigDecimal
+    ): Long {
+        if (sourceAmountCents <= 0L) return 0L
+        if (discountPercentage.compareTo(BigDecimal.ZERO) <= 0) return 0L
+        val divisor = BigDecimal("100").subtract(discountPercentage)
+        if (divisor.compareTo(BigDecimal.ZERO) <= 0) return 0L
+        return BigDecimal(sourceAmountCents)
+            .multiply(discountPercentage)
+            .divide(divisor, 0, RoundingMode.HALF_UP)
+            .toLong()
+            .coerceAtLeast(0L)
+    }
+
     // ── Add-On Totals ───────────────────────────────────────────────────
 
     /**

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/AddOnCalculationServiceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/AddOnCalculationServiceTest.kt
@@ -6,6 +6,7 @@ import es.pedrazamiguez.splittrip.domain.enums.AddOnValueType
 import es.pedrazamiguez.splittrip.domain.model.AddOn
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -532,6 +533,101 @@ class AddOnCalculationServiceTest {
         fun `handles single element`() {
             val result = addOnService.sumPercentagesFromInputs(listOf("42.5"))
             assertEquals(BigDecimal("42.5"), result)
+        }
+    }
+
+    // ── calculateIncludedDiscountPercentageCents ─────────────────────────
+
+    @Nested
+    inner class CalculateIncludedDiscountPercentageCents {
+
+        @Test
+        fun `10 percent on 1821_52 EUR returns 202_39 EUR (20239 cents) - issue 1078 scenario`() {
+            // baseCost = 182152 / 0.9 = 202391; discount = 202391 - 182152 = 20239
+            // Equivalent: 182152 * 10 / 90 = 20239.111 → 20239 (HALF_UP)
+            val result = addOnService.calculateIncludedDiscountPercentageCents(
+                sourceAmountCents = 182152L,
+                discountPercentage = BigDecimal("10")
+            )
+            assertEquals(20239L, result)
+        }
+
+        @Test
+        fun `does NOT use the buggy source × pct ÷ 100 formula`() {
+            // The buggy formula would return 18215 (10% of 1821.52).
+            // The correct formula returns 20239 (the actual embedded discount).
+            val buggy = 182152L * 10L / 100L
+            val result = addOnService.calculateIncludedDiscountPercentageCents(
+                sourceAmountCents = 182152L,
+                discountPercentage = BigDecimal("10")
+            )
+            assertEquals(20239L, result)
+            assertEquals(18215L, buggy)
+            assertNotEquals(buggy, result)
+        }
+
+        @Test
+        fun `25 percent on 7500 cents returns 2500 cents`() {
+            // baseCost = 7500 / 0.75 = 10000; discount = 2500
+            val result = addOnService.calculateIncludedDiscountPercentageCents(
+                sourceAmountCents = 7500L,
+                discountPercentage = BigDecimal("25")
+            )
+            assertEquals(2500L, result)
+        }
+
+        @Test
+        fun `zero percent returns zero`() {
+            val result = addOnService.calculateIncludedDiscountPercentageCents(
+                sourceAmountCents = 100000L,
+                discountPercentage = BigDecimal.ZERO
+            )
+            assertEquals(0L, result)
+        }
+
+        @Test
+        fun `negative percent returns zero`() {
+            val result = addOnService.calculateIncludedDiscountPercentageCents(
+                sourceAmountCents = 100000L,
+                discountPercentage = BigDecimal("-10")
+            )
+            assertEquals(0L, result)
+        }
+
+        @Test
+        fun `100 percent or above returns zero (degenerate - no base cost)`() {
+            assertEquals(
+                0L,
+                addOnService.calculateIncludedDiscountPercentageCents(
+                    sourceAmountCents = 100000L,
+                    discountPercentage = BigDecimal("100")
+                )
+            )
+            assertEquals(
+                0L,
+                addOnService.calculateIncludedDiscountPercentageCents(
+                    sourceAmountCents = 100000L,
+                    discountPercentage = BigDecimal("150")
+                )
+            )
+        }
+
+        @Test
+        fun `zero or negative source amount returns zero`() {
+            assertEquals(
+                0L,
+                addOnService.calculateIncludedDiscountPercentageCents(
+                    sourceAmountCents = 0L,
+                    discountPercentage = BigDecimal("10")
+                )
+            )
+            assertEquals(
+                0L,
+                addOnService.calculateIncludedDiscountPercentageCents(
+                    sourceAmountCents = -100L,
+                    discountPercentage = BigDecimal("10")
+                )
+            )
         }
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnEventHandler.kt
@@ -17,6 +17,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpens
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import java.math.BigDecimal
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
@@ -483,12 +484,7 @@ class AddOnEventHandler(
         )
         if (addOn.valueType == AddOnValueType.PERCENTAGE && sourceAmountCents <= 0) return addOn
 
-        val resolvedCents = addOnCalculationService.resolveAddOnAmountCents(
-            normalizedInput = inputBd,
-            valueType = addOn.valueType,
-            decimalDigits = decimalDigits,
-            sourceAmountCents = sourceAmountCents
-        )
+        val resolvedCents = resolveAddOnAmountCentsForType(addOn, inputBd, decimalDigits, sourceAmountCents)
 
         // Convert to group currency using the add-on's own rate
         val groupAmountCents = convertAddOnToGroupCurrency(resolvedCents, addOn)
@@ -526,6 +522,36 @@ class AddOnEventHandler(
             amountCents,
             addOn.displayExchangeRate
         )
+    }
+
+    /**
+     * Routes percentage-based INCLUDED DISCOUNTs through the corrected formula
+     * `source × pct / (100 − pct)`. The generic resolver returns `source × pct / 100`,
+     * which under-reports the embedded discount because [sourceAmountCents] is the
+     * already-discounted price, not the original base cost.
+     */
+    private fun resolveAddOnAmountCentsForType(
+        addOn: AddOnUiModel,
+        inputBd: BigDecimal,
+        decimalDigits: Int,
+        sourceAmountCents: Long
+    ): Long {
+        val isIncludedDiscountPercentage = addOn.mode == AddOnMode.INCLUDED &&
+            addOn.type == AddOnType.DISCOUNT &&
+            addOn.valueType == AddOnValueType.PERCENTAGE
+        return if (isIncludedDiscountPercentage) {
+            addOnCalculationService.calculateIncludedDiscountPercentageCents(
+                sourceAmountCents = sourceAmountCents,
+                discountPercentage = inputBd
+            )
+        } else {
+            addOnCalculationService.resolveAddOnAmountCents(
+                normalizedInput = inputBd,
+                valueType = addOn.valueType,
+                decimalDigits = decimalDigits,
+                sourceAmountCents = sourceAmountCents
+            )
+        }
     }
 
     private fun exchangeRateLabelOrEmpty(

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/AddOnEventHandlerTest.kt
@@ -1440,4 +1440,75 @@ class AddOnEventHandlerTest {
             assertEquals(500L, updated.groupAmountCents)
         }
     }
+
+    // ── INCLUDED DISCOUNT PERCENTAGE — Issue #1078 regression ────────────
+
+    @Nested
+    @DisplayName("resolveAddOnAmounts — INCLUDED DISCOUNT PERCENTAGE (issue 1078)")
+    inner class IncludedDiscountPercentage {
+
+        @Test
+        fun `10 percent on 1821_52 EUR resolves to 20239 cents, not buggy 18215`() = runTest {
+            // Reproduces the issue exactly: user enters 1821.52 EUR as the already-discounted
+            // price and adds a 10% INCLUDED DISCOUNT. The discount embedded in the original
+            // pre-discount price (2023.91 EUR) is 202.39 EUR, NOT 182.15 EUR (the buggy result).
+            uiState.value = baseState.copy(sourceAmount = "1821.52")
+            handler.bind(uiState, actions, this)
+            handler.handleAddOnAdded(AddOnType.DISCOUNT)
+            val id = uiState.value.addOns[0].id
+            handler.handleModeChanged(id, AddOnMode.INCLUDED)
+            handler.handleValueTypeChanged(id, AddOnValueType.PERCENTAGE)
+
+            handler.handleAmountChanged(id, "10")
+
+            val addOn = uiState.value.addOns[0]
+            assertEquals(20239L, addOn.resolvedAmountCents)
+            assertEquals(20239L, addOn.groupAmountCents)
+        }
+
+        @Test
+        fun `ON_TOP DISCOUNT PERCENTAGE still uses generic formula (no regression)`() = runTest {
+            // Same input, but ON_TOP DISCOUNT must remain pct × source / 100 = 18215.
+            uiState.value = baseState.copy(sourceAmount = "1821.52")
+            handler.bind(uiState, actions, this)
+            handler.handleAddOnAdded(AddOnType.DISCOUNT)
+            val id = uiState.value.addOns[0].id
+            handler.handleValueTypeChanged(id, AddOnValueType.PERCENTAGE)
+
+            handler.handleAmountChanged(id, "10")
+
+            assertEquals(AddOnMode.ON_TOP, uiState.value.addOns[0].mode)
+            assertEquals(18215L, uiState.value.addOns[0].resolvedAmountCents)
+        }
+
+        @Test
+        fun `INCLUDED non-discount PERCENTAGE still uses generic formula (no regression)`() = runTest {
+            // INCLUDED TIP 10% on 1821.52 must remain 18215 — only DISCOUNTs are corrected.
+            uiState.value = baseState.copy(sourceAmount = "1821.52")
+            handler.bind(uiState, actions, this)
+            handler.handleAddOnAdded(AddOnType.TIP)
+            val id = uiState.value.addOns[0].id
+            handler.handleModeChanged(id, AddOnMode.INCLUDED)
+            handler.handleValueTypeChanged(id, AddOnValueType.PERCENTAGE)
+
+            handler.handleAmountChanged(id, "10")
+
+            assertEquals(18215L, uiState.value.addOns[0].resolvedAmountCents)
+        }
+
+        @Test
+        fun `INCLUDED DISCOUNT EXACT is unaffected (already correct)`() = runTest {
+            // EXACT amounts pass through directly — must NOT route through the new formula.
+            uiState.value = baseState.copy(sourceAmount = "1821.52")
+            handler.bind(uiState, actions, this)
+            handler.handleAddOnAdded(AddOnType.DISCOUNT)
+            val id = uiState.value.addOns[0].id
+            handler.handleModeChanged(id, AddOnMode.INCLUDED)
+            // valueType defaults to EXACT — no change needed
+
+            handler.handleAmountChanged(id, "150")
+
+            assertEquals(15000L, uiState.value.addOns[0].resolvedAmountCents)
+        }
+    }
 }


### PR DESCRIPTION
Add a dedicated calculation for INCLUDED DISCOUNT percentages that computes the embedded discount as source × pct / (100 − pct) (AddOnCalculationService.calculateIncludedDiscountPercentageCents). Guard against non-positive source, non-positive pct, and pct ≥ 100. Route percentage-based INCLUDED DISCOUNTs in AddOnEventHandler to the new method while preserving the generic resolver for other cases. Add domain and UI tests reproducing the issue (#1078) and covering edge cases to prevent regression.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1078 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
