### PR TITLE
[SPLTRP-1092]: Extract `ScheduledBadgeUiMapper` to eliminate duplicated scheduled-payment badge logic in `:features:expenses`

### DIFF
--- a/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpenseDetailPreviewHelper.kt
+++ b/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpenseDetailPreviewHelper.kt
@@ -252,13 +252,14 @@ fun ExpenseDetailPreviewHelper(
         mapper = { localeProvider, resourceProvider ->
             // Mapper is stateless — both domain services have empty constructors and
             // safe defaults, so we can instantiate them inline for previews.
+            val formattingHelper = FormattingHelper(localeProvider)
             ExpenseDetailUiMapper(
-                formattingHelper = FormattingHelper(localeProvider),
+                formattingHelper = formattingHelper,
                 resourceProvider = resourceProvider,
                 expenseCalculatorService = ExpenseCalculatorService(),
                 addOnCalculationService = AddOnCalculationService(),
                 scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
-                    formattingHelper = FormattingHelper(localeProvider),
+                    formattingHelper = formattingHelper,
                     resourceProvider = resourceProvider
                 )
             )

--- a/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpenseDetailPreviewHelper.kt
+++ b/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpenseDetailPreviewHelper.kt
@@ -20,6 +20,7 @@ import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDetailUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ScheduledBadgeUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDetailUiModel
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -255,7 +256,11 @@ fun ExpenseDetailPreviewHelper(
                 formattingHelper = FormattingHelper(localeProvider),
                 resourceProvider = resourceProvider,
                 expenseCalculatorService = ExpenseCalculatorService(),
-                addOnCalculationService = AddOnCalculationService()
+                addOnCalculationService = AddOnCalculationService(),
+                scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
+                    formattingHelper = FormattingHelper(localeProvider),
+                    resourceProvider = resourceProvider
+                )
             )
         },
         transform = { mapper, domain ->

--- a/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpensesUiPreviewHelpers.kt
+++ b/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpensesUiPreviewHelpers.kt
@@ -1,6 +1,8 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.preview
 
 import androidx.compose.runtime.Composable
+import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
+import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.preview.MappedPreview
 import es.pedrazamiguez.splittrip.domain.model.Contribution
@@ -12,6 +14,16 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.Scheduled
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDateGroupUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseUiModel
 import kotlinx.collections.immutable.ImmutableList
+
+private fun buildExpenseUiMapper(localeProvider: LocaleProvider, resourceProvider: ResourceProvider): ExpenseUiMapper =
+    ExpenseUiMapper(
+        localeProvider = localeProvider,
+        resourceProvider = resourceProvider,
+        scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
+            formattingHelper = FormattingHelper(localeProvider),
+            resourceProvider = resourceProvider
+        )
+    )
 
 @Composable
 fun ExpenseItemPreviewHelper(
@@ -25,14 +37,7 @@ fun ExpenseItemPreviewHelper(
     MappedPreview(
         domain = domainExpense,
         mapper = { localeProvider, resourceProvider ->
-            ExpenseUiMapper(
-                localeProvider = localeProvider,
-                resourceProvider = resourceProvider,
-                scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
-                    formattingHelper = FormattingHelper(localeProvider),
-                    resourceProvider = resourceProvider
-                )
-            )
+            buildExpenseUiMapper(localeProvider, resourceProvider)
         },
         transform = { mapper, domain ->
             mapper.map(domain, memberProfiles, currentUserId, pairedContributions, subunits)
@@ -53,14 +58,7 @@ fun ExpenseListPreviewHelper(
     MappedPreview(
         domain = domainExpenses,
         mapper = { localeProvider, resourceProvider ->
-            ExpenseUiMapper(
-                localeProvider = localeProvider,
-                resourceProvider = resourceProvider,
-                scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
-                    formattingHelper = FormattingHelper(localeProvider),
-                    resourceProvider = resourceProvider
-                )
-            )
+            buildExpenseUiMapper(localeProvider, resourceProvider)
         },
         transform = { mapper, domain ->
             mapper.mapGroupedByDate(domain, memberProfiles, currentUserId, pairedContributions, subunits)

--- a/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpensesUiPreviewHelpers.kt
+++ b/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ExpensesUiPreviewHelpers.kt
@@ -1,12 +1,14 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.preview
 
 import androidx.compose.runtime.Composable
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.preview.MappedPreview
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ScheduledBadgeUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDateGroupUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseUiModel
 import kotlinx.collections.immutable.ImmutableList
@@ -23,7 +25,14 @@ fun ExpenseItemPreviewHelper(
     MappedPreview(
         domain = domainExpense,
         mapper = { localeProvider, resourceProvider ->
-            ExpenseUiMapper(localeProvider, resourceProvider)
+            ExpenseUiMapper(
+                localeProvider = localeProvider,
+                resourceProvider = resourceProvider,
+                scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
+                    formattingHelper = FormattingHelper(localeProvider),
+                    resourceProvider = resourceProvider
+                )
+            )
         },
         transform = { mapper, domain ->
             mapper.map(domain, memberProfiles, currentUserId, pairedContributions, subunits)
@@ -44,7 +53,14 @@ fun ExpenseListPreviewHelper(
     MappedPreview(
         domain = domainExpenses,
         mapper = { localeProvider, resourceProvider ->
-            ExpenseUiMapper(localeProvider, resourceProvider)
+            ExpenseUiMapper(
+                localeProvider = localeProvider,
+                resourceProvider = resourceProvider,
+                scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
+                    formattingHelper = FormattingHelper(localeProvider),
+                    resourceProvider = resourceProvider
+                )
+            )
         },
         transform = { mapper, domain ->
             mapper.mapGroupedByDate(domain, memberProfiles, currentUserId, pairedContributions, subunits)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
@@ -41,6 +41,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpens
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDetailUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ScheduledBadgeUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.screen.impl.AddExpenseScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.expense.presentation.screen.impl.ExpenseDetailScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.expense.presentation.screen.impl.ExpensesScreenUiProviderImpl
@@ -69,6 +70,13 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val expensesUiModule = module {
+
+    factory {
+        ScheduledBadgeUiMapper(
+            formattingHelper = get<FormattingHelper>(),
+            resourceProvider = get<ResourceProvider>()
+        )
+    }
 
     single {
         val entitySplitFlattenDelegate = EntitySplitFlattenDelegate(
@@ -106,7 +114,8 @@ val expensesUiModule = module {
     single {
         ExpenseUiMapper(
             localeProvider = get<LocaleProvider>(),
-            resourceProvider = get<ResourceProvider>()
+            resourceProvider = get<ResourceProvider>(),
+            scheduledBadgeUiMapper = get<ScheduledBadgeUiMapper>()
         )
     }
 
@@ -268,7 +277,8 @@ val expensesUiModule = module {
             formattingHelper = get<FormattingHelper>(),
             resourceProvider = get<ResourceProvider>(),
             expenseCalculatorService = get<ExpenseCalculatorService>(),
-            addOnCalculationService = get<AddOnCalculationService>()
+            addOnCalculationService = get<AddOnCalculationService>(),
+            scheduledBadgeUiMapper = get<ScheduledBadgeUiMapper>()
         )
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapper.kt
@@ -25,7 +25,6 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDet
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitDetailUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.SubunitSplitGroupUiModel
 import java.math.BigDecimal
-import java.time.LocalDate
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -33,7 +32,8 @@ class ExpenseDetailUiMapper(
     private val formattingHelper: FormattingHelper,
     private val resourceProvider: ResourceProvider,
     private val expenseCalculatorService: ExpenseCalculatorService,
-    private val addOnCalculationService: AddOnCalculationService
+    private val addOnCalculationService: AddOnCalculationService,
+    private val scheduledBadgeUiMapper: ScheduledBadgeUiMapper
 ) {
 
     fun map(
@@ -43,7 +43,7 @@ class ExpenseDetailUiMapper(
         withdrawalLookup: Map<String, CashWithdrawal> = emptyMap(),
         subunitNameLookup: Map<String, String> = emptyMap()
     ): ExpenseDetailUiModel {
-        val (scheduledBadgeText, isScheduledPastDue) = buildScheduledBadge(expense)
+        val (scheduledBadgeText, isScheduledPastDue) = scheduledBadgeUiMapper.buildBadge(expense)
         val isForeignCurrency = expense.sourceCurrency != expense.groupCurrency
         val youLabel = resourceProvider.getString(R.string.you_label)
         val paidByName = resolveDisplayName(expense.createdBy, memberProfiles, currentUserId, youLabel)
@@ -377,23 +377,6 @@ class ExpenseDetailUiMapper(
                     null
                 }
             }
-        }
-    }
-
-    private fun buildScheduledBadge(expense: Expense): Pair<String?, Boolean> {
-        val dueDate = expense.dueDate
-        if (expense.paymentStatus != PaymentStatus.SCHEDULED || dueDate == null) return null to false
-        val dueDateLocal = dueDate.toLocalDate()
-        return when {
-            dueDateLocal.isEqual(LocalDate.now()) ->
-                resourceProvider.getString(R.string.expense_scheduled_due_today) to true
-            dueDateLocal.isBefore(LocalDate.now()) ->
-                resourceProvider.getString(R.string.expense_scheduled_paid) to true
-            else ->
-                resourceProvider.getString(
-                    R.string.expense_scheduled_due_on,
-                    formattingHelper.formatShortDate(dueDate)
-                ) to false
         }
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapper.kt
@@ -7,7 +7,6 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.forma
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatShortDate
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatSourceAmount
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
-import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.model.Subunit
@@ -16,11 +15,14 @@ import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toStringRes
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDateGroupUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseUiModel
-import java.time.LocalDate
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
-class ExpenseUiMapper(private val localeProvider: LocaleProvider, private val resourceProvider: ResourceProvider) {
+class ExpenseUiMapper(
+    private val localeProvider: LocaleProvider,
+    private val resourceProvider: ResourceProvider,
+    private val scheduledBadgeUiMapper: ScheduledBadgeUiMapper
+) {
 
     fun map(
         expense: Expense,
@@ -30,7 +32,7 @@ class ExpenseUiMapper(private val localeProvider: LocaleProvider, private val re
         subunits: Map<String, Subunit> = emptyMap()
     ): ExpenseUiModel {
         val appLocale = localeProvider.getCurrentLocale()
-        val (badgeText, isPastDue) = buildScheduledBadge(expense, appLocale)
+        val (badgeText, isPastDue) = scheduledBadgeUiMapper.buildBadge(expense)
         val outOfPocket = expense.payerType == PayerType.USER
         val pairedContribution = pairedContributions[expense.id]
         val effectivePayerId = expense.payerId ?: expense.createdBy.takeIf { it.isNotBlank() }
@@ -125,36 +127,6 @@ class ExpenseUiMapper(private val localeProvider: LocaleProvider, private val re
                 )
             }
             .toImmutableList()
-    }
-
-    /**
-     * Builds the scheduled-payment badge for the expense item.
-     *
-     * @return Pair of (badgeText, isPastDue).
-     *         badgeText is null when the expense is not SCHEDULED.
-     */
-    private fun buildScheduledBadge(expense: Expense, locale: java.util.Locale): Pair<String?, Boolean> {
-        if (expense.paymentStatus != PaymentStatus.SCHEDULED) return null to false
-
-        val dueDate = expense.dueDate ?: return null to false
-        val today = LocalDate.now()
-        val dueDateLocal = dueDate.toLocalDate()
-
-        return when {
-            dueDateLocal.isEqual(today) -> {
-                resourceProvider.getString(R.string.expense_scheduled_due_today) to true
-            }
-            dueDateLocal.isBefore(today) -> {
-                resourceProvider.getString(R.string.expense_scheduled_paid) to true
-            }
-            else -> {
-                val formattedDate = dueDate.formatShortDate(locale)
-                resourceProvider.getString(
-                    R.string.expense_scheduled_due_on,
-                    formattedDate
-                ) to false
-            }
-        }
     }
 
     /**

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ScheduledBadgeUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ScheduledBadgeUiMapper.kt
@@ -1,0 +1,47 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
+
+import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
+import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.features.expense.R
+import java.time.LocalDate
+
+/**
+ * Centralises all scheduled-payment badge logic so that both [ExpenseUiMapper] (list) and
+ * [ExpenseDetailUiMapper] (detail) produce identical badge text from a single source of truth.
+ *
+ * Returns a [Pair] of (badgeText, isPastDue):
+ * - badgeText is null when the expense is not SCHEDULED or has no due date.
+ * - isPastDue signals that the due date has passed or is today (used for urgent/error styling).
+ */
+class ScheduledBadgeUiMapper(
+    private val formattingHelper: FormattingHelper,
+    private val resourceProvider: ResourceProvider
+) {
+
+    fun buildBadge(expense: Expense): Pair<String?, Boolean> {
+        val dueDate = expense.dueDate
+        if (expense.paymentStatus != PaymentStatus.SCHEDULED || dueDate == null) return null to false
+
+        val today = LocalDate.now()
+        val dueDateLocal = dueDate.toLocalDate()
+
+        return when {
+            dueDateLocal.isBefore(today) ->
+                resourceProvider.getString(R.string.expense_scheduled_paid) to true
+
+            dueDateLocal.isEqual(today) ->
+                resourceProvider.getString(R.string.expense_scheduled_due_today) to true
+
+            dueDateLocal.isEqual(today.plusDays(1)) ->
+                resourceProvider.getString(R.string.expense_scheduled_due_tomorrow) to false
+
+            else ->
+                resourceProvider.getString(
+                    R.string.expense_scheduled_due_on,
+                    formattingHelper.formatShortDate(dueDate)
+                ) to false
+        }
+    }
+}

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -117,6 +117,7 @@
     <!-- Scheduled Payment Badge -->
     <string name="expense_scheduled_due_on">Vence el %1$s</string>
     <string name="expense_scheduled_due_today">Vence hoy</string>
+    <string name="expense_scheduled_due_tomorrow">Vence mañana</string>
     <string name="expense_scheduled_paid">Pagado</string>
 
     <!-- Split Types -->

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <!-- Scheduled Payment Badge -->
     <string name="expense_scheduled_due_on">Due on %1$s</string>
     <string name="expense_scheduled_due_today">Due today</string>
+    <string name="expense_scheduled_due_tomorrow">Due tomorrow</string>
     <string name="expense_scheduled_paid">Paid</string>
 
     <!-- Split Types -->

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
@@ -78,12 +78,17 @@ class ExpenseDetailUiMapperTest {
         val formattingHelper = FormattingHelper(localeProvider)
         val expenseCalculatorService = ExpenseCalculatorService()
         val addOnCalculationService = AddOnCalculationService()
+        val scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
+            formattingHelper = formattingHelper,
+            resourceProvider = resourceProvider
+        )
 
         mapper = ExpenseDetailUiMapper(
             formattingHelper = formattingHelper,
             resourceProvider = resourceProvider,
             expenseCalculatorService = expenseCalculatorService,
-            addOnCalculationService = addOnCalculationService
+            addOnCalculationService = addOnCalculationService,
+            scheduledBadgeUiMapper = scheduledBadgeUiMapper
         )
     }
 
@@ -1107,6 +1112,18 @@ class ExpenseDetailUiMapperTest {
         @Test
         fun `isScheduledPastDue is false for non-scheduled expense`() {
             val result = mapper.map(baseExpense, memberProfiles, currentUserId)
+            assertFalse(result.isScheduledPastDue)
+        }
+
+        @Test
+        fun `scheduledBadgeText shows due tomorrow for scheduled expense due tomorrow`() {
+            every { resourceProvider.getString(any()) } returns "Due tomorrow"
+            val expense = baseExpense.copy(
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().plusDays(1).withHour(12).withMinute(0)
+            )
+            val result = mapper.map(expense, memberProfiles, currentUserId)
+            assertEquals("Due tomorrow", result.scheduledBadgeText)
             assertFalse(result.isScheduledPastDue)
         }
     }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseDetailUiMapperTest.kt
@@ -20,6 +20,7 @@ import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
 import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.features.expense.R
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
@@ -1117,7 +1118,8 @@ class ExpenseDetailUiMapperTest {
 
         @Test
         fun `scheduledBadgeText shows due tomorrow for scheduled expense due tomorrow`() {
-            every { resourceProvider.getString(any()) } returns "Due tomorrow"
+            // Stub only the specific resource ID so the test fails if the wrong branch is hit.
+            every { resourceProvider.getString(R.string.expense_scheduled_due_tomorrow) } returns "Due tomorrow"
             val expense = baseExpense.copy(
                 paymentStatus = PaymentStatus.SCHEDULED,
                 dueDate = LocalDateTime.now().plusDays(1).withHour(12).withMinute(0)

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ExpenseUiMapperTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
 
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.domain.enums.ExpenseCategory
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
@@ -83,13 +84,24 @@ class ExpenseUiMapperTest {
 
         // Stub scheduled badge strings
         every { resourceProvider.getString(R.string.expense_scheduled_due_today) } returns "Due today"
+        every { resourceProvider.getString(R.string.expense_scheduled_due_tomorrow) } returns "Due tomorrow"
         every { resourceProvider.getString(R.string.expense_scheduled_paid) } returns "Paid"
         every { resourceProvider.getString(R.string.expense_scheduled_due_on, *anyVararg()) } answers {
             val varargs = it.invocation.args[1] as Array<*>
             "Due on ${varargs[0]}"
         }
 
-        mapper = ExpenseUiMapper(localeProvider, resourceProvider)
+        val formattingHelper = FormattingHelper(localeProvider)
+        val scheduledBadgeUiMapper = ScheduledBadgeUiMapper(
+            formattingHelper = formattingHelper,
+            resourceProvider = resourceProvider
+        )
+
+        mapper = ExpenseUiMapper(
+            localeProvider = localeProvider,
+            resourceProvider = resourceProvider,
+            scheduledBadgeUiMapper = scheduledBadgeUiMapper
+        )
     }
 
     // ---------- formattedOriginalAmount ----------
@@ -579,6 +591,21 @@ class ExpenseUiMapperTest {
 
             assertEquals("Due today", result.scheduledBadgeText)
             assertTrue(result.isScheduledPastDue)
+        }
+
+        @Test
+        fun `scheduled expense due tomorrow shows due tomorrow`() {
+            val tomorrowDueDate = LocalDateTime.now().plusDays(1).withHour(12).withMinute(0)
+            val expense = Expense(
+                id = "e6",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = tomorrowDueDate
+            )
+
+            val result = mapper.map(expense)
+
+            assertEquals("Due tomorrow", result.scheduledBadgeText)
+            assertFalse(result.isScheduledPastDue)
         }
     }
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ScheduledBadgeUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/ScheduledBadgeUiMapperTest.kt
@@ -1,0 +1,241 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
+
+import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
+import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
+import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.features.expense.R
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+import java.util.Locale
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("ScheduledBadgeUiMapper")
+class ScheduledBadgeUiMapperTest {
+
+    private lateinit var mapper: ScheduledBadgeUiMapper
+    private lateinit var localeProvider: LocaleProvider
+    private lateinit var resourceProvider: ResourceProvider
+
+    @BeforeEach
+    fun setUp() {
+        localeProvider = mockk()
+        resourceProvider = mockk()
+
+        every { localeProvider.getCurrentLocale() } returns Locale.US
+
+        every { resourceProvider.getString(R.string.expense_scheduled_paid) } returns "Paid"
+        every { resourceProvider.getString(R.string.expense_scheduled_due_today) } returns "Due today"
+        every { resourceProvider.getString(R.string.expense_scheduled_due_tomorrow) } returns "Due tomorrow"
+        every { resourceProvider.getString(R.string.expense_scheduled_due_on, *anyVararg()) } answers {
+            val varargs = it.invocation.args[1] as Array<*>
+            "Due on ${varargs[0]}"
+        }
+
+        mapper = ScheduledBadgeUiMapper(
+            formattingHelper = FormattingHelper(localeProvider),
+            resourceProvider = resourceProvider
+        )
+    }
+
+    @Nested
+    @DisplayName("Non-SCHEDULED status")
+    inner class NonScheduledStatus {
+
+        @Test
+        fun `returns null badge and isPastDue false for FINISHED expense`() {
+            val expense = Expense(id = "e1", paymentStatus = PaymentStatus.FINISHED)
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertNull(badge)
+            assertFalse(isPastDue)
+        }
+
+        @Test
+        fun `returns null badge and isPastDue false for PENDING expense`() {
+            val expense = Expense(id = "e2", paymentStatus = PaymentStatus.PENDING)
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertNull(badge)
+            assertFalse(isPastDue)
+        }
+
+        @Test
+        fun `returns null badge and isPastDue false for CANCELLED expense`() {
+            val expense = Expense(id = "e3", paymentStatus = PaymentStatus.CANCELLED)
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertNull(badge)
+            assertFalse(isPastDue)
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULED with null dueDate")
+    inner class NullDueDate {
+
+        @Test
+        fun `returns null badge and isPastDue false when dueDate is null`() {
+            val expense = Expense(id = "e4", paymentStatus = PaymentStatus.SCHEDULED, dueDate = null)
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertNull(badge)
+            assertFalse(isPastDue)
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULED — past due (before today)")
+    inner class PastDue {
+
+        @Test
+        fun `returns Paid badge and isPastDue true for expense due 5 days ago`() {
+            val expense = Expense(
+                id = "e5",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().minusDays(5)
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Paid", badge)
+            assertTrue(isPastDue)
+        }
+
+        @Test
+        fun `returns Paid badge in ES locale for past due expense`() {
+            every { localeProvider.getCurrentLocale() } returns Locale.forLanguageTag("es-ES")
+            every { resourceProvider.getString(R.string.expense_scheduled_paid) } returns "Pagado"
+
+            val expense = Expense(
+                id = "e6",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().minusDays(1)
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Pagado", badge)
+            assertTrue(isPastDue)
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULED — due today")
+    inner class DueToday {
+
+        @Test
+        fun `returns Due today badge and isPastDue true`() {
+            val expense = Expense(
+                id = "e7",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().withHour(12).withMinute(0)
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Due today", badge)
+            assertTrue(isPastDue)
+        }
+
+        @Test
+        fun `returns ES badge for due today`() {
+            every { localeProvider.getCurrentLocale() } returns Locale.forLanguageTag("es-ES")
+            every { resourceProvider.getString(R.string.expense_scheduled_due_today) } returns "Vence hoy"
+
+            val expense = Expense(
+                id = "e8",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().withHour(10).withMinute(0)
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Vence hoy", badge)
+            assertTrue(isPastDue)
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULED — due tomorrow")
+    inner class DueTomorrow {
+
+        @Test
+        fun `returns Due tomorrow badge and isPastDue false`() {
+            val expense = Expense(
+                id = "e9",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().plusDays(1).withHour(12).withMinute(0)
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Due tomorrow", badge)
+            assertFalse(isPastDue)
+        }
+
+        @Test
+        fun `returns ES badge for due tomorrow`() {
+            every { localeProvider.getCurrentLocale() } returns Locale.forLanguageTag("es-ES")
+            every { resourceProvider.getString(R.string.expense_scheduled_due_tomorrow) } returns "Vence mañana"
+
+            val expense = Expense(
+                id = "e10",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = LocalDateTime.now().plusDays(1).withHour(9).withMinute(0)
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Vence mañana", badge)
+            assertFalse(isPastDue)
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULED — future (beyond tomorrow)")
+    inner class FutureDate {
+
+        @Test
+        fun `returns Due on date badge and isPastDue false for EN locale`() {
+            val futureDate = LocalDateTime.now().plusDays(10).withHour(12).withMinute(0)
+            val expense = Expense(
+                id = "e11",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = futureDate
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertTrue(badge!!.startsWith("Due on"))
+            assertFalse(isPastDue)
+        }
+
+        @Test
+        fun `returns Due on date badge with formatted date in ES locale`() {
+            every { localeProvider.getCurrentLocale() } returns Locale.forLanguageTag("es-ES")
+            every {
+                resourceProvider.getString(R.string.expense_scheduled_due_on, *anyVararg())
+            } answers {
+                val varargs = it.invocation.args[1] as Array<*>
+                "Vence el ${varargs[0]}"
+            }
+
+            // Use a known date so we can assert the formatted output
+            val futureDate = LocalDateTime.of(2027, 8, 20, 12, 0)
+            val expense = Expense(
+                id = "e12",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = futureDate
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            // ES locale formats "20 ago" (short month in Spanish)
+            assertEquals("Vence el 20 ago", badge)
+            assertFalse(isPastDue)
+        }
+
+        @Test
+        fun `returns Due on date badge with formatted date in EN locale`() {
+            val futureDate = LocalDateTime.of(2027, 8, 20, 12, 0)
+            val expense = Expense(
+                id = "e13",
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = futureDate
+            )
+            val (badge, isPastDue) = mapper.buildBadge(expense)
+            assertEquals("Due on 20 Aug", badge)
+            assertFalse(isPastDue)
+        }
+    }
+}


### PR DESCRIPTION
Introduce ScheduledBadgeUiMapper to centralise scheduled-payment badge logic and ensure consistent badge text/styling across list and detail screens. Refactor ExpenseUiMapper and ExpenseDetailUiMapper to use the new mapper, register it in the expenses DI module, and update debug preview helpers to construct mappers with the new dependency. Add "Due tomorrow" / "Vence mañana" string resources and add comprehensive unit tests (ScheduledBadgeUiMapperTest) while updating existing mapper tests to use the new mapper. Removes duplicated badge-building code from both mappers.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1092 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
