### PR TITLE
[SPLTRP-1091]: Refine `ExpenseDetailScreen`: split chip row into two lines, center hero amount, replace "IMPORTE" with expense scope label, and personalize payer text with "You"

### DIFF
--- a/core/common/src/main/kotlin/es/pedrazamiguez/splittrip/core/common/util/DisplayNameResolver.kt
+++ b/core/common/src/main/kotlin/es/pedrazamiguez/splittrip/core/common/util/DisplayNameResolver.kt
@@ -1,0 +1,42 @@
+package es.pedrazamiguez.splittrip.core.common.util
+
+/**
+ * Stateless utility for resolving a human-readable display name for a given user ID.
+ *
+ * Centralises two concerns that were previously duplicated across feature mappers:
+ * 1. The fallback hierarchy: displayName → email → userId.
+ * 2. "You" personalisation: when [userId] matches [currentUserId] the caller-supplied
+ *    [youLabel] is returned instead of the real name, keeping the UI personal.
+ *
+ * Features that already have `MemberOptionUiModel.isCurrentUser` can pass
+ * `currentUserId = if (member.isCurrentUser) userId else null` to trigger the same logic.
+ */
+object DisplayNameResolver {
+
+    /**
+     * Resolves the best display name for [userId].
+     *
+     * @param userId        The user ID to resolve. Returns `""` immediately when `null`.
+     * @param currentUserId The authenticated user's ID. When equal to [userId], [youLabel] is
+     *                      returned to avoid showing the real name ("Paid by you" UX).
+     * @param youLabel      Localised string for the current user (e.g. `"You"` / `"tú"`).
+     * @param displayName   The target user's display name; may be `null` or blank.
+     * @param email         The target user's email, used as a fallback when [displayName] is
+     *                      absent. Defaults to `""`.
+     * @return The resolved display name, fallen back through the priority chain, or `""` when
+     *         [userId] is `null`.
+     */
+    fun resolve(
+        userId: String?,
+        currentUserId: String?,
+        youLabel: String,
+        displayName: String?,
+        email: String = ""
+    ): String {
+        if (userId == null) return ""
+        if (userId == currentUserId) return youLabel
+        return displayName?.takeIf { it.isNotBlank() }
+            ?: email.takeIf { it.isNotBlank() }
+            ?: userId
+    }
+}

--- a/core/common/src/test/kotlin/es/pedrazamiguez/splittrip/core/common/util/DisplayNameResolverTest.kt
+++ b/core/common/src/test/kotlin/es/pedrazamiguez/splittrip/core/common/util/DisplayNameResolverTest.kt
@@ -1,0 +1,147 @@
+package es.pedrazamiguez.splittrip.core.common.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class DisplayNameResolverTest {
+
+    @Nested
+    inner class NullOrMissingUser {
+
+        @Test
+        fun `returns empty string when userId is null`() {
+            val result = DisplayNameResolver.resolve(
+                userId = null,
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = "Alice"
+            )
+
+            assertEquals("", result)
+        }
+
+        @Test
+        fun `returns userId as last resort when display name and email are both blank`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-unknown",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = null,
+                email = ""
+            )
+
+            assertEquals("user-unknown", result)
+        }
+
+        @Test
+        fun `returns userId as last resort when display name is blank and email is blank`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-unknown",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = "   ",
+                email = "  "
+            )
+
+            assertEquals("user-unknown", result)
+        }
+    }
+
+    @Nested
+    inner class CurrentUser {
+
+        @Test
+        fun `returns youLabel when userId matches currentUserId`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-1",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = "Alice",
+                email = "alice@example.com"
+            )
+
+            assertEquals("You", result)
+        }
+
+        @Test
+        fun `returns youLabel in Spanish locale form when provided`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-1",
+                currentUserId = "user-1",
+                youLabel = "tú",
+                displayName = "Alice"
+            )
+
+            assertEquals("tú", result)
+        }
+    }
+
+    @Nested
+    inner class OtherUser {
+
+        @Test
+        fun `returns displayName when present and not current user`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-2",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = "Bob",
+                email = "bob@example.com"
+            )
+
+            assertEquals("Bob", result)
+        }
+
+        @Test
+        fun `returns email when displayName is null`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-2",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = null,
+                email = "bob@example.com"
+            )
+
+            assertEquals("bob@example.com", result)
+        }
+
+        @Test
+        fun `returns email when displayName is blank`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-2",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = "  ",
+                email = "bob@example.com"
+            )
+
+            assertEquals("bob@example.com", result)
+        }
+
+        @Test
+        fun `returns userId when both displayName and email are null or blank`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-2",
+                currentUserId = "user-1",
+                youLabel = "You",
+                displayName = null,
+                email = ""
+            )
+
+            assertEquals("user-2", result)
+        }
+
+        @Test
+        fun `does not return youLabel for non-current user even when currentUserId is null`() {
+            val result = DisplayNameResolver.resolve(
+                userId = "user-2",
+                currentUserId = null,
+                youLabel = "You",
+                displayName = "Charlie"
+            )
+
+            assertEquals("Charlie", result)
+        }
+    }
+}

