### PR TITLE
[SPLTRP-1110]: [B] Extend ReceiptOcrService to support multi-page PDFs with OOM-safe rendering

### DIFF
--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParser.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParser.kt
@@ -62,8 +62,8 @@ internal class AICoreReceiptParser(
     private suspend fun runInference(ocrText: String): String? {
         ensureEngineReady()
 
-        val truncatedText = ocrText.take(MAX_OCR_INPUT_CHARS)
-        Timber.d("AICoreReceiptParser: ocr text: %d chars", truncatedText.length)
+        val truncatedText = smartTruncate(ocrText)
+        Timber.d("AICoreReceiptParser: ocr text: %d chars (raw=%d)", truncatedText.length, ocrText.length)
         Timber.d("AICoreReceiptParser: sending prompt (text length=%d chars)", truncatedText.length)
         val inferenceStartMs = System.currentTimeMillis()
         val response = generativeModel.generateContent(buildPrompt(truncatedText))
@@ -138,9 +138,31 @@ internal class AICoreReceiptParser(
         private const val FIELD_COUNT_THREE = 3
         private const val FIELD_COUNT_TWO = 2
 
-        // Increased from 400: Thai/Asian receipts list items before the total;
-        // truncating too early misses the grand total line at the bottom.
-        private const val MAX_OCR_INPUT_CHARS = 900
+        // Multi-page PDFs (up to 5 pages) easily exceed 900 chars. The grand total on a
+        // flight receipt always appears near the end, so a head-only `.take()` misses it.
+        // Budget raised to 3 000 chars — well within Gemini Nano's 8k-token context window.
+        private const val MAX_OCR_INPUT_CHARS = 3_000
+
+        // Head captures merchant/airline name and booking reference (top of document).
+        // Tail captures fare breakdown and grand total (bottom of document).
+        // Together they stay within MAX_OCR_INPUT_CHARS even for long multi-page receipts.
+        private const val OCR_INPUT_HEAD_CHARS = 600
+        private const val OCR_INPUT_TAIL_CHARS = MAX_OCR_INPUT_CHARS - OCR_INPUT_HEAD_CHARS
+
+        /**
+         * Returns at most [MAX_OCR_INPUT_CHARS] of [text].
+         *
+         * When truncation is needed we keep the first [OCR_INPUT_HEAD_CHARS] (merchant/airline
+         * name, booking ref) and the last [OCR_INPUT_TAIL_CHARS] (fare breakdown, grand total)
+         * rather than blindly taking the head. This ensures the grand total — which appears at
+         * the bottom of multi-page flight receipts — is always present in the prompt.
+         */
+        internal fun smartTruncate(text: String): String {
+            if (text.length <= MAX_OCR_INPUT_CHARS) return text
+            val head = text.take(OCR_INPUT_HEAD_CHARS)
+            val tail = text.takeLast(OCR_INPUT_TAIL_CHARS)
+            return "$head\n…\n$tail"
+        }
 
         private fun emptyAiCoreReceipt() = ExtractedReceipt(
             amount = null,

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParser.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParser.kt
@@ -147,7 +147,8 @@ internal class AICoreReceiptParser(
         // Tail captures fare breakdown and grand total (bottom of document).
         // Together they stay within MAX_OCR_INPUT_CHARS even for long multi-page receipts.
         private const val OCR_INPUT_HEAD_CHARS = 600
-        private const val OCR_INPUT_TAIL_CHARS = MAX_OCR_INPUT_CHARS - OCR_INPUT_HEAD_CHARS
+        private const val SEPARATOR = "\n…\n"
+        private const val OCR_INPUT_TAIL_CHARS = MAX_OCR_INPUT_CHARS - OCR_INPUT_HEAD_CHARS - SEPARATOR.length
 
         /**
          * Returns at most [MAX_OCR_INPUT_CHARS] of [text].
@@ -161,7 +162,7 @@ internal class AICoreReceiptParser(
             if (text.length <= MAX_OCR_INPUT_CHARS) return text
             val head = text.take(OCR_INPUT_HEAD_CHARS)
             val tail = text.takeLast(OCR_INPUT_TAIL_CHARS)
-            return "$head\n…\n$tail"
+            return "$head$SEPARATOR$tail"
         }
 
         private fun emptyAiCoreReceipt() = ExtractedReceipt(

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrService.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrService.kt
@@ -27,6 +27,8 @@ import timber.log.Timber
  */
 internal interface PdfPageRenderer {
     fun renderFirstPage(uri: Uri): Bitmap
+    fun getPageCount(uri: Uri): Int
+    fun renderPage(uri: Uri, pageIndex: Int): Bitmap
 }
 
 /**
@@ -34,7 +36,19 @@ internal interface PdfPageRenderer {
  * with OOM-safe downsampling bounded to a maximum page dimension.
  */
 internal class PdfPageRendererImpl(private val context: Context) : PdfPageRenderer {
-    override fun renderFirstPage(uri: Uri): Bitmap {
+    override fun renderFirstPage(uri: Uri): Bitmap = renderPage(uri, 0)
+
+    override fun getPageCount(uri: Uri): Int {
+        val parcelFileDescriptor = context.contentResolver.openFileDescriptor(uri, "r")
+            ?: throw IOException("Could not open file descriptor for $uri")
+        return parcelFileDescriptor.use { pfd ->
+            PdfRenderer(pfd).use { renderer ->
+                renderer.pageCount
+            }
+        }
+    }
+
+    override fun renderPage(uri: Uri, pageIndex: Int): Bitmap {
         val parcelFileDescriptor = context.contentResolver.openFileDescriptor(uri, "r")
             ?: throw IOException("Could not open file descriptor for $uri")
         return parcelFileDescriptor.use { pfd ->
@@ -42,7 +56,10 @@ internal class PdfPageRendererImpl(private val context: Context) : PdfPageRender
                 if (renderer.pageCount == 0) {
                     throw IOException("PDF has no pages")
                 }
-                renderer.openPage(0).use { pg ->
+                require(pageIndex in 0 until renderer.pageCount) {
+                    "Page index $pageIndex out of bounds for PDF with ${renderer.pageCount} pages"
+                }
+                renderer.openPage(pageIndex).use { pg ->
                     renderPage(pg)
                 }
             }
@@ -109,7 +126,6 @@ internal class MLKitOcrService(
 ) : ReceiptOcrService {
 
     override suspend fun recogniseText(attachment: ReceiptAttachment): Result<RawReceiptText> {
-        var renderedBitmap: Bitmap? = null
         return try {
             val mimeType = attachment.mimeType.lowercase(java.util.Locale.ROOT)
             require(mimeType in SUPPORTED_MIME_TYPES) {
@@ -117,49 +133,82 @@ internal class MLKitOcrService(
             }
 
             val uri = Uri.parse(attachment.localUri)
+            val fullTextBuilder = StringBuilder()
+            val textBlocks = mutableListOf<TextBlock>()
 
-            // Perform potentially blocking/heavy resource loading on the IO dispatcher
-            val inputImage = withContext(ioDispatcher) {
-                try {
-                    if (mimeType == "application/pdf") {
-                        val bitmap = pdfPageRenderer.renderFirstPage(uri)
-                        renderedBitmap = bitmap
-                        InputImage.fromBitmap(bitmap, 0)
-                    } else {
-                        InputImage.fromFilePath(context, uri)
-                    }
-                } catch (e: CancellationException) {
-                    renderedBitmap?.recycle()
-                    renderedBitmap = null
-                    throw e
-                } catch (e: Exception) {
-                    renderedBitmap?.recycle()
-                    renderedBitmap = null
-                    throw IOException("Failed to load image from URI: ${attachment.localUri}", e)
-                }
+            if (mimeType == "application/pdf") {
+                processPdf(uri, fullTextBuilder, textBlocks)
+            } else {
+                processImage(uri, fullTextBuilder, textBlocks)
             }
 
-            // Perform CPU-heavy ML Kit OCR process and mapping on the Default dispatcher
-            val ocrResult = withContext(defaultDispatcher) {
-                ocrEngine.process(inputImage)
-            }
-            val blocks = ocrResult.blocks.map { blockText ->
-                TextBlock(
-                    text = blockText,
-                    confidence = null
-                )
-            }.toImmutableList()
+            val finalFullText = fullTextBuilder.toString()
+            val finalBlocks = textBlocks.toImmutableList()
 
             // Safe length/blocks count log to prevent exposing raw financial PII data
-            Timber.d("OCR completed: extracted ${blocks.size} blocks (${ocrResult.text.length} chars)")
+            Timber.d("OCR completed: extracted ${finalBlocks.size} blocks (${finalFullText.length} chars)")
 
             Result.success(
                 RawReceiptText(
-                    fullText = ocrResult.text,
-                    blocks = blocks,
+                    fullText = finalFullText,
+                    blocks = finalBlocks,
                     recognisedAt = Instant.now()
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun processPdf(
+        uri: Uri,
+        fullTextBuilder: StringBuilder,
+        textBlocks: MutableList<TextBlock>
+    ) {
+        val pageCount = withContext(ioDispatcher) {
+            try {
+                pdfPageRenderer.getPageCount(uri)
+            } catch (e: Exception) {
+                throw IOException("Failed to read PDF page count from URI: $uri", e)
+            }
+        }
+        val pagesToProcess = minOf(pageCount, MAX_PDF_PAGES)
+        for (pageIndex in 0 until pagesToProcess) {
+            processPdfPage(uri, pageIndex, fullTextBuilder, textBlocks)
+        }
+    }
+
+    private suspend fun processPdfPage(
+        uri: Uri,
+        pageIndex: Int,
+        fullTextBuilder: StringBuilder,
+        textBlocks: MutableList<TextBlock>
+    ) {
+        var renderedBitmap: Bitmap? = null
+        try {
+            renderedBitmap = withContext(ioDispatcher) {
+                pdfPageRenderer.renderPage(uri, pageIndex)
+            }
+            val inputImage = InputImage.fromBitmap(renderedBitmap, 0)
+            val ocrResult = withContext(defaultDispatcher) {
+                ocrEngine.process(inputImage)
+            }
+            if (ocrResult.text.isNotEmpty()) {
+                if (fullTextBuilder.isNotEmpty()) {
+                    fullTextBuilder.append("\n\n")
+                }
+                fullTextBuilder.append(ocrResult.text)
+            }
+            ocrResult.blocks.forEach { blockText ->
+                textBlocks.add(
+                    TextBlock(
+                        text = blockText,
+                        confidence = null
+                    )
+                )
+            }
         } catch (e: CancellationException) {
             renderedBitmap?.recycle()
             renderedBitmap = null
@@ -167,13 +216,43 @@ internal class MLKitOcrService(
         } catch (e: Exception) {
             renderedBitmap?.recycle()
             renderedBitmap = null
-            Result.failure(e)
+            throw IOException("Failed to load or process PDF page $pageIndex from URI: $uri", e)
         } finally {
             renderedBitmap?.recycle()
         }
     }
 
+    private suspend fun processImage(
+        uri: Uri,
+        fullTextBuilder: StringBuilder,
+        textBlocks: MutableList<TextBlock>
+    ) {
+        val inputImage = withContext(ioDispatcher) {
+            try {
+                InputImage.fromFilePath(context, uri)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw IOException("Failed to load image from URI: $uri", e)
+            }
+        }
+        val ocrResult = withContext(defaultDispatcher) {
+            ocrEngine.process(inputImage)
+        }
+        fullTextBuilder.append(ocrResult.text)
+        ocrResult.blocks.forEach { blockText ->
+            textBlocks.add(
+                TextBlock(
+                    text = blockText,
+                    confidence = null
+                )
+            )
+        }
+    }
+
     private companion object {
+        const val MAX_PDF_PAGES = 5
+
         val SUPPORTED_MIME_TYPES = setOf(
             "image/jpeg",
             "image/jpg",

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrService.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrService.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
- * Interface representing PDF first-page rendering logic, separated for unit-testability.
+ * Interface representing PDF rendering logic (page count and page-specific rendering), separated for unit-testability.
  */
 internal interface PdfPageRenderer {
     fun renderFirstPage(uri: Uri): Bitmap
@@ -167,16 +167,23 @@ internal class MLKitOcrService(
         fullTextBuilder: StringBuilder,
         textBlocks: MutableList<TextBlock>
     ) {
-        val pageCount = withContext(ioDispatcher) {
-            try {
-                pdfPageRenderer.getPageCount(uri)
-            } catch (e: Exception) {
-                throw IOException("Failed to read PDF page count from URI: $uri", e)
-            }
+        val pageCount = readPageCount(uri)
+        if (pageCount <= 0) {
+            throw IOException("PDF has no pages")
         }
         val pagesToProcess = minOf(pageCount, MAX_PDF_PAGES)
         for (pageIndex in 0 until pagesToProcess) {
             processPdfPage(uri, pageIndex, fullTextBuilder, textBlocks)
+        }
+    }
+
+    private suspend fun readPageCount(uri: Uri): Int = withContext(ioDispatcher) {
+        try {
+            pdfPageRenderer.getPageCount(uri)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw IOException("Failed to read PDF page count from URI: $uri", e)
         }
     }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParserTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParserTest.kt
@@ -27,8 +27,8 @@ class AICoreReceiptParserTest {
         // Simulates a 5-page flight receipt (~6 000 chars).
         val text = "X".repeat(6_000)
         val result = AICoreReceiptParser.smartTruncate(text)
-        // head(600) + "\n…\n"(3) + tail(2400) = 3003 — the ellipsis separator is tiny overhead
-        assertTrue(result.length <= 3_003, "Expected ≤3003 chars, got ${result.length}")
+        // head(600) + "\n…\n"(3) + tail(2397) = 3000
+        assertTrue(result.length <= 3_000, "Expected ≤3000 chars, got ${result.length}")
     }
 
     @Test

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParserTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParserTest.kt
@@ -1,0 +1,72 @@
+package es.pedrazamiguez.splittrip.data.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AICoreReceiptParserTest {
+
+    // ── smartTruncate — no truncation needed ──────────────────────────────────
+
+    @Test
+    fun `smartTruncate returns text unchanged when below budget`() {
+        val text = "A".repeat(2_999)
+        assertEquals(text, AICoreReceiptParser.smartTruncate(text))
+    }
+
+    @Test
+    fun `smartTruncate returns text unchanged when exactly at budget`() {
+        val text = "A".repeat(3_000)
+        assertEquals(text, AICoreReceiptParser.smartTruncate(text))
+    }
+
+    // ── smartTruncate — truncation path ───────────────────────────────────────
+
+    @Test
+    fun `smartTruncate result length never exceeds budget when input is long`() {
+        // Simulates a 5-page flight receipt (~6 000 chars).
+        val text = "X".repeat(6_000)
+        val result = AICoreReceiptParser.smartTruncate(text)
+        // head(600) + "\n…\n"(3) + tail(2400) = 3003 — the ellipsis separator is tiny overhead
+        assertTrue(result.length <= 3_003, "Expected ≤3003 chars, got ${result.length}")
+    }
+
+    @Test
+    fun `smartTruncate preserves merchant name at the head`() {
+        val airlineName = "AIRLINE NAME BOOKING REF ".repeat(24) // 600 chars exactly
+        val fareDetails = "FARE BREAKDOWN GRAND TOTAL ".repeat(200) // long tail region
+        val text = airlineName + fareDetails
+
+        val result = AICoreReceiptParser.smartTruncate(text)
+
+        // The first 600 chars (airline name block) must be intact.
+        assertTrue(
+            result.startsWith(airlineName),
+            "Head of result should start with the merchant/airline name block"
+        )
+    }
+
+    @Test
+    fun `smartTruncate preserves grand total at the tail`() {
+        val header = "HEADER DATA ".repeat(300) // long, will be truncated
+        val grandTotalLine = "GRAND TOTAL 1234.56 EUR 2026-05-22"
+        // Pad so the grand total line is the very last content, within the last 2400 chars.
+        val fareSection = "item ".repeat(400) + grandTotalLine
+
+        val text = header + fareSection
+
+        val result = AICoreReceiptParser.smartTruncate(text)
+
+        assertTrue(
+            result.endsWith(grandTotalLine),
+            "Tail of result should contain the grand total line"
+        )
+    }
+
+    @Test
+    fun `smartTruncate inserts ellipsis separator between head and tail`() {
+        val text = "A".repeat(6_000)
+        val result = AICoreReceiptParser.smartTruncate(text)
+        assertTrue(result.contains("\n…\n"), "Truncated result must contain the ellipsis separator")
+    }
+}

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrServiceTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrServiceTest.kt
@@ -95,9 +95,11 @@ class MLKitOcrServiceTest {
             capturedAtMillis = 123456789L
         )
 
+        every { pdfPageRenderer.getPageCount(any()) } returns 1
+
         // Mock Bitmap
         val mockBitmap = mockk<Bitmap>(relaxed = true)
-        every { pdfPageRenderer.renderFirstPage(any()) } returns mockBitmap
+        every { pdfPageRenderer.renderPage(any(), 0) } returns mockBitmap
 
         val mockInputImage = mockk<InputImage>()
         every { InputImage.fromBitmap(mockBitmap, 0) } returns mockInputImage
@@ -110,6 +112,172 @@ class MLKitOcrServiceTest {
         assertTrue(result.isSuccess)
         assertEquals("PDF Page 1 text", result.getOrThrow().fullText)
         verify { mockBitmap.recycle() } // Verify bitmap was recycled
+    }
+
+    @Test
+    fun `recogniseText with multi-page PDF renders pages and accumulates OCR results`() = runTest(testDispatcher) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } returns 3
+
+        val mockBitmap1 = mockk<Bitmap>(relaxed = true)
+        val mockBitmap2 = mockk<Bitmap>(relaxed = true)
+        val mockBitmap3 = mockk<Bitmap>(relaxed = true)
+        every { pdfPageRenderer.renderPage(any(), 0) } returns mockBitmap1
+        every { pdfPageRenderer.renderPage(any(), 1) } returns mockBitmap2
+        every { pdfPageRenderer.renderPage(any(), 2) } returns mockBitmap3
+
+        val mockImage1 = mockk<InputImage>()
+        val mockImage2 = mockk<InputImage>()
+        val mockImage3 = mockk<InputImage>()
+        every { InputImage.fromBitmap(mockBitmap1, 0) } returns mockImage1
+        every { InputImage.fromBitmap(mockBitmap2, 0) } returns mockImage2
+        every { InputImage.fromBitmap(mockBitmap3, 0) } returns mockImage3
+
+        coEvery { ocrEngine.process(mockImage1) } returns OcrResult("Page 1 Text", listOf("Block 1.1", "Block 1.2"))
+        coEvery { ocrEngine.process(mockImage2) } returns OcrResult("Page 2 Text", listOf("Block 2.1"))
+        coEvery { ocrEngine.process(mockImage3) } returns OcrResult("Page 3 Text", listOf("Block 3.1"))
+
+        val result = service.recogniseText(attachment)
+
+        assertTrue(result.isSuccess)
+        val rawText = result.getOrThrow()
+        assertEquals("Page 1 Text\n\nPage 2 Text\n\nPage 3 Text", rawText.fullText)
+        assertEquals(4, rawText.blocks.size)
+        assertEquals("Block 1.1", rawText.blocks[0].text)
+        assertEquals("Block 1.2", rawText.blocks[1].text)
+        assertEquals("Block 2.1", rawText.blocks[2].text)
+        assertEquals("Block 3.1", rawText.blocks[3].text)
+
+        verify { mockBitmap1.recycle() }
+        verify { mockBitmap2.recycle() }
+        verify { mockBitmap3.recycle() }
+    }
+
+    @Test
+    fun `recogniseText with PDF exceeding max pages limits processing to 5 pages`() = runTest(testDispatcher) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } returns 7
+
+        val mockBitmaps = List(7) { mockk<Bitmap>(relaxed = true) }
+        val mockImages = List(7) { mockk<InputImage>() }
+
+        for (i in 0 until 7) {
+            every { pdfPageRenderer.renderPage(any(), i) } returns mockBitmaps[i]
+            every { InputImage.fromBitmap(mockBitmaps[i], 0) } returns mockImages[i]
+            coEvery { ocrEngine.process(mockImages[i]) } returns OcrResult("Text $i", emptyList())
+        }
+
+        val result = service.recogniseText(attachment)
+
+        assertTrue(result.isSuccess)
+        val rawText = result.getOrThrow()
+        assertEquals("Text 0\n\nText 1\n\nText 2\n\nText 3\n\nText 4", rawText.fullText)
+
+        verify(exactly = 5) { pdfPageRenderer.renderPage(any(), any()) }
+        verify(exactly = 0) { pdfPageRenderer.renderPage(any(), 5) }
+        verify(exactly = 0) { pdfPageRenderer.renderPage(any(), 6) }
+
+        verify(exactly = 1) { mockBitmaps[0].recycle() }
+        verify(exactly = 1) { mockBitmaps[1].recycle() }
+        verify(exactly = 1) { mockBitmaps[2].recycle() }
+        verify(exactly = 1) { mockBitmaps[3].recycle() }
+        verify(exactly = 1) { mockBitmaps[4].recycle() }
+        verify(exactly = 0) { mockBitmaps[5].recycle() }
+        verify(exactly = 0) { mockBitmaps[6].recycle() }
+    }
+
+    @Test
+    fun `recogniseText when PDF page rendering throws exception continues to clean up and returns failure`() = runTest(
+        testDispatcher
+    ) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } returns 3
+
+        val mockBitmap1 = mockk<Bitmap>(relaxed = true)
+        every { pdfPageRenderer.renderPage(any(), 0) } returns mockBitmap1
+        every { pdfPageRenderer.renderPage(any(), 1) } throws IOException("Rendering error")
+
+        val mockImage1 = mockk<InputImage>()
+        every { InputImage.fromBitmap(mockBitmap1, 0) } returns mockImage1
+        coEvery { ocrEngine.process(mockImage1) } returns OcrResult("Page 1 Text", emptyList())
+
+        val result = service.recogniseText(attachment)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertTrue(exception?.message?.contains("Failed to load or process PDF page 1") == true)
+
+        verify { mockBitmap1.recycle() }
+    }
+
+    @Test
+    fun `recogniseText when PDF page count reading throws exception returns failure`() = runTest(testDispatcher) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } throws IOException("Page count error")
+
+        val result = service.recogniseText(attachment)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertTrue(exception?.message?.contains("Failed to read PDF page count") == true)
+    }
+
+    @Test
+    fun `recogniseText when PDF cancellation occurs recycles bitmap and rethrows`() = runTest(
+        testDispatcher
+    ) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } returns 3
+
+        val mockBitmap1 = mockk<Bitmap>(relaxed = true)
+        val mockBitmap2 = mockk<Bitmap>(relaxed = true)
+        every { pdfPageRenderer.renderPage(any(), 0) } returns mockBitmap1
+        every { pdfPageRenderer.renderPage(any(), 1) } returns mockBitmap2
+
+        val mockImage1 = mockk<InputImage>()
+        val mockImage2 = mockk<InputImage>()
+        every { InputImage.fromBitmap(mockBitmap1, 0) } returns mockImage1
+        every { InputImage.fromBitmap(mockBitmap2, 0) } returns mockImage2
+
+        coEvery { ocrEngine.process(mockImage1) } returns OcrResult("Page 1 Text", emptyList())
+        coEvery { ocrEngine.process(mockImage2) } throws kotlinx.coroutines.CancellationException("Cancelled")
+
+        try {
+            service.recogniseText(attachment)
+            org.junit.jupiter.api.Assertions.fail("Expected CancellationException")
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            assertEquals("Cancelled", e.message)
+        }
+
+        verify { mockBitmap1.recycle() }
+        verify { mockBitmap2.recycle() }
     }
 
     @Test

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrServiceTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/MLKitOcrServiceTest.kt
@@ -245,6 +245,43 @@ class MLKitOcrServiceTest {
     }
 
     @Test
+    fun `recogniseText when PDF page count reading throws CancellationException rethrows`() = runTest(testDispatcher) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } throws
+            kotlinx.coroutines.CancellationException("Page count cancelled")
+
+        try {
+            service.recogniseText(attachment)
+            org.junit.jupiter.api.Assertions.fail("Expected CancellationException")
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            assertEquals("Page count cancelled", e.message)
+        }
+    }
+
+    @Test
+    fun `recogniseText when PDF has 0 pages returns failure`() = runTest(testDispatcher) {
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/receipt.pdf",
+            mimeType = "application/pdf",
+            capturedAtMillis = 123456789L
+        )
+
+        every { pdfPageRenderer.getPageCount(any()) } returns 0
+
+        val result = service.recogniseText(attachment)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("PDF has no pages", exception?.message)
+    }
+
+    @Test
     fun `recogniseText when PDF cancellation occurs recycles bitmap and rethrows`() = runTest(
         testDispatcher
     ) {

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/DeveloperServicesScreen.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/DeveloperServicesScreen.kt
@@ -268,13 +268,21 @@ private fun AiExtractionTabContent(
             }
         }
 
-        GradientButton(
-            text = stringResource(R.string.developer_services_ai_select_receipt),
-            onClick = onSelectReceiptForAiClick,
-            modifier = Modifier.fillMaxWidth()
-        )
+        AnimatedVisibility(
+            visible = uiState.extractionStatus !is ExtractionStatus.Loading,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically()
+        ) {
+            Column {
+                GradientButton(
+                    text = stringResource(R.string.developer_services_ai_select_receipt),
+                    onClick = onSelectReceiptForAiClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
 
-        Spacer(modifier = Modifier.height(MaterialTheme.spacing.Small))
+                Spacer(modifier = Modifier.height(MaterialTheme.spacing.Small))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Extend PDF rendering and OCR to handle multiple pages. PdfPageRenderer now exposes getPageCount and renderPage; PdfPageRendererImpl implements page-count reading and page-specific rendering, and renderFirstPage delegates to renderPage. MLKitOcrService was refactored to process PDFs across up to MAX_PDF_PAGES (5), with new processPdf/processPdfPage and processImage helpers, improved error handling, cancellation behavior, and bitmap cleanup. Tests updated to use renderPage/getPageCount and new unit tests added for multi-page processing, page limits, error cases and cancellation.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1110 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
