### PR TITLE
[SPLTRP-1089]: Fix `MissingFormatArgumentException` crash in `ExpenseDetailUiMapper` for foreign-currency add-ons and cash tranches

### DIFF
--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
@@ -253,6 +253,7 @@ class ExpenseDetailUiMapper(
             formattedRate = if (isForeign) {
                 resourceProvider.getString(
                     R.string.expense_detail_exchange_rate_full,
+                    addOn.currency,
                     formattingHelper.formatRateForDisplay(addOn.exchangeRate.toPlainString()),
                     groupCurrency
                 )
@@ -312,8 +313,9 @@ class ExpenseDetailUiMapper(
         if (withdrawal.exchangeRate.compareTo(BigDecimal.ZERO) == 0) return null
         return resourceProvider.getString(
             R.string.expense_detail_exchange_rate_full,
+            withdrawal.currency,
             formattingHelper.formatRateForDisplay(withdrawal.exchangeRate.toPlainString()),
-            withdrawal.currency
+            groupCurrency
         )
     }
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
@@ -933,41 +933,31 @@ class ExpenseDetailUiMapperTest {
         )
 
         @Test
-        fun `add-on formattedRate contains source currency, rate, and group currency in EN locale`() {
+        fun `add-on formattedRate renders as 1 source equals rate target in EN locale`() {
             every { localeProvider.getCurrentLocale() } returns Locale.US
             stubRateString()
             val expense = baseExpense.copy(addOns = listOf(foreignFeeAddOn))
 
             val result = mapper.map(expense, memberProfiles, currentUserId)
 
-            val formattedRate = result.addOns.first().formattedRate
-            assertNotNull(formattedRate)
-            // Source currency must appear
-            assertTrue(formattedRate!!.contains("GBP"))
-            // Target (group) currency must appear
-            assertTrue(formattedRate.contains("EUR"))
-            // Rate value must appear
-            assertTrue(formattedRate.contains("0.83"))
+            // Exact assertion verifies both presence and ordering: swapping source/target would fail.
+            assertEquals("1 GBP = 0.83 EUR", result.addOns.first().formattedRate)
         }
 
         @Test
-        fun `add-on formattedRate contains source currency, rate, and group currency in ES locale`() {
+        fun `add-on formattedRate renders as 1 source equals rate target in ES locale`() {
             every { localeProvider.getCurrentLocale() } returns Locale("es", "ES")
             stubRateString()
             val expense = baseExpense.copy(addOns = listOf(foreignFeeAddOn))
 
             val result = mapper.map(expense, memberProfiles, currentUserId)
 
-            val formattedRate = result.addOns.first().formattedRate
-            assertNotNull(formattedRate)
-            assertTrue(formattedRate!!.contains("GBP"))
-            assertTrue(formattedRate.contains("EUR"))
-            // ES locale formats 0.83 with a comma decimal separator
-            assertTrue(formattedRate.contains("0,83"))
+            // ES locale formats the rate with a comma decimal separator (0,83 not 0.83).
+            assertEquals("1 GBP = 0,83 EUR", result.addOns.first().formattedRate)
         }
 
         @Test
-        fun `cash tranche formattedRate contains source currency, rate, and group currency in EN locale`() {
+        fun `cash tranche formattedRate renders as 1 source equals rate target in EN locale`() {
             every { localeProvider.getCurrentLocale() } returns Locale.US
             stubRateString()
             val expense = baseExpense.copy(
@@ -988,18 +978,12 @@ class ExpenseDetailUiMapperTest {
                 withdrawalLookup = mapOf("w-gbp" to withdrawal)
             )
 
-            val formattedRate = result.cashTranches.first().formattedRate
-            assertNotNull(formattedRate)
-            // Source currency (withdrawal currency) must appear first
-            assertTrue(formattedRate!!.contains("GBP"))
-            // Target (group) currency must appear
-            assertTrue(formattedRate.contains("EUR"))
-            // Rate value must appear
-            assertTrue(formattedRate.contains("0.83"))
+            // Exact assertion verifies both presence and ordering: swapping source/target would fail.
+            assertEquals("1 GBP = 0.83 EUR", result.cashTranches.first().formattedRate)
         }
 
         @Test
-        fun `cash tranche formattedRate contains source currency, rate, and group currency in ES locale`() {
+        fun `cash tranche formattedRate renders as 1 source equals rate target in ES locale`() {
             every { localeProvider.getCurrentLocale() } returns Locale("es", "ES")
             stubRateString()
             val expense = baseExpense.copy(
@@ -1020,12 +1004,8 @@ class ExpenseDetailUiMapperTest {
                 withdrawalLookup = mapOf("w-gbp" to withdrawal)
             )
 
-            val formattedRate = result.cashTranches.first().formattedRate
-            assertNotNull(formattedRate)
-            assertTrue(formattedRate!!.contains("GBP"))
-            assertTrue(formattedRate.contains("EUR"))
-            // ES locale formats 0.83 with a comma decimal separator
-            assertTrue(formattedRate.contains("0,83"))
+            // ES locale formats the rate with a comma decimal separator (0,83 not 0.83).
+            assertEquals("1 GBP = 0,83 EUR", result.cashTranches.first().formattedRate)
         }
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
@@ -906,4 +906,126 @@ class ExpenseDetailUiMapperTest {
             assertFalse(result.isScheduledPastDue)
         }
     }
+
+    @Nested
+    inner class ForeignCurrencyRateFormatting {
+
+        // Stub that interpolates the actual args so assertions can verify all three components.
+        // The vararg is packed as an Array at invocation.args[1], so we access elements via the
+        // array rather than directly from the invocation args list.
+        private fun stubRateString() {
+            every {
+                resourceProvider.getString(any(), any(), any(), any())
+            } answers {
+                val varargs = it.invocation.args[1] as Array<*>
+                "1 ${varargs[0]} = ${varargs[1]} ${varargs[2]}"
+            }
+        }
+
+        private val foreignFeeAddOn = AddOn(
+            type = AddOnType.FEE,
+            mode = AddOnMode.ON_TOP,
+            valueType = AddOnValueType.EXACT,
+            amountCents = 500L,
+            currency = "GBP",
+            exchangeRate = BigDecimal("0.83"),
+            groupAmountCents = 415L
+        )
+
+        @Test
+        fun `add-on formattedRate contains source currency, rate, and group currency in EN locale`() {
+            every { localeProvider.getCurrentLocale() } returns Locale.US
+            stubRateString()
+            val expense = baseExpense.copy(addOns = listOf(foreignFeeAddOn))
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            val formattedRate = result.addOns.first().formattedRate
+            assertNotNull(formattedRate)
+            // Source currency must appear
+            assertTrue(formattedRate!!.contains("GBP"))
+            // Target (group) currency must appear
+            assertTrue(formattedRate.contains("EUR"))
+            // Rate value must appear
+            assertTrue(formattedRate.contains("0.83"))
+        }
+
+        @Test
+        fun `add-on formattedRate contains source currency, rate, and group currency in ES locale`() {
+            every { localeProvider.getCurrentLocale() } returns Locale("es", "ES")
+            stubRateString()
+            val expense = baseExpense.copy(addOns = listOf(foreignFeeAddOn))
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            val formattedRate = result.addOns.first().formattedRate
+            assertNotNull(formattedRate)
+            assertTrue(formattedRate!!.contains("GBP"))
+            assertTrue(formattedRate.contains("EUR"))
+            // ES locale formats 0.83 with a comma decimal separator
+            assertTrue(formattedRate.contains("0,83"))
+        }
+
+        @Test
+        fun `cash tranche formattedRate contains source currency, rate, and group currency in EN locale`() {
+            every { localeProvider.getCurrentLocale() } returns Locale.US
+            stubRateString()
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-gbp", amountConsumed = 500L))
+            )
+            val withdrawal = CashWithdrawal(
+                id = "w-gbp",
+                groupId = "group-456",
+                currency = "GBP",
+                exchangeRate = BigDecimal("0.83"),
+                withdrawalScope = PayerType.GROUP
+            )
+
+            val result = mapper.map(
+                expense,
+                memberProfiles,
+                currentUserId,
+                withdrawalLookup = mapOf("w-gbp" to withdrawal)
+            )
+
+            val formattedRate = result.cashTranches.first().formattedRate
+            assertNotNull(formattedRate)
+            // Source currency (withdrawal currency) must appear first
+            assertTrue(formattedRate!!.contains("GBP"))
+            // Target (group) currency must appear
+            assertTrue(formattedRate.contains("EUR"))
+            // Rate value must appear
+            assertTrue(formattedRate.contains("0.83"))
+        }
+
+        @Test
+        fun `cash tranche formattedRate contains source currency, rate, and group currency in ES locale`() {
+            every { localeProvider.getCurrentLocale() } returns Locale("es", "ES")
+            stubRateString()
+            val expense = baseExpense.copy(
+                cashTranches = listOf(CashTranche(withdrawalId = "w-gbp", amountConsumed = 500L))
+            )
+            val withdrawal = CashWithdrawal(
+                id = "w-gbp",
+                groupId = "group-456",
+                currency = "GBP",
+                exchangeRate = BigDecimal("0.83"),
+                withdrawalScope = PayerType.GROUP
+            )
+
+            val result = mapper.map(
+                expense,
+                memberProfiles,
+                currentUserId,
+                withdrawalLookup = mapOf("w-gbp" to withdrawal)
+            )
+
+            val formattedRate = result.cashTranches.first().formattedRate
+            assertNotNull(formattedRate)
+            assertTrue(formattedRate!!.contains("GBP"))
+            assertTrue(formattedRate.contains("EUR"))
+            // ES locale formats 0.83 with a comma decimal separator
+            assertTrue(formattedRate.contains("0,83"))
+        }
+    }
 }


### PR DESCRIPTION
Pass the source currency as an argument to the exchange-rate resource string and ensure the group currency is used as the target argument (reordered for withdrawals). This makes the formattedRate include: source currency, rate value, and group currency. Added unit tests (ForeignCurrencyRateFormatting) that stub the resourceProvider to verify formattedRate for add-ons and cash tranches in EN and ES locales (including locale-specific decimal separator checks).

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1089 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