--- a/features/contributions/src/main/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/mapper/AddContributionUiMapper.kt
+++ b/features/contributions/src/main/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/mapper/AddContributionUiMapper.kt
@@ -76,6 +76,9 @@ class AddContributionUiMapper(
     ): String {
         if (userId == null) return ""
         val member = members.firstOrNull { it.userId == userId } ?: return ""
+        // When no youLabel is provided, skip "you" personalisation and return the display
+        // name directly — avoids blank labels at call sites that don't supply the string.
+        if (youLabel.isBlank()) return member.displayName
         return DisplayNameResolver.resolve(
             userId = userId,
             currentUserId = if (member.isCurrentUser) userId else null,

--- a/features/contributions/src/main/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/mapper/AddContributionUiMapper.kt
+++ b/features/contributions/src/main/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/mapper/AddContributionUiMapper.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.features.contribution.presentation.mapper
 
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
+import es.pedrazamiguez.splittrip.core.common.util.DisplayNameResolver
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatAmountWithCurrency
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.resolveCurrencySymbol
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.MemberOptionUiModel
@@ -63,10 +64,23 @@ class AddContributionUiMapper(
     /**
      * Looks up the display name for a given userId from a pre-mapped member list.
      *
-     * @return The member's display name, or an empty string if not found.
+     * Returns [youLabel] when the member has [MemberOptionUiModel.isCurrentUser] set to `true`,
+     * delegating "you" personalisation to [DisplayNameResolver].
+     *
+     * @return The member's display name or [youLabel] for the current user; `""` if not found.
      */
     fun resolveDisplayName(
         userId: String?,
-        members: ImmutableList<MemberOptionUiModel>
-    ): String = members.firstOrNull { it.userId == userId }?.displayName ?: ""
+        members: ImmutableList<MemberOptionUiModel>,
+        youLabel: String = ""
+    ): String {
+        if (userId == null) return ""
+        val member = members.firstOrNull { it.userId == userId } ?: return ""
+        return DisplayNameResolver.resolve(
+            userId = userId,
+            currentUserId = if (member.isCurrentUser) userId else null,
+            youLabel = youLabel,
+            displayName = member.displayName
+        )
+    }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/ExpenseDetailPrimitives.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/ExpenseDetailPrimitives.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.component.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -55,7 +56,75 @@ internal fun CategoryChip(
     }
 }
 
-/** Neutral surface chip. Used for payment method and payment status. */
+/** Filled secondary-container chip with icon + label. Used for the payment method in the hero. */
+@Composable
+internal fun MethodChip(
+    icon: ImageVector,
+    label: String
+) {
+    Row(
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(horizontal = MaterialTheme.spacing.Small, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onSecondaryContainer
+        )
+        CaptionText(text = label, color = MaterialTheme.colorScheme.onSecondaryContainer)
+    }
+}
+
+/** Filled tertiary-container chip with icon + label. Used for the payment status in the hero. */
+@Composable
+internal fun StatusBadgeChip(
+    icon: ImageVector,
+    label: String
+) {
+    Row(
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.tertiaryContainer)
+            .padding(horizontal = MaterialTheme.spacing.Small, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onTertiaryContainer
+        )
+        CaptionText(text = label, color = MaterialTheme.colorScheme.onTertiaryContainer)
+    }
+}
+
+/**
+ * Outlined chip for the date in the hero. Uses a border tinted with [MaterialTheme.colorScheme.tertiary]
+ * to visually relate to the status chip without competing with it.
+ */
+@Composable
+internal fun DateChip(text: String) {
+    Box(
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.small)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.tertiary,
+                shape = MaterialTheme.shapes.small
+            )
+            .padding(horizontal = MaterialTheme.spacing.Small, vertical = 4.dp)
+    ) {
+        CaptionText(text = text, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+/** Neutral surface chip. Used for standalone status text without an icon. */
 @Composable
 internal fun StatusChip(text: String) {
     Box(

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/HeroSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/HeroSection.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -100,7 +101,8 @@ private fun HeroAmountContent(expense: ExpenseDetailUiModel) {
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Medium,
         textAlign = TextAlign.Center,
-        maxLines = 1
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
     )
     Text(
         text = expense.formattedGroupAmount,
@@ -118,7 +120,8 @@ private fun HeroAmountContent(expense: ExpenseDetailUiModel) {
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Medium,
         textAlign = TextAlign.Center,
-        maxLines = 1
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
     )
     if (expense.vendorText != null) {
         Text(
@@ -128,7 +131,8 @@ private fun HeroAmountContent(expense: ExpenseDetailUiModel) {
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Medium,
             textAlign = TextAlign.Center,
-            maxLines = 1
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
     if (expense.isForeignCurrency && expense.formattedSourceAmount != null) {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/HeroSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/HeroSection.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,14 +20,13 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
-import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
-import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Calendar
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.AmountText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.CaptionText
@@ -38,12 +35,11 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toIco
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDetailUiModel
 
 private val HERO_AMOUNT_SIZE = 40.sp
-private val HERO_ICON_SIZE = 14.dp
 private val RECEIPT_THUMBNAIL_HEIGHT = 160.dp
 
 @Composable
 internal fun HeroSection(expense: ExpenseDetailUiModel) {
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Small)) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Medium)) {
         HeroTagRow(expense)
         // §4.4 ambient shadow: hero is the only screen element warranting an inset
         // tier so the page's information hierarchy reads top-to-bottom by elevation.
@@ -62,54 +58,77 @@ internal fun HeroSection(expense: ExpenseDetailUiModel) {
 @Composable
 private fun HeroTagRow(expense: ExpenseDetailUiModel) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Small),
-        verticalAlignment = Alignment.CenterVertically
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top
     ) {
-        CategoryChip(
-            icon = expense.category.toIconVector(),
-            label = expense.categoryText
-        )
-        StatusChip(text = expense.paymentMethodText)
-        StatusChip(text = expense.paymentStatusText)
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        // Left column: identity chips (category + payment method)
+        Column(
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Small)
         ) {
-            Icon(
-                imageVector = TablerIcons.Outline.Calendar,
-                contentDescription = null,
-                modifier = Modifier.size(HERO_ICON_SIZE),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            CategoryChip(
+                icon = expense.category.toIconVector(),
+                label = expense.categoryText
             )
-            CaptionText(
-                text = expense.dateText,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+            MethodChip(
+                icon = expense.paymentMethodIcon,
+                label = expense.paymentMethodText
             )
+        }
+
+        // Right column: state chips (payment status + date)
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Small)
+        ) {
+            StatusBadgeChip(
+                icon = expense.paymentStatusIcon,
+                label = expense.paymentStatusText
+            )
+            DateChip(text = expense.dateText)
         }
     }
 }
 
 @Composable
 private fun HeroAmountContent(expense: ExpenseDetailUiModel) {
-    CaptionText(
-        text = stringResource(R.string.expense_review_amount).uppercase(),
-        color = MaterialTheme.colorScheme.onSurfaceVariant
+    Text(
+        text = expense.expenseScopeLabel.uppercase(),
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Medium,
+        textAlign = TextAlign.Center,
+        maxLines = 1
     )
     Text(
         text = expense.formattedGroupAmount,
+        modifier = Modifier.fillMaxWidth(),
         style = MaterialTheme.typography.displaySmall,
         fontWeight = FontWeight.ExtraBold,
         color = MaterialTheme.colorScheme.primary,
-        fontSize = HERO_AMOUNT_SIZE
+        fontSize = HERO_AMOUNT_SIZE,
+        textAlign = TextAlign.Center
     )
-    CaptionText(
+    Text(
         text = expense.paidByText,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Medium,
+        textAlign = TextAlign.Center,
+        maxLines = 1
     )
     if (expense.vendorText != null) {
-        CaptionText(
+        Text(
             text = expense.vendorText,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center,
+            maxLines = 1
         )
     }
     if (expense.isForeignCurrency && expense.formattedSourceAmount != null) {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/ProvenanceSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/ProvenanceSection.kt
@@ -9,11 +9,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.SyncStatusIndicator
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.CaptionText
-import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDetailUiModel
 
 @Composable
@@ -30,7 +28,7 @@ internal fun ProvenanceSection(expense: ExpenseDetailUiModel) {
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.ExtraSmall)) {
             CaptionText(
-                text = stringResource(R.string.expense_detail_created_by, expense.createdByText),
+                text = expense.createdByText,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             CaptionText(

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/SplitBreakdownSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/SplitBreakdownSection.kt
@@ -47,7 +47,10 @@ internal fun SplitBreakdownSection(
     splits: ImmutableList<SplitDetailUiModel>,
     splitGroups: ImmutableList<SubunitSplitGroupUiModel>
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Small)) {
+    Column(
+        modifier = Modifier.padding(top = MaterialTheme.spacing.Small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Small)
+    ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/chips/CondensedChips.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/chips/CondensedChips.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
@@ -37,6 +38,8 @@ import es.pedrazamiguez.splittrip.features.expense.R
  * @param onItemSelected Callback when an item is selected.
  * @param itemId Extracts the unique ID from an item.
  * @param itemLabel Extracts the display label from an item.
+ * @param itemIcon Optional: extracts an [ImageVector] shown as a leading icon when unselected.
+ *                 When the chip is selected the checkmark replaces it (M3 filter-chip convention).
  * @param visibleCount How many chips to show before collapsing into "More".
  * @param modifier Modifier for the FlowRow container.
  */
@@ -49,6 +52,7 @@ fun <T> CondensedChips(
     onItemSelected: (String) -> Unit,
     itemId: (T) -> String,
     itemLabel: (T) -> String,
+    itemIcon: ((T) -> ImageVector?)? = null,
     visibleCount: Int = 3,
     modifier: Modifier = Modifier
 ) {
@@ -98,10 +102,14 @@ fun <T> CondensedChips(
                 label = itemLabel(item),
                 selected = isSelected,
                 onClick = { onItemSelected(id) },
-                leadingIcon = if (isSelected) {
-                    { Icon(TablerIcons.Outline.Check, contentDescription = null) }
-                } else {
-                    null
+                leadingIcon = when {
+                    isSelected -> {
+                        { Icon(TablerIcons.Outline.Check, contentDescription = null) }
+                    }
+                    itemIcon != null -> itemIcon(item)?.let { icon ->
+                        { Icon(icon, contentDescription = null) }
+                    }
+                    else -> null
                 }
             )
         }
@@ -112,7 +120,8 @@ fun <T> CondensedChips(
                 selectedId = selectedId,
                 onItemSelected = onItemSelected,
                 itemId = itemId,
-                itemLabel = itemLabel
+                itemLabel = itemLabel,
+                itemIcon = itemIcon
             )
         }
     }
@@ -124,7 +133,8 @@ private fun <T> OverflowPassportChip(
     selectedId: String?,
     onItemSelected: (String) -> Unit,
     itemId: (T) -> String,
-    itemLabel: (T) -> String
+    itemLabel: (T) -> String,
+    itemIcon: ((T) -> ImageVector?)? = null
 ) {
     Box {
         var expanded by remember { mutableStateOf(false) }
@@ -149,6 +159,7 @@ private fun <T> OverflowPassportChip(
         ) {
             overflowItems.forEach { item ->
                 val id = itemId(item)
+                val isSelected = selectedId == id
                 DropdownMenuItem(
                     text = {
                         Text(
@@ -161,10 +172,14 @@ private fun <T> OverflowPassportChip(
                         onItemSelected(id)
                         expanded = false
                     },
-                    leadingIcon = if (selectedId == id) {
-                        { Icon(TablerIcons.Outline.Check, contentDescription = null) }
-                    } else {
-                        null
+                    leadingIcon = when {
+                        isSelected -> {
+                            { Icon(TablerIcons.Outline.Check, contentDescription = null) }
+                        }
+                        itemIcon != null -> itemIcon(item)?.let { icon ->
+                            { Icon(icon, contentDescription = null) }
+                        }
+                        else -> null
                     }
                 )
             }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/payment/PaymentMethodSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/payment/PaymentMethodSection.kt
@@ -41,6 +41,7 @@ internal fun PaymentMethodSection(
             },
             itemId = { it.id },
             itemLabel = { it.displayText },
+            itemIcon = { it.icon },
             visibleCount = 6
         )
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/extensions/PaymentMethodExtensions.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/extensions/PaymentMethodExtensions.kt
@@ -1,6 +1,13 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.extensions
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.vector.ImageVector
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.BuildingBank
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CashBanknote
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CreditCard
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Qrcode
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Wallet
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.features.expense.R
 
@@ -17,4 +24,18 @@ fun PaymentMethod.toStringRes(): Int = when (this) {
     PaymentMethod.ALIPAY -> R.string.payment_method_alipay
     PaymentMethod.WECHAT_PAY -> R.string.payment_method_wechat_pay
     PaymentMethod.OTHER -> R.string.payment_method_other
+}
+
+fun PaymentMethod.toIconVector(): ImageVector = when (this) {
+    PaymentMethod.CASH -> TablerIcons.Outline.CashBanknote
+    PaymentMethod.BIZUM -> TablerIcons.Outline.Qrcode
+    PaymentMethod.PIX -> TablerIcons.Outline.Qrcode
+    PaymentMethod.CREDIT_CARD -> TablerIcons.Outline.CreditCard
+    PaymentMethod.DEBIT_CARD -> TablerIcons.Outline.CreditCard
+    PaymentMethod.BANK_TRANSFER -> TablerIcons.Outline.BuildingBank
+    PaymentMethod.PAYPAL -> TablerIcons.Outline.Wallet
+    PaymentMethod.VENMO -> TablerIcons.Outline.Wallet
+    PaymentMethod.ALIPAY -> TablerIcons.Outline.Qrcode
+    PaymentMethod.WECHAT_PAY -> TablerIcons.Outline.Qrcode
+    PaymentMethod.OTHER -> TablerIcons.Outline.Wallet
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/extensions/PaymentStatusExtensions.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/extensions/PaymentStatusExtensions.kt
@@ -1,6 +1,12 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.extensions
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.vector.ImageVector
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Calendar
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CircleCheck
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Clock
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.X
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.features.expense.R
 
@@ -11,4 +17,12 @@ fun PaymentStatus.toStringRes(): Int = when (this) {
     PaymentStatus.FINISHED -> R.string.payment_status_finished
     PaymentStatus.SCHEDULED -> R.string.payment_status_scheduled
     PaymentStatus.CANCELLED -> R.string.payment_status_cancelled
+}
+
+fun PaymentStatus.toIconVector(): ImageVector = when (this) {
+    PaymentStatus.FINISHED -> TablerIcons.Outline.CircleCheck
+    PaymentStatus.RECEIVED -> TablerIcons.Outline.CircleCheck
+    PaymentStatus.PENDING -> TablerIcons.Outline.Clock
+    PaymentStatus.SCHEDULED -> TablerIcons.Outline.Calendar
+    PaymentStatus.CANCELLED -> TablerIcons.Outline.X
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseOptionsUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseOptionsUiMapper.kt
@@ -15,6 +15,7 @@ import es.pedrazamiguez.splittrip.domain.model.Currency
 import es.pedrazamiguez.splittrip.domain.model.WithdrawalPoolOption
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toFundingSourceStringRes
+import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toIconVector
 import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toStringRes
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.CashTranchePreviewUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.CategoryUiModel
@@ -57,7 +58,8 @@ class AddExpenseOptionsUiMapper(
         methods.map { method ->
             PaymentMethodUiModel(
                 id = method.name,
-                displayText = resourceProvider.getString(method.toStringRes())
+                displayText = resourceProvider.getString(method.toStringRes()),
+                icon = method.toIconVector()
             )
         }.toImmutableList()
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
 
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.core.common.util.DisplayNameResolver
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
 import es.pedrazamiguez.splittrip.domain.enums.AddOnType
@@ -16,6 +17,7 @@ import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toIconVector
 import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toStringRes
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnDetailUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.CashTrancheDetailUiModel
@@ -43,7 +45,13 @@ class ExpenseDetailUiMapper(
     ): ExpenseDetailUiModel {
         val (scheduledBadgeText, isScheduledPastDue) = buildScheduledBadge(expense)
         val isForeignCurrency = expense.sourceCurrency != expense.groupCurrency
-        val paidByName = resolveDisplayName(expense.createdBy, memberProfiles)
+        val youLabel = resourceProvider.getString(R.string.you_label)
+        val paidByName = resolveDisplayName(expense.createdBy, memberProfiles, currentUserId, youLabel)
+        val paidByText = if (expense.createdBy == currentUserId) {
+            resourceProvider.getString(R.string.paid_by_you)
+        } else {
+            resourceProvider.getString(R.string.paid_by, paidByName)
+        }
 
         val effectiveTotal = if (expense.addOns.isNotEmpty()) {
             addOnCalculationService.calculateEffectiveGroupAmount(expense.groupAmount, expense.addOns)
@@ -64,7 +72,7 @@ class ExpenseDetailUiMapper(
             null
         }
 
-        val (soloSplits, splitGroups) = mapSplits(expense, memberProfiles, currentUserId, subunitNameLookup)
+        val (soloSplits, splitGroups) = mapSplits(expense, memberProfiles, currentUserId, youLabel, subunitNameLookup)
 
         return ExpenseDetailUiModel(
             id = expense.id,
@@ -90,9 +98,17 @@ class ExpenseDetailUiMapper(
             },
             isForeignCurrency = isForeignCurrency,
             paymentMethodText = resourceProvider.getString(expense.paymentMethod.toStringRes()),
+            paymentMethodIcon = expense.paymentMethod.toIconVector(),
             paymentStatusText = resourceProvider.getString(expense.paymentStatus.toStringRes()),
-            paidByText = resourceProvider.getString(R.string.paid_by, paidByName),
-            dateText = formattingHelper.formatShortDate(expense.createdAt),
+            paymentStatusIcon = expense.paymentStatus.toIconVector(),
+            expenseScopeLabel = buildExpenseScopeLabel(expense.payerType),
+            paidByText = paidByText,
+            dateText = if (expense.paymentStatus == PaymentStatus.SCHEDULED && expense.dueDate != null) {
+                // For scheduled expenses the chip shows the due date, not the creation date.
+                formattingHelper.formatShortDate(expense.dueDate)
+            } else {
+                formattingHelper.formatShortDate(expense.createdAt)
+            },
             vendorText = expense.vendor?.takeIf { it.isNotBlank() },
             notesText = expense.notes?.takeIf { it.isNotBlank() },
             scheduledBadgeText = scheduledBadgeText,
@@ -127,7 +143,11 @@ class ExpenseDetailUiMapper(
                 subunitNameLookup
             ),
             receiptUri = expense.receiptLocalUri,
-            createdByText = paidByName,
+            createdByText = if (expense.createdBy == currentUserId) {
+                resourceProvider.getString(R.string.expense_detail_created_by_you)
+            } else {
+                resourceProvider.getString(R.string.expense_detail_created_by, paidByName)
+            },
             createdAtText = formattingHelper.formatShortDate(expense.createdAt),
             syncStatus = expense.syncStatus
         )
@@ -159,10 +179,11 @@ class ExpenseDetailUiMapper(
         expense: Expense,
         memberProfiles: Map<String, User>,
         currentUserId: String?,
+        youLabel: String,
         subunitNameLookup: Map<String, String>
     ): Pair<ImmutableList<SplitDetailUiModel>, ImmutableList<SubunitSplitGroupUiModel>> {
         val rows = expense.splits.map { split ->
-            split to mapSplitRow(split, expense, memberProfiles, currentUserId, subunitNameLookup)
+            split to mapSplitRow(split, expense, memberProfiles, currentUserId, youLabel, subunitNameLookup)
         }
         val solo = rows.filter { it.first.subunitId.isNullOrBlank() }.map { it.second }
         val grouped = rows
@@ -219,6 +240,7 @@ class ExpenseDetailUiMapper(
         expense: Expense,
         memberProfiles: Map<String, User>,
         currentUserId: String?,
+        youLabel: String,
         subunitNameLookup: Map<String, String>
     ): SplitDetailUiModel {
         val groupAmountCents = expenseCalculatorService.computeProportionalAmount(
@@ -241,7 +263,7 @@ class ExpenseDetailUiMapper(
             "${formattingHelper.formatForDisplay(pct.toPlainString(), 1)}%"
         }
         return SplitDetailUiModel(
-            displayName = resolveDisplayName(split.userId, memberProfiles),
+            displayName = resolveDisplayName(split.userId, memberProfiles, currentUserId, youLabel),
             formattedAmount = formattedAmount,
             formattedSourceAmount = formattedSourceAmount,
             shareText = shareText,
@@ -387,15 +409,30 @@ class ExpenseDetailUiMapper(
         } else {
             resourceProvider.getString(
                 R.string.expense_paid_by_member,
-                resolveDisplayName(payerId, memberProfiles)
+                resolveDisplayName(payerId, memberProfiles, currentUserId = null, youLabel = "")
             )
         }
     }
 
-    private fun resolveDisplayName(userId: String, memberProfiles: Map<String, User>): String {
-        val user = memberProfiles[userId] ?: return userId
-        return user.displayName?.takeIf { it.isNotBlank() }
-            ?: user.email.takeIf { it.isNotBlank() }
-            ?: userId
+    private fun buildExpenseScopeLabel(payerType: PayerType): String = when (payerType) {
+        PayerType.GROUP -> resourceProvider.getString(R.string.expense_scope_group)
+        PayerType.SUBUNIT -> resourceProvider.getString(R.string.expense_scope_subunit)
+        PayerType.USER -> resourceProvider.getString(R.string.expense_scope_personal)
+    }
+
+    private fun resolveDisplayName(
+        userId: String,
+        memberProfiles: Map<String, User>,
+        currentUserId: String?,
+        youLabel: String
+    ): String {
+        val user = memberProfiles[userId]
+        return DisplayNameResolver.resolve(
+            userId = userId,
+            currentUserId = currentUserId,
+            youLabel = youLabel,
+            displayName = user?.displayName,
+            email = user?.email ?: ""
+        )
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/ExpenseDetailUiModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/ExpenseDetailUiModel.kt
@@ -1,5 +1,9 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.model
 
+import androidx.compose.ui.graphics.vector.ImageVector
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CircleCheck
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CreditCard
 import es.pedrazamiguez.splittrip.domain.enums.ExpenseCategory
 import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import kotlinx.collections.immutable.ImmutableList
@@ -23,7 +27,11 @@ data class ExpenseDetailUiModel(
 
     // Metadata
     val paymentMethodText: String = "",
+    val paymentMethodIcon: ImageVector = TablerIcons.Outline.CreditCard,
     val paymentStatusText: String = "",
+    val paymentStatusIcon: ImageVector = TablerIcons.Outline.CircleCheck,
+    /** Contextual role of this expense — e.g. "group expense", "personal expense". */
+    val expenseScopeLabel: String = "",
     val paidByText: String = "",
     val dateText: String = "",
     val vendorText: String? = null,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/PaymentMethodUiModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/model/PaymentMethodUiModel.kt
@@ -1,3 +1,11 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.model
 
-data class PaymentMethodUiModel(val id: String, val displayText: String)
+import androidx.compose.ui.graphics.vector.ImageVector
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CreditCard
+
+data class PaymentMethodUiModel(
+    val id: String,
+    val displayText: String,
+    val icon: ImageVector = TablerIcons.Outline.CreditCard
+)

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -25,6 +25,8 @@
     <string name="expense_error_config_retry_hint">Revisa tu conexión e inténtalo de nuevo</string>
     <string name="expense_error_retry_button">Reintentar</string>
     <string name="paid_by">Pagado por %1$s</string>
+    <string name="paid_by_you">Pagado por ti</string>
+    <string name="you_label">tú</string>
 
     <!-- Expense Actions -->
     <string name="expense_actions_title">Gasto \"%1$s\"</string>
@@ -259,6 +261,7 @@
     <string name="expense_detail_section_split">Desglose de reparto</string>
     <string name="expense_detail_section_addons">Extras</string>
     <string name="expense_detail_created_by">Añadido por %1$s</string>
+    <string name="expense_detail_created_by_you">Añadido por ti</string>
     <string name="expense_detail_split_you_badge">Tú</string>
     <string name="expense_detail_section_breakdown">Desglose</string>
     <string name="expense_detail_breakdown_base_cost">Coste base</string>
@@ -269,6 +272,11 @@
     <string name="expense_detail_receipt_thumbnail_cd">Foto del recibo</string>
     <string name="expense_detail_addon_mode_included">Incluido</string>
     <string name="expense_detail_addon_mode_on_top">Sumado</string>
+
+    <!-- Expense scope labels — shown as the hero card header in place of "IMPORTE" -->
+    <string name="expense_scope_group">gasto grupal</string>
+    <string name="expense_scope_subunit">gasto de subunidad</string>
+    <string name="expense_scope_personal">gasto personal</string>
 
     <!-- Withdrawal pool selection — shown in Exchange Rate step when multiple pools have funds -->
     <string name="add_expense_cash_pool_selection_title">Usar efectivo de</string>

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="expense_error_config_retry_hint">Check your connection and try again</string>
     <string name="expense_error_retry_button">Try again</string>
     <string name="paid_by">Paid by %1$s</string>
+    <string name="paid_by_you">Paid by you</string>
+    <string name="you_label">You</string>
 
     <!-- Expense Actions -->
     <string name="expense_actions_title">Expense \"%1$s\"</string>
@@ -258,6 +260,7 @@
     <string name="expense_detail_section_split">Split breakdown</string>
     <string name="expense_detail_section_addons">Add-ons</string>
     <string name="expense_detail_created_by">Added by %1$s</string>
+    <string name="expense_detail_created_by_you">Added by you</string>
     <string name="expense_detail_split_you_badge">You</string>
     <string name="expense_detail_section_breakdown">Breakdown</string>
     <string name="expense_detail_breakdown_base_cost">Base cost</string>
@@ -268,6 +271,11 @@
     <string name="expense_detail_receipt_thumbnail_cd">Receipt photo</string>
     <string name="expense_detail_addon_mode_included">Included</string>
     <string name="expense_detail_addon_mode_on_top">On top</string>
+
+    <!-- Expense scope labels — shown as the hero card header in place of "IMPORTE" -->
+    <string name="expense_scope_group">group expense</string>
+    <string name="expense_scope_subunit">subunit expense</string>
+    <string name="expense_scope_personal">personal expense</string>
 
     <!-- Withdrawal pool selection — shown in Exchange Rate step when multiple pools have funds -->
     <string name="add_expense_cash_pool_selection_title">Draw cash from</string>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
@@ -237,7 +237,8 @@ class ExpenseDetailUiMapperTest {
 
             val currentUserSplit = result.splits.find { it.isCurrentUser }
             assertNotNull(currentUserSplit)
-            assertEquals("Alice", currentUserSplit?.displayName)
+            // Current user's split shows the localised "You" label, not the raw profile name
+            assertEquals("translated_string", currentUserSplit?.displayName)
         }
 
         @Test
@@ -306,7 +307,20 @@ class ExpenseDetailUiMapperTest {
         }
 
         @Test
-        fun `resolves display name from member profiles`() {
+        fun `resolves display name from member profiles — other user gets profile name`() {
+            val expense = baseExpense.copy(
+                splits = listOf(
+                    ExpenseSplit(userId = otherUserId, amountCents = 5000L)
+                )
+            )
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            assertEquals("Bob", result.splits.first().displayName)
+        }
+
+        @Test
+        fun `resolves display name — current user gets you label`() {
             val expense = baseExpense.copy(
                 splits = listOf(
                     ExpenseSplit(userId = currentUserId, amountCents = 5000L)
@@ -315,7 +329,8 @@ class ExpenseDetailUiMapperTest {
 
             val result = mapper.map(expense, memberProfiles, currentUserId)
 
-            assertEquals("Alice", result.splits.first().displayName)
+            // The mapper resolves currentUserId to the localised "You" label (mocked as "translated_string")
+            assertEquals("translated_string", result.splits.first().displayName)
         }
 
         @Test
@@ -1195,6 +1210,95 @@ class ExpenseDetailUiMapperTest {
 
             // ES locale formats the rate with a comma decimal separator (0,83 not 0.83).
             assertEquals("1 GBP = 0,83 EUR", result.cashTranches.first().formattedRate)
+        }
+    }
+
+    @Nested
+    inner class PersonalisedPaidByText {
+
+        @Test
+        fun `paidByText uses paid_by_you when createdBy is the current user`() {
+            // The baseExpense already has createdBy = currentUserId
+            every { resourceProvider.getString(any()) } returns "Paid by you"
+
+            val result = mapper.map(baseExpense, memberProfiles, currentUserId)
+
+            // paid_by_you is a no-args string resource → getString(R.string.paid_by_you)
+            assertEquals("Paid by you", result.paidByText)
+        }
+
+        @Test
+        fun `paidByText uses paid_by template when createdBy is another member`() {
+            val expense = baseExpense.copy(createdBy = otherUserId)
+            every { resourceProvider.getString(any(), any()) } returns "Paid by Bob"
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            // paid_by is a template resource → getString(R.string.paid_by, paidByName)
+            assertEquals("Paid by Bob", result.paidByText)
+        }
+
+        @Test
+        fun `paidByText contains member display name when payer is another member`() {
+            val expense = baseExpense.copy(createdBy = otherUserId)
+            // Capture the actual name passed into the template
+            every { resourceProvider.getString(any(), "Bob") } returns "Paid by Bob"
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            assertEquals("Paid by Bob", result.paidByText)
+        }
+    }
+
+    @Nested
+    inner class ExpenseScopeLabel {
+
+        @Test
+        fun `expenseScopeLabel maps to scope_group for GROUP payer`() {
+            val expense = baseExpense.copy(payerType = PayerType.GROUP)
+            every { resourceProvider.getString(any()) } returns "Group expense"
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            assertEquals("Group expense", result.expenseScopeLabel)
+        }
+
+        @Test
+        fun `expenseScopeLabel maps to scope_personal for USER payer`() {
+            val expense = baseExpense.copy(payerType = PayerType.USER)
+            every { resourceProvider.getString(any()) } returns "Personal"
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            assertEquals("Personal", result.expenseScopeLabel)
+        }
+
+        @Test
+        fun `expenseScopeLabel maps to scope_subunit for SUBUNIT payer`() {
+            val expense = baseExpense.copy(payerType = PayerType.SUBUNIT)
+            every { resourceProvider.getString(any()) } returns "Subunit"
+
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+
+            assertEquals("Subunit", result.expenseScopeLabel)
+        }
+    }
+
+    @Nested
+    inner class IconFields {
+
+        @Test
+        fun `paymentMethodIcon is non-null for CREDIT_CARD`() {
+            val result = mapper.map(baseExpense, memberProfiles, currentUserId)
+
+            assertNotNull(result.paymentMethodIcon)
+        }
+
+        @Test
+        fun `paymentStatusIcon is non-null for FINISHED`() {
+            val result = mapper.map(baseExpense, memberProfiles, currentUserId)
+
+            assertNotNull(result.paymentStatusIcon)
         }
     }
 }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/mapper/AddCashWithdrawalUiMapper.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/mapper/AddCashWithdrawalUiMapper.kt
@@ -1,6 +1,7 @@
 package es.pedrazamiguez.splittrip.features.withdrawal.presentation.mapper
 
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.core.common.util.DisplayNameResolver
 import es.pedrazamiguez.splittrip.core.designsystem.extension.resolveLocalizedName
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatDisplay
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
@@ -55,12 +56,25 @@ class AddCashWithdrawalUiMapper(
     /**
      * Looks up the display name for a given userId from a pre-mapped member list.
      *
-     * @return The member's display name, or an empty string if not found.
+     * Returns [youLabel] when the member has [MemberOptionUiModel.isCurrentUser] set to `true`,
+     * delegating "you" personalisation to [DisplayNameResolver].
+     *
+     * @return The member's display name or [youLabel] for the current user; `""` if not found.
      */
     fun resolveDisplayName(
         userId: String?,
-        members: ImmutableList<MemberOptionUiModel>
-    ): String = members.firstOrNull { it.userId == userId }?.displayName ?: ""
+        members: ImmutableList<MemberOptionUiModel>,
+        youLabel: String = ""
+    ): String {
+        if (userId == null) return ""
+        val member = members.firstOrNull { it.userId == userId } ?: return ""
+        return DisplayNameResolver.resolve(
+            userId = userId,
+            currentUserId = if (member.isCurrentUser) userId else null,
+            youLabel = youLabel,
+            displayName = member.displayName
+        )
+    }
 
     // ── Label Building ─────────────────────────────────────────────────────
 

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/mapper/AddCashWithdrawalUiMapper.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/mapper/AddCashWithdrawalUiMapper.kt
@@ -68,6 +68,9 @@ class AddCashWithdrawalUiMapper(
     ): String {
         if (userId == null) return ""
         val member = members.firstOrNull { it.userId == userId } ?: return ""
+        // When no youLabel is provided, skip "you" personalisation and return the display
+        // name directly — avoids blank labels at call sites that don't supply the string.
+        if (youLabel.isBlank()) return member.displayName
         return DisplayNameResolver.resolve(
             userId = userId,
             currentUserId = if (member.isCurrentUser) userId else null,


### PR DESCRIPTION
Introduce DisplayNameResolver (with tests) to centralise display-name fallback and "You" personalization. Update mappers (ExpenseDetail, AddContribution, AddCashWithdrawal) to use the resolver and return localized you-labels. Add payment method/status icon support: new toIconVector extensions, PaymentMethodUiModel icon field, and AddExpenseOptionsUiMapper wiring. Enhance expense detail UI: new MethodChip, StatusBadgeChip, DateChip, HeroSection layout and centered amount/labels, SplitBreakdown padding. Extend CondensedChips to accept optional leading icons (and show icons in overflow). Add string resources for paid_by_you, you_label and expense scope labels. Update tests to cover the new resolver, personalized paid-by text, scope labels and icon fields.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1091 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
