### PR TITLE
[SPLTRP-1113]: Implement Offline-First PDF Receipt Preview and Omni Viewer

### DIFF
--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
@@ -38,6 +38,6 @@ object Routes {
     fun receiptViewerRoute(receiptUri: String, mimeType: String? = null): String {
         val encodedUri = Uri.encode(receiptUri)
         val base = "receipt_viewer/$encodedUri"
-        return if (mimeType != null) "$base?mimeType=$mimeType" else base
+        return if (mimeType != null) "$base?mimeType=${Uri.encode(mimeType)}" else base
     }
 }

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
@@ -22,7 +22,7 @@ object Routes {
     const val EXPENSE_DETAIL = "expense_detail/{expenseId}"
     const val MANAGE_SUBUNITS = "manage_subunits/{groupId}"
     const val CREATE_EDIT_SUBUNIT = "create_edit_subunit/{groupId}?subunitId={subunitId}"
-    const val RECEIPT_VIEWER = "receipt_viewer/{receiptUri}"
+    const val RECEIPT_VIEWER = "receipt_viewer/{receiptUri}?mimeType={mimeType}"
 
     fun groupDetailRoute(groupId: String) = "group_detail/$groupId"
 
@@ -35,8 +35,9 @@ object Routes {
         return if (subunitId != null) "$base?subunitId=$subunitId" else base
     }
 
-    fun receiptViewerRoute(receiptUri: String): String {
+    fun receiptViewerRoute(receiptUri: String, mimeType: String? = null): String {
         val encodedUri = Uri.encode(receiptUri)
-        return "receipt_viewer/$encodedUri"
+        val base = "receipt_viewer/$encodedUri"
+        return if (mimeType != null) "$base?mimeType=$mimeType" else base
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -52,4 +52,5 @@ dependencies {
     // Unit Testing (extras — common test deps provided by convention plugin)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.koin.test)
+    testImplementation("org.json:json:20240303")
 }

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImplTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImplTest.kt
@@ -1,0 +1,92 @@
+package es.pedrazamiguez.splittrip.data.firebase.storage
+
+import android.net.Uri
+import com.google.android.gms.tasks.Task
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+import com.google.firebase.storage.UploadTask
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CloudStorageDataSourceImplTest {
+
+    private lateinit var storage: FirebaseStorage
+    private lateinit var rootRef: StorageReference
+    private lateinit var childRef: StorageReference
+    private lateinit var dataSource: CloudStorageDataSourceImpl
+
+    @BeforeEach
+    fun setUp() {
+        storage = mockk()
+        rootRef = mockk()
+        childRef = mockk()
+        every { storage.reference } returns rootRef
+        every { rootRef.child(any()) } returns childRef
+
+        mockkStatic(Uri::class)
+        val mockUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse(any()) } returns mockUri
+        every { Uri.fromFile(any()) } returns mockUri
+        every { mockUri.path } returns "/path/to/file.pdf"
+
+        // Mock tasks await extension function
+        mockkStatic("kotlinx.coroutines.tasks.TasksKt")
+
+        dataSource = CloudStorageDataSourceImpl(storage)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+        unmockkAll()
+    }
+
+    @Test
+    fun `uploadReceipt uploads file and returns download URL`() = runTest {
+        val mockSnapshot = mockk<UploadTask.TaskSnapshot>()
+        val mockUploadTask = mockk<UploadTask>()
+        every { childRef.putFile(any(), any()) } returns mockUploadTask
+        coEvery { mockUploadTask.await() } returns mockSnapshot
+
+        val mockDownloadUri = mockk<Uri>()
+        every { mockDownloadUri.toString() } returns "https://firebase.storage/receipt.pdf"
+        val mockDownloadUrlTask = mockk<Task<Uri>>()
+        every { childRef.downloadUrl } returns mockDownloadUrlTask
+        coEvery { mockDownloadUrlTask.await() } returns mockDownloadUri
+
+        val url = dataSource.uploadReceipt("expense-123", "file:///path/to/file.pdf", "application/pdf")
+
+        assertEquals("https://firebase.storage/receipt.pdf", url)
+        verify(exactly = 1) { rootRef.child("receipts/expense-123/receipt.pdf") }
+    }
+
+    @Test
+    fun `uploadReceipt normalises raw path and uploads successfully`() = runTest {
+        val mockSnapshot = mockk<UploadTask.TaskSnapshot>()
+        val mockUploadTask = mockk<UploadTask>()
+        every { childRef.putFile(any(), any()) } returns mockUploadTask
+        coEvery { mockUploadTask.await() } returns mockSnapshot
+
+        val mockDownloadUri = mockk<Uri>()
+        every { mockDownloadUri.toString() } returns "https://firebase.storage/receipt.jpg"
+        val mockDownloadUrlTask = mockk<Task<Uri>>()
+        every { childRef.downloadUrl } returns mockDownloadUrlTask
+        coEvery { mockDownloadUrlTask.await() } returns mockDownloadUri
+
+        val url = dataSource.uploadReceipt("expense-456", "/raw/filesystem/path/receipt.jpg", "image/jpeg")
+
+        assertEquals("https://firebase.storage/receipt.jpg", url)
+        verify(exactly = 1) { rootRef.child("receipts/expense-456/receipt.jpg") }
+    }
+}

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/dao/ExpenseDao.kt
@@ -74,6 +74,9 @@ interface ExpenseDao {
     @Query("UPDATE expenses SET receiptRemoteUrl = :remoteUrl WHERE id = :expenseId")
     suspend fun updateReceiptRemoteUrl(expenseId: String, remoteUrl: String)
 
+    @Query("UPDATE expenses SET receiptLocalUri = :localUri WHERE id = :expenseId")
+    suspend fun updateReceiptLocalUri(expenseId: String, localUri: String)
+
     /**
      * Reconciles local expenses for a group with the authoritative cloud snapshot.
      *

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalExpenseDataSourceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datasource/impl/LocalExpenseDataSourceImpl.kt
@@ -118,6 +118,10 @@ class LocalExpenseDataSourceImpl(
         expenseDao.updateReceiptRemoteUrl(expenseId, remoteUrl)
     }
 
+    override suspend fun updateReceiptLocalUri(expenseId: String, localUri: String) {
+        expenseDao.updateReceiptLocalUri(expenseId, localUri)
+    }
+
     override suspend fun clearAllExpenses() {
         expenseDao.clearAllExpenses()
     }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
@@ -210,7 +210,11 @@ internal class ReceiptStorageServiceImpl(
         FileOutputStream(destFile).use { output ->
             @Suppress("DEPRECATION") // WEBP_LOSSLESS added in API 30; WEBP used on < 30 (see KDoc)
             val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                Bitmap.CompressFormat.WEBP_LOSSLESS
+                try {
+                    Bitmap.CompressFormat.valueOf("WEBP_LOSSLESS")
+                } catch (_: Throwable) {
+                    Bitmap.CompressFormat.WEBP
+                }
             } else {
                 Bitmap.CompressFormat.WEBP
             }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.webkit.MimeTypeMap
 import androidx.core.net.toUri
+import es.pedrazamiguez.splittrip.domain.exception.TerminalDownloadException
 import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import java.io.File
@@ -92,7 +93,10 @@ internal class ReceiptStorageServiceImpl(
                 connection.connect()
 
                 if (connection.responseCode != HttpURLConnection.HTTP_OK) {
-                    error("Failed to download file: HTTP ${connection.responseCode}")
+                    throw TerminalDownloadException(
+                        responseCode = connection.responseCode,
+                        message = "Failed to download file: HTTP ${connection.responseCode}"
+                    )
                 }
 
                 connection.inputStream.use { input ->

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
@@ -4,15 +4,23 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.os.Build
+import android.webkit.MimeTypeMap
 import androidx.core.net.toUri
 import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import java.io.File
 import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+
+internal fun interface HttpConnectionFactory {
+    fun openConnection(url: String): HttpURLConnection
+}
 
 /**
  * Copies a user-selected file from a content:// or file:// URI into the app's
@@ -29,7 +37,10 @@ import timber.log.Timber
  * transient content:// URI granted by the OS picker.
  */
 internal class ReceiptStorageServiceImpl(
-    private val context: Context
+    private val context: Context,
+    private val connectionFactory: HttpConnectionFactory = HttpConnectionFactory { url ->
+        URL(url).openConnection() as HttpURLConnection
+    }
 ) : ReceiptStorageService {
 
     override suspend fun copyAndCompress(sourceUri: String): ReceiptAttachment =
@@ -72,16 +83,15 @@ internal class ReceiptStorageServiceImpl(
             val uniqueId = UUID.randomUUID().toString()
             val tempFile = File(context.cacheDir, "download_receipt_$uniqueId").also { it.parentFile?.mkdirs() }
 
-            var connection: java.net.HttpURLConnection? = null
+            var connection: HttpURLConnection? = null
             try {
-                val url = java.net.URL(remoteUrl)
-                connection = url.openConnection() as java.net.HttpURLConnection
+                connection = connectionFactory.openConnection(remoteUrl)
                 connection.connectTimeout = CONNECTION_TIMEOUT_MS
                 connection.readTimeout = CONNECTION_TIMEOUT_MS
                 connection.requestMethod = "GET"
                 connection.connect()
 
-                if (connection.responseCode != java.net.HttpURLConnection.HTTP_OK) {
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) {
                     error("Failed to download file: HTTP ${connection.responseCode}")
                 }
 
@@ -126,14 +136,14 @@ internal class ReceiptStorageServiceImpl(
         val resolver = context.contentResolver
         var mimeType = resolver.getType(uri)
         if (mimeType.isNullOrBlank() || mimeType == FALLBACK_MIME) {
-            val fileExtension = android.webkit.MimeTypeMap.getFileExtensionFromUrl(sourceUri)
+            val fileExtension = MimeTypeMap.getFileExtensionFromUrl(sourceUri)
                 .ifBlank {
                     val path = uri.path.orEmpty()
                     val dotIndex = path.lastIndexOf('.')
                     if (dotIndex != -1) path.substring(dotIndex + 1) else ""
                 }
             if (fileExtension.isNotEmpty()) {
-                val inferredMime = android.webkit.MimeTypeMap.getSingleton()
+                val inferredMime = MimeTypeMap.getSingleton()
                     .getMimeTypeFromExtension(fileExtension.lowercase())
                 if (!inferredMime.isNullOrBlank()) {
                     mimeType = inferredMime
@@ -199,7 +209,7 @@ internal class ReceiptStorageServiceImpl(
         val destFile = File(dir, "$uniqueId$WEBP_EXT")
         FileOutputStream(destFile).use { output ->
             @Suppress("DEPRECATION") // WEBP_LOSSLESS added in API 30; WEBP used on < 30 (see KDoc)
-            val format = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 Bitmap.CompressFormat.WEBP_LOSSLESS
             } else {
                 Bitmap.CompressFormat.WEBP

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
@@ -65,6 +65,63 @@ internal class ReceiptStorageServiceImpl(
             }
         }
 
+    override suspend fun downloadAndStore(remoteUrl: String): ReceiptAttachment =
+        withContext(Dispatchers.IO) {
+            val uri = Uri.parse(remoteUrl)
+            val receiptsDir = File(context.filesDir, RECEIPTS_DIR).also { it.mkdirs() }
+            val uniqueId = UUID.randomUUID().toString()
+            val tempFile = File(context.cacheDir, "download_receipt_$uniqueId").also { it.parentFile?.mkdirs() }
+
+            var connection: java.net.HttpURLConnection? = null
+            try {
+                val url = java.net.URL(remoteUrl)
+                connection = url.openConnection() as java.net.HttpURLConnection
+                connection.connectTimeout = CONNECTION_TIMEOUT_MS
+                connection.readTimeout = CONNECTION_TIMEOUT_MS
+                connection.requestMethod = "GET"
+                connection.connect()
+
+                if (connection.responseCode != java.net.HttpURLConnection.HTTP_OK) {
+                    error("Failed to download file: HTTP ${connection.responseCode}")
+                }
+
+                connection.inputStream.use { input ->
+                    FileOutputStream(tempFile).use { output ->
+                        input.copyTo(output)
+                    }
+                }
+
+                var contentType = connection.contentType ?: ""
+                if (contentType.contains(";")) {
+                    contentType = contentType.substringBefore(";")
+                }
+
+                val finalMime = if (contentType.isNotBlank() && contentType != "application/octet-stream") {
+                    contentType
+                } else {
+                    resolveMimeType(uri, remoteUrl)
+                }
+
+                val (destFile, actualMime) = if (finalMime.startsWith("image/")) {
+                    compressImage(tempFile, receiptsDir, uniqueId)
+                } else {
+                    copyVerbatim(tempFile, receiptsDir, uniqueId, finalMime)
+                }
+
+                ReceiptAttachment(
+                    localUri = destFile.toUri().toString(),
+                    mimeType = actualMime,
+                    capturedAtMillis = System.currentTimeMillis(),
+                    remoteUrl = remoteUrl
+                )
+            } finally {
+                connection?.disconnect()
+                if (tempFile.exists()) {
+                    tempFile.delete()
+                }
+            }
+        }
+
     private fun resolveMimeType(uri: Uri, sourceUri: String): String {
         val resolver = context.contentResolver
         var mimeType = resolver.getType(uri)
@@ -183,6 +240,7 @@ internal class ReceiptStorageServiceImpl(
 
     private companion object {
         const val RECEIPTS_DIR = "receipts"
+        const val CONNECTION_TIMEOUT_MS = 10000
         const val WEBP_EXT = ".webp"
         const val WEBP_MIME = "image/webp"
         const val FALLBACK_MIME = "application/octet-stream"

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
@@ -1,0 +1,118 @@
+package es.pedrazamiguez.splittrip.data.local.service
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.net.URLStreamHandlerFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ReceiptStorageServiceImplTest {
+
+    private lateinit var context: Context
+    private lateinit var service: ReceiptStorageServiceImpl
+    private lateinit var mockConnection: HttpURLConnection
+
+    companion object {
+        private var factoryRegistered = false
+
+        @Volatile
+        private var mockConnectionInstance: HttpURLConnection? = null
+
+        private fun registerFactoryIfNeeded() {
+            if (!factoryRegistered) {
+                try {
+                    URL.setURLStreamHandlerFactory(object : URLStreamHandlerFactory {
+                        override fun createURLStreamHandler(protocol: String): URLStreamHandler? {
+                            if (protocol == "http" || protocol == "https") {
+                                return object : URLStreamHandler() {
+                                    override fun openConnection(u: URL?): URLConnection {
+                                        return mockConnectionInstance
+                                            ?: error("Mock Connection not set")
+                                    }
+                                }
+                            }
+                            return null
+                        }
+                    })
+                    factoryRegistered = true
+                } catch (ignored: Error) {
+                    // Already set, ignore
+                }
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        service = ReceiptStorageServiceImpl(context)
+        mockConnection = mockk(relaxed = true)
+        registerFactoryIfNeeded()
+        mockConnectionInstance = mockConnection
+    }
+
+    @After
+    fun tearDown() {
+        mockConnectionInstance = null
+        val receiptsDir = File(context.filesDir, "receipts")
+        if (receiptsDir.exists()) {
+            receiptsDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun downloadAndStore_success_downloadsAndSavesPdf() = runTest {
+        // Given
+        val remoteUrl = "https://example.com/receipt.pdf"
+        val pdfContent = "Dummy PDF Content".toByteArray()
+
+        every { mockConnection.responseCode } returns HttpURLConnection.HTTP_OK
+        every { mockConnection.contentType } returns "application/pdf"
+        every { mockConnection.inputStream } returns ByteArrayInputStream(pdfContent)
+
+        // When
+        val attachment = service.downloadAndStore(remoteUrl)
+
+        // Then
+        assertNotNull(attachment)
+        assertEquals("application/pdf", attachment.mimeType)
+        assertEquals(remoteUrl, attachment.remoteUrl)
+        assertTrue(attachment.localUri.startsWith("file:/"))
+        assertTrue(attachment.localUri.endsWith(".pdf"))
+
+        val localFile = File(java.net.URI(attachment.localUri))
+        assertTrue(localFile.exists())
+        assertEquals("Dummy PDF Content", localFile.readText())
+    }
+
+    @Test
+    fun downloadAndStore_httpError_throwsException() = runTest {
+        // Given
+        val remoteUrl = "https://example.com/receipt.pdf"
+        every { mockConnection.responseCode } returns HttpURLConnection.HTTP_NOT_FOUND
+
+        // When/Then
+        try {
+            service.downloadAndStore(remoteUrl)
+            org.junit.Assert.fail("Expected an exception to be thrown")
+        } catch (e: Exception) {
+            assertTrue(e.message?.contains("Failed to download file: HTTP 404") == true)
+        }
+    }
+}

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
@@ -1,9 +1,17 @@
 package es.pedrazamiguez.splittrip.data.local.service
 
+import android.content.ContentResolver
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.HttpURLConnection
@@ -16,6 +24,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.util.ReflectionHelpers
 
 @RunWith(RobolectricTestRunner::class)
 class ReceiptStorageServiceImplTest {
@@ -24,6 +33,7 @@ class ReceiptStorageServiceImplTest {
     private lateinit var service: ReceiptStorageServiceImpl
     private lateinit var mockConnection: HttpURLConnection
     private lateinit var mockConnectionFactory: HttpConnectionFactory
+    private val originalSdkInt = Build.VERSION.SDK_INT
 
     @Before
     fun setUp() {
@@ -39,6 +49,9 @@ class ReceiptStorageServiceImplTest {
         if (receiptsDir.exists()) {
             receiptsDir.deleteRecursively()
         }
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", originalSdkInt)
+        clearAllMocks()
+        unmockkAll()
     }
 
     @Test
@@ -79,5 +92,187 @@ class ReceiptStorageServiceImplTest {
         } catch (e: Exception) {
             assertTrue(e.message?.contains("Failed to download file: HTTP 404") == true)
         }
+    }
+
+    @Test
+    fun copyAndCompress_pdf_copiesVerbatim() = runTest {
+        val mockContext = mockk<Context>()
+        val mockResolver = mockk<ContentResolver>()
+        val tempFilesDir = File(context.filesDir, "filesDir_temp").also { it.mkdirs() }
+        val tempCacheDir = File(context.cacheDir, "cacheDir_temp").also { it.mkdirs() }
+        every { mockContext.filesDir } returns tempFilesDir
+        every { mockContext.cacheDir } returns tempCacheDir
+        every { mockContext.contentResolver } returns mockResolver
+        every { mockContext.packageName } returns "es.pedrazamiguez.splittrip"
+
+        val localService = ReceiptStorageServiceImpl(mockContext, mockConnectionFactory)
+
+        val sourceUri = "content://com.android.providers.media.documents/document/document%3A1000000034"
+        val mockUri = mockk<Uri>(relaxed = true)
+        mockkStatic(Uri::class)
+        every { Uri.parse(sourceUri) } returns mockUri
+        every { mockResolver.getType(mockUri) } returns "application/pdf"
+
+        val pdfData = "Mock PDF Data".toByteArray()
+        every { mockResolver.openInputStream(mockUri) } returns ByteArrayInputStream(pdfData)
+
+        // When
+        val attachment = localService.copyAndCompress(sourceUri)
+
+        // Then
+        assertNotNull(attachment)
+        assertEquals("application/pdf", attachment.mimeType)
+        assertTrue(attachment.localUri.endsWith(".pdf"))
+
+        val copiedFile = File(java.net.URI(attachment.localUri))
+        assertTrue(copiedFile.exists())
+        assertEquals("Mock PDF Data", copiedFile.readText())
+
+        // Clean up
+        tempFilesDir.deleteRecursively()
+        tempCacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun copyAndCompress_imageJpeg_compressesToWebp_AndroidR() = runTest {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.R)
+
+        val mockContext = mockk<Context>()
+        val mockResolver = mockk<ContentResolver>()
+        val tempFilesDir = File(context.filesDir, "filesDir_image_R").also { it.mkdirs() }
+        val tempCacheDir = File(context.cacheDir, "cacheDir_image_R").also { it.mkdirs() }
+        every { mockContext.filesDir } returns tempFilesDir
+        every { mockContext.cacheDir } returns tempCacheDir
+        every { mockContext.contentResolver } returns mockResolver
+        every { mockContext.packageName } returns "es.pedrazamiguez.splittrip"
+
+        val localService = ReceiptStorageServiceImpl(mockContext, mockConnectionFactory)
+
+        val sourceUri = "content://com.android.providers.media.documents/document/image%3A1"
+        val mockUri = mockk<Uri>(relaxed = true)
+        mockkStatic(Uri::class)
+        every { Uri.parse(sourceUri) } returns mockUri
+        every { mockResolver.getType(mockUri) } returns "image/jpeg"
+
+        val imageData = "Fake Image Data".toByteArray()
+        every { mockResolver.openInputStream(mockUri) } returns ByteArrayInputStream(imageData)
+
+        mockkStatic(BitmapFactory::class)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { BitmapFactory.decodeFile(any(), any()) } returns mockBitmap
+        every { mockBitmap.compress(any(), any(), any()) } answers {
+            val os = arg<java.io.OutputStream>(2)
+            os.write("Compressed Lossless Webp Bytes".toByteArray())
+            true
+        }
+
+        // When
+        val attachment = localService.copyAndCompress(sourceUri)
+
+        // Then
+        assertNotNull(attachment)
+        assertEquals("image/webp", attachment.mimeType)
+        assertTrue(attachment.localUri.endsWith(".webp"))
+
+        val compressedFile = File(java.net.URI(attachment.localUri))
+        assertTrue(compressedFile.exists())
+        assertEquals("Compressed Lossless Webp Bytes", compressedFile.readText())
+
+        // Clean up
+        tempFilesDir.deleteRecursively()
+        tempCacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun copyAndCompress_imageJpeg_compressesToWebp_AndroidM() = runTest {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.M)
+
+        val mockContext = mockk<Context>()
+        val mockResolver = mockk<ContentResolver>()
+        val tempFilesDir = File(context.filesDir, "filesDir_image_M").also { it.mkdirs() }
+        val tempCacheDir = File(context.cacheDir, "cacheDir_image_M").also { it.mkdirs() }
+        every { mockContext.filesDir } returns tempFilesDir
+        every { mockContext.cacheDir } returns tempCacheDir
+        every { mockContext.contentResolver } returns mockResolver
+        every { mockContext.packageName } returns "es.pedrazamiguez.splittrip"
+
+        val localService = ReceiptStorageServiceImpl(mockContext, mockConnectionFactory)
+
+        val sourceUri = "content://com.android.providers.media.documents/document/image%3A1"
+        val mockUri = mockk<Uri>(relaxed = true)
+        mockkStatic(Uri::class)
+        every { Uri.parse(sourceUri) } returns mockUri
+        every { mockResolver.getType(mockUri) } returns "image/jpeg"
+
+        val imageData = "Fake Image Data".toByteArray()
+        every { mockResolver.openInputStream(mockUri) } returns ByteArrayInputStream(imageData)
+
+        mockkStatic(BitmapFactory::class)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { BitmapFactory.decodeFile(any(), any()) } returns mockBitmap
+        every { mockBitmap.compress(any(), any(), any()) } answers {
+            val os = arg<java.io.OutputStream>(2)
+            os.write("Compressed Legacy Webp Bytes".toByteArray())
+            true
+        }
+
+        // When
+        val attachment = localService.copyAndCompress(sourceUri)
+
+        // Then
+        assertNotNull(attachment)
+        assertEquals("image/webp", attachment.mimeType)
+        assertTrue(attachment.localUri.endsWith(".webp"))
+
+        val compressedFile = File(java.net.URI(attachment.localUri))
+        assertTrue(compressedFile.exists())
+        assertEquals("Compressed Legacy Webp Bytes", compressedFile.readText())
+
+        // Clean up
+        tempFilesDir.deleteRecursively()
+        tempCacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun copyAndCompress_cameraTempFile_deletesSourceCameraFile() = runTest {
+        val mockContext = mockk<Context>()
+        val mockResolver = mockk<ContentResolver>()
+        val tempFilesDir = File(context.filesDir, "filesDir_camera").also { it.mkdirs() }
+        val tempCacheDir = File(context.cacheDir, "cacheDir_camera").also { it.mkdirs() }
+        every { mockContext.filesDir } returns tempFilesDir
+        every { mockContext.cacheDir } returns tempCacheDir
+        every { mockContext.contentResolver } returns mockResolver
+        every { mockContext.packageName } returns "es.pedrazamiguez.splittrip"
+
+        val localService = ReceiptStorageServiceImpl(mockContext, mockConnectionFactory)
+
+        val receiptsDir = File(tempFilesDir, "receipts").also { it.mkdirs() }
+        val cameraFile = File(receiptsDir, "camera_123.jpg").also { it.writeText("Camera Photo Bytes") }
+
+        val sourceUri = "content://es.pedrazamiguez.splittrip.fileprovider/camera_123.jpg"
+        val mockUri = mockk<Uri>(relaxed = true)
+        mockkStatic(Uri::class)
+        every { Uri.parse(sourceUri) } returns mockUri
+        every { mockUri.authority } returns "es.pedrazamiguez.splittrip.fileprovider"
+        every { mockUri.lastPathSegment } returns "camera_123.jpg"
+
+        every { mockResolver.getType(mockUri) } returns "image/jpeg"
+        every { mockResolver.openInputStream(mockUri) } returns ByteArrayInputStream("Camera Photo Bytes".toByteArray())
+
+        mockkStatic(BitmapFactory::class)
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { BitmapFactory.decodeFile(any(), any()) } returns mockBitmap
+        every { mockBitmap.compress(any(), any(), any()) } returns true
+
+        // When
+        val attachment = localService.copyAndCompress(sourceUri)
+
+        // Then
+        assertNotNull(attachment)
+        assertTrue("Camera temp file should be deleted", !cameraFile.exists())
+
+        // Clean up
+        tempFilesDir.deleteRecursively()
+        tempCacheDir.deleteRecursively()
     }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
@@ -7,10 +7,6 @@ import io.mockk.mockk
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.HttpURLConnection
-import java.net.URL
-import java.net.URLConnection
-import java.net.URLStreamHandler
-import java.net.URLStreamHandlerFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -27,49 +23,18 @@ class ReceiptStorageServiceImplTest {
     private lateinit var context: Context
     private lateinit var service: ReceiptStorageServiceImpl
     private lateinit var mockConnection: HttpURLConnection
-
-    companion object {
-        private var factoryRegistered = false
-
-        @Volatile
-        private var mockConnectionInstance: HttpURLConnection? = null
-
-        private fun registerFactoryIfNeeded() {
-            if (!factoryRegistered) {
-                try {
-                    URL.setURLStreamHandlerFactory(object : URLStreamHandlerFactory {
-                        override fun createURLStreamHandler(protocol: String): URLStreamHandler? {
-                            if (protocol == "http" || protocol == "https") {
-                                return object : URLStreamHandler() {
-                                    override fun openConnection(u: URL?): URLConnection {
-                                        return mockConnectionInstance
-                                            ?: error("Mock Connection not set")
-                                    }
-                                }
-                            }
-                            return null
-                        }
-                    })
-                    factoryRegistered = true
-                } catch (ignored: Error) {
-                    // Already set, ignore
-                }
-            }
-        }
-    }
+    private lateinit var mockConnectionFactory: HttpConnectionFactory
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        service = ReceiptStorageServiceImpl(context)
         mockConnection = mockk(relaxed = true)
-        registerFactoryIfNeeded()
-        mockConnectionInstance = mockConnection
+        mockConnectionFactory = HttpConnectionFactory { mockConnection }
+        service = ReceiptStorageServiceImpl(context, mockConnectionFactory)
     }
 
     @After
     fun tearDown() {
-        mockConnectionInstance = null
         val receiptsDir = File(context.filesDir, "receipts")
         if (receiptsDir.exists()) {
             receiptsDir.deleteRecursively()

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
@@ -7,6 +7,7 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import es.pedrazamiguez.splittrip.domain.exception.TerminalDownloadException
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -89,7 +90,8 @@ class ReceiptStorageServiceImplTest {
         try {
             service.downloadAndStore(remoteUrl)
             org.junit.Assert.fail("Expected an exception to be thrown")
-        } catch (e: Exception) {
+        } catch (e: TerminalDownloadException) {
+            assertEquals(404, e.responseCode)
             assertTrue(e.message?.contains("Failed to download file: HTTP 404") == true)
         }
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -273,6 +273,10 @@ class ExpenseRepositoryImpl(
         localExpenseDataSource.updateReceiptRemoteUrl(expenseId, remoteUrl)
     }
 
+    override suspend fun updateReceiptLocalUri(expenseId: String, localUri: String) {
+        localExpenseDataSource.updateReceiptLocalUri(expenseId, localUri)
+    }
+
     /**
      * Uploads the receipt to Firebase Cloud Storage if the expense has an attachment with a
      * local path but no remote URL yet.  Called inside the syncScope after the Firestore write

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreCapabilityProvider.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreCapabilityProvider.kt
@@ -12,7 +12,9 @@ import java.util.Locale
  * disk I/O and the installed package set does not change within a process lifetime.
  */
 internal class AICoreCapabilityProvider(
-    private val context: Context
+    private val context: Context,
+    private val sdkInt: Int = Build.VERSION.SDK_INT,
+    private val manufacturer: String = Build.MANUFACTURER
 ) {
     @Volatile private var cachedIsSupported: Boolean? = null
 
@@ -21,9 +23,9 @@ internal class AICoreCapabilityProvider(
     }
 
     private fun computeIsSupported(): Boolean {
-        val sdkSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-        val manufacturer = Build.MANUFACTURER.lowercase(Locale.ROOT)
-        val manufacturerSupported = manufacturer.contains("google") || manufacturer.contains("samsung")
+        val sdkSupported = sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        val manufacturerLower = manufacturer.lowercase(Locale.ROOT)
+        val manufacturerSupported = manufacturerLower.contains("google") || manufacturerLower.contains("samsung")
         if (!sdkSupported || !manufacturerSupported) return false
         return try {
             @Suppress("DEPRECATION")

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreCapabilityProviderTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreCapabilityProviderTest.kt
@@ -1,0 +1,96 @@
+package es.pedrazamiguez.splittrip.data.service
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AICoreCapabilityProviderTest {
+
+    private lateinit var context: Context
+    private lateinit var packageManager: PackageManager
+
+    @BeforeEach
+    fun setUp() {
+        context = mockk()
+        packageManager = mockk()
+        every { context.packageManager } returns packageManager
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+        unmockkAll()
+    }
+
+    @Test
+    fun `isSupported returns false when SDK is below UpsideDownCake`() {
+        val provider = AICoreCapabilityProvider(
+            context = context,
+            sdkInt = Build.VERSION_CODES.M,
+            manufacturer = "Google"
+        )
+        assertFalse(provider.isSupported())
+    }
+
+    @Test
+    fun `isSupported returns false when manufacturer is not Google or Samsung`() {
+        val provider = AICoreCapabilityProvider(
+            context = context,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+            manufacturer = "Xiaomi"
+        )
+        assertFalse(provider.isSupported())
+    }
+
+    @Test
+    fun `isSupported returns false when package is not installed`() {
+        val provider = AICoreCapabilityProvider(
+            context = context,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+            manufacturer = "Samsung"
+        )
+        every { packageManager.getPackageInfo("com.google.android.aicore", 0) } throws
+            PackageManager.NameNotFoundException()
+
+        assertFalse(provider.isSupported())
+    }
+
+    @Test
+    fun `isSupported returns true when SDK, manufacturer and package are all valid`() {
+        val provider = AICoreCapabilityProvider(
+            context = context,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+            manufacturer = "Google"
+        )
+        every { packageManager.getPackageInfo("com.google.android.aicore", 0) } returns mockk<PackageInfo>()
+
+        assertTrue(provider.isSupported())
+    }
+
+    @Test
+    fun `isSupported caches the result after first call`() {
+        val provider = AICoreCapabilityProvider(
+            context = context,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+            manufacturer = "Google"
+        )
+        every { packageManager.getPackageInfo("com.google.android.aicore", 0) } returns mockk<PackageInfo>()
+
+        assertTrue(provider.isSupported())
+        assertTrue(provider.isSupported())
+
+        // Verify packageInfo was only checked once
+        verify(exactly = 1) { packageManager.getPackageInfo("com.google.android.aicore", 0) }
+    }
+}

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParserTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/AICoreReceiptParserTest.kt
@@ -1,10 +1,46 @@
 package es.pedrazamiguez.splittrip.data.service
 
+import com.google.ai.edge.aicore.Candidate
+import com.google.ai.edge.aicore.GenerateContentResponse
+import com.google.ai.edge.aicore.GenerativeModel
+import es.pedrazamiguez.splittrip.domain.model.ExtractionConfidence
+import es.pedrazamiguez.splittrip.domain.model.ExtractionSource
+import es.pedrazamiguez.splittrip.domain.model.RawReceiptText
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class AICoreReceiptParserTest {
+
+    private lateinit var generativeModel: GenerativeModel
+    private lateinit var parser: AICoreReceiptParser
+
+    @BeforeEach
+    fun setUp() {
+        generativeModel = mockk(relaxed = true)
+        parser = AICoreReceiptParser(generativeModel)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+        unmockkAll()
+    }
 
     // ── smartTruncate — no truncation needed ──────────────────────────────────
 
@@ -24,10 +60,8 @@ class AICoreReceiptParserTest {
 
     @Test
     fun `smartTruncate result length never exceeds budget when input is long`() {
-        // Simulates a 5-page flight receipt (~6 000 chars).
         val text = "X".repeat(6_000)
         val result = AICoreReceiptParser.smartTruncate(text)
-        // head(600) + "\n…\n"(3) + tail(2397) = 3000
         assertTrue(result.length <= 3_000, "Expected ≤3000 chars, got ${result.length}")
     }
 
@@ -39,7 +73,6 @@ class AICoreReceiptParserTest {
 
         val result = AICoreReceiptParser.smartTruncate(text)
 
-        // The first 600 chars (airline name block) must be intact.
         assertTrue(
             result.startsWith(airlineName),
             "Head of result should start with the merchant/airline name block"
@@ -50,7 +83,6 @@ class AICoreReceiptParserTest {
     fun `smartTruncate preserves grand total at the tail`() {
         val header = "HEADER DATA ".repeat(300) // long, will be truncated
         val grandTotalLine = "GRAND TOTAL 1234.56 EUR 2026-05-22"
-        // Pad so the grand total line is the very last content, within the last 2400 chars.
         val fareSection = "item ".repeat(400) + grandTotalLine
 
         val text = header + fareSection
@@ -68,5 +100,227 @@ class AICoreReceiptParserTest {
         val text = "A".repeat(6_000)
         val result = AICoreReceiptParser.smartTruncate(text)
         assertTrue(result.contains("\n…\n"), "Truncated result must contain the ellipsis separator")
+    }
+
+    // ── parse ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse returns empty receipt when raw text is blank`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "   ",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isSuccess)
+        val receipt = result.getOrThrow()
+        assertNull(receipt.amount)
+        assertNull(receipt.currency)
+        assertNull(receipt.date)
+        assertNull(receipt.title)
+        assertEquals(ExtractionSource.AI_CORE, receipt.source)
+        assertEquals(ExtractionConfidence.LOW, receipt.confidence)
+    }
+
+    @Test
+    fun `parse parses valid JSON with all fields as HIGH confidence`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store 12.34 EUR 2026-05-20",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val jsonResponse = """
+            {
+                "amount": "12.34",
+                "currency": "EUR",
+                "date": "2026-05-20",
+                "title": "Store"
+            }
+        """.trimIndent()
+
+        val mockResponse = mockk<GenerateContentResponse>()
+        val mockCandidate = mockk<Candidate>()
+        every { mockResponse.text } returns jsonResponse
+        every { mockResponse.candidates } returns listOf(mockCandidate)
+        every { mockCandidate.finishReason } returns Candidate.FinishReason.STOP
+
+        coEvery { generativeModel.generateContent(any<String>()) } returns mockResponse
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isSuccess)
+        val receipt = result.getOrThrow()
+        assertEquals(BigDecimal("12.34"), receipt.amount)
+        assertEquals("EUR", receipt.currency)
+        assertEquals(LocalDate.of(2026, 5, 20), receipt.date)
+        assertEquals("Store", receipt.title)
+        assertEquals(ExtractionConfidence.HIGH, receipt.confidence)
+
+        coVerify(exactly = 1) { generativeModel.prepareInferenceEngine() }
+    }
+
+    @Test
+    fun `parse parses valid JSON with three fields as MEDIUM confidence`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store 12.34 2026-05-20",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val jsonResponse = """
+            {
+                "amount": "12.34",
+                "date": "2026-05-20",
+                "title": "Store"
+            }
+        """.trimIndent()
+
+        val mockResponse = mockk<GenerateContentResponse>()
+        val mockCandidate = mockk<Candidate>()
+        every { mockResponse.text } returns jsonResponse
+        every { mockResponse.candidates } returns listOf(mockCandidate)
+        every { mockCandidate.finishReason } returns Candidate.FinishReason.STOP
+
+        coEvery { generativeModel.generateContent(any<String>()) } returns mockResponse
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isSuccess)
+        val receipt = result.getOrThrow()
+        assertEquals(BigDecimal("12.34"), receipt.amount)
+        assertNull(receipt.currency)
+        assertEquals(LocalDate.of(2026, 5, 20), receipt.date)
+        assertEquals("Store", receipt.title)
+        assertEquals(ExtractionConfidence.MEDIUM, receipt.confidence)
+    }
+
+    @Test
+    fun `parse parses valid JSON with two fields as MEDIUM confidence`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store 12.34",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val jsonResponse = """
+            {
+                "amount": "12.34",
+                "title": "Store"
+            }
+        """.trimIndent()
+
+        val mockResponse = mockk<GenerateContentResponse>()
+        val mockCandidate = mockk<Candidate>()
+        every { mockResponse.text } returns jsonResponse
+        every { mockResponse.candidates } returns listOf(mockCandidate)
+        every { mockCandidate.finishReason } returns Candidate.FinishReason.STOP
+
+        coEvery { generativeModel.generateContent(any<String>()) } returns mockResponse
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isSuccess)
+        val receipt = result.getOrThrow()
+        assertEquals(BigDecimal("12.34"), receipt.amount)
+        assertNull(receipt.currency)
+        assertNull(receipt.date)
+        assertEquals("Store", receipt.title)
+        assertEquals(ExtractionConfidence.MEDIUM, receipt.confidence)
+    }
+
+    @Test
+    fun `parse parses valid JSON with one field as LOW confidence`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val jsonResponse = """
+            {
+                "title": "Store"
+            }
+        """.trimIndent()
+
+        val mockResponse = mockk<GenerateContentResponse>()
+        val mockCandidate = mockk<Candidate>()
+        every { mockResponse.text } returns jsonResponse
+        every { mockResponse.candidates } returns listOf(mockCandidate)
+        every { mockCandidate.finishReason } returns Candidate.FinishReason.STOP
+
+        coEvery { generativeModel.generateContent(any<String>()) } returns mockResponse
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isSuccess)
+        val receipt = result.getOrThrow()
+        assertNull(receipt.amount)
+        assertNull(receipt.currency)
+        assertNull(receipt.date)
+        assertEquals("Store", receipt.title)
+        assertEquals(ExtractionConfidence.LOW, receipt.confidence)
+    }
+
+    @Test
+    fun `parse returns empty receipt when response is not valid JSON`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store 12.34",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val nonJsonResponse = "This is not a JSON object"
+
+        val mockResponse = mockk<GenerateContentResponse>()
+        val mockCandidate = mockk<Candidate>()
+        every { mockResponse.text } returns nonJsonResponse
+        every { mockResponse.candidates } returns listOf(mockCandidate)
+        every { mockCandidate.finishReason } returns Candidate.FinishReason.STOP
+
+        coEvery { generativeModel.generateContent(any<String>()) } returns mockResponse
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isSuccess)
+        val receipt = result.getOrThrow()
+        assertNull(receipt.amount)
+        assertNull(receipt.currency)
+        assertNull(receipt.date)
+        assertNull(receipt.title)
+        assertEquals(ExtractionConfidence.LOW, receipt.confidence)
+    }
+
+    @Test
+    fun `parse propagates exception when inference fails`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store 12.34",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val exception = RuntimeException("Inference engine error")
+
+        coEvery { generativeModel.generateContent(any<String>()) } throws exception
+
+        val result = parser.parse(rawText)
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `parse rethrows CancellationException`() = runTest {
+        val rawText = RawReceiptText(
+            fullText = "Store 12.34",
+            blocks = persistentListOf(),
+            recognisedAt = Instant.now()
+        )
+        val cancellationException = CancellationException("Job cancelled")
+
+        coEvery { generativeModel.generateContent(any<String>()) } throws cancellationException
+
+        try {
+            parser.parse(rawText)
+            org.junit.jupiter.api.Assertions.fail("Expected CancellationException to be thrown")
+        } catch (e: CancellationException) {
+            assertEquals("Job cancelled", e.message)
+        }
     }
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalExpenseDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/local/LocalExpenseDataSource.kt
@@ -49,5 +49,11 @@ interface LocalExpenseDataSource {
      */
     suspend fun updateReceiptRemoteUrl(expenseId: String, remoteUrl: String)
 
+    /**
+     * Persists the stable local URI for an expense's receipt.
+     * Called by the repository after a successful background download.
+     */
+    suspend fun updateReceiptLocalUri(expenseId: String, localUri: String)
+
     suspend fun clearAllExpenses()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/ExpensesDomainModule.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/ExpensesDomainModule.kt
@@ -21,6 +21,7 @@ import es.pedrazamiguez.splittrip.domain.service.split.SubunitAwareSplitService
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AttachReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.DownloadReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetAvailableWithdrawalPoolsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
@@ -81,5 +82,11 @@ val expensesDomainModule = module {
     factory { SubunitAwareSplitService(splitCalculatorFactory = get<ExpenseSplitCalculatorFactory>()) }
     factory<AttachReceiptUseCase> {
         AttachReceiptUseCase(receiptStorageService = get<ReceiptStorageService>())
+    }
+    factory {
+        DownloadReceiptUseCase(
+            receiptStorageService = get<ReceiptStorageService>(),
+            expenseRepository = get<ExpenseRepository>()
+        )
     }
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/exception/TerminalDownloadException.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/exception/TerminalDownloadException.kt
@@ -1,0 +1,9 @@
+package es.pedrazamiguez.splittrip.domain.exception
+
+/**
+ * Thrown when a remote receipt download fails with a terminal HTTP response code (e.g. 4xx).
+ */
+class TerminalDownloadException(
+    val responseCode: Int,
+    message: String
+) : Exception(message)

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/ExpenseRepository.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/ExpenseRepository.kt
@@ -54,4 +54,10 @@ interface ExpenseRepository {
      * (e.g. after a cross-device download).
      */
     suspend fun updateReceiptRemoteUrl(expenseId: String, remoteUrl: String)
+
+    /**
+     * Writes the local URI for an expense's receipt to local Room so that subsequent
+     * reads can load the file from on-device storage.
+     */
+    suspend fun updateReceiptLocalUri(expenseId: String, localUri: String)
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ReceiptStorageService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ReceiptStorageService.kt
@@ -22,4 +22,12 @@ interface ReceiptStorageService {
      * @throws IllegalStateException if the file could not be written to app storage.
      */
     suspend fun copyAndCompress(sourceUri: String): ReceiptAttachment
+
+    /**
+     * Downloads the file from [remoteUrl] and stores it locally under `filesDir/receipts/`.
+     *
+     * @param remoteUrl The download URL of the remote receipt file.
+     * @return A [ReceiptAttachment] with the stable `file://` local URI.
+     */
+    suspend fun downloadAndStore(remoteUrl: String): ReceiptAttachment
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/DownloadReceiptUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/DownloadReceiptUseCase.kt
@@ -1,0 +1,30 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
+
+/**
+ * Downloads a receipt file from [remoteUrl] and persists its local path [localUri]
+ * in Room for the given [expenseId].
+ *
+ * This ensures subsequent access to the receipt (thumbnail preview or full viewer)
+ * runs offline-first.
+ */
+class DownloadReceiptUseCase(
+    private val receiptStorageService: ReceiptStorageService,
+    private val expenseRepository: ExpenseRepository
+) {
+    /**
+     * Downloads the remote file and updates the repository's local URI.
+     *
+     * @param expenseId The unique ID of the expense.
+     * @param remoteUrl The remote download URL of the receipt.
+     * @return The updated [ReceiptAttachment] containing the new local path.
+     */
+    suspend operator fun invoke(expenseId: String, remoteUrl: String): Result<ReceiptAttachment> = runCatching {
+        val attachment = receiptStorageService.downloadAndStore(remoteUrl)
+        expenseRepository.updateReceiptLocalUri(expenseId, attachment.localUri)
+        attachment
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AttachReceiptUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AttachReceiptUseCaseTest.kt
@@ -1,0 +1,54 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AttachReceiptUseCaseTest {
+
+    private lateinit var receiptStorageService: ReceiptStorageService
+    private lateinit var useCase: AttachReceiptUseCase
+
+    @BeforeEach
+    fun setUp() {
+        receiptStorageService = mockk()
+        useCase = AttachReceiptUseCase(receiptStorageService)
+    }
+
+    @Test
+    fun `invoke calls copyAndCompress and returns success`() = runTest {
+        val sourceUri = "content://picker/receipt.jpg"
+        val attachment = ReceiptAttachment(
+            localUri = "file:///path/to/copied.webp",
+            mimeType = "image/webp",
+            capturedAtMillis = 1000L
+        )
+        coEvery { receiptStorageService.copyAndCompress(sourceUri) } returns attachment
+
+        val result = useCase(sourceUri)
+
+        assertTrue(result.isSuccess)
+        assertEquals(attachment, result.getOrNull())
+        coVerify(exactly = 1) { receiptStorageService.copyAndCompress(sourceUri) }
+    }
+
+    @Test
+    fun `invoke returns failure when storage service throws`() = runTest {
+        val sourceUri = "content://picker/receipt.jpg"
+        val exception = RuntimeException("Copy error")
+        coEvery { receiptStorageService.copyAndCompress(sourceUri) } throws exception
+
+        val result = useCase(sourceUri)
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        coVerify(exactly = 1) { receiptStorageService.copyAndCompress(sourceUri) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/DownloadReceiptUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/DownloadReceiptUseCaseTest.kt
@@ -1,0 +1,71 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DownloadReceiptUseCaseTest {
+
+    private lateinit var receiptStorageService: ReceiptStorageService
+    private lateinit var expenseRepository: ExpenseRepository
+    private lateinit var useCase: DownloadReceiptUseCase
+
+    @BeforeEach
+    fun setUp() {
+        receiptStorageService = mockk()
+        expenseRepository = mockk(relaxed = true)
+        useCase = DownloadReceiptUseCase(receiptStorageService, expenseRepository)
+    }
+
+    @Test
+    fun `invoke downloads receipt and updates repository local URI`() = runTest {
+        // Given
+        val expenseId = "expense-123"
+        val remoteUrl = "https://example.com/receipt.pdf"
+        val localUri = "file:///data/user/0/es.pedrazamiguez.splittrip/files/receipts/unique-pdf.pdf"
+        val attachment = ReceiptAttachment(
+            localUri = localUri,
+            mimeType = "application/pdf",
+            capturedAtMillis = 1000L,
+            remoteUrl = remoteUrl
+        )
+
+        coEvery { receiptStorageService.downloadAndStore(remoteUrl) } returns attachment
+
+        // When
+        val result = useCase(expenseId, remoteUrl)
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(attachment, result.getOrNull())
+        coVerify(exactly = 1) { receiptStorageService.downloadAndStore(remoteUrl) }
+        coVerify(exactly = 1) { expenseRepository.updateReceiptLocalUri(expenseId, localUri) }
+    }
+
+    @Test
+    fun `invoke returns failure when storage service throws`() = runTest {
+        // Given
+        val expenseId = "expense-123"
+        val remoteUrl = "https://example.com/receipt.pdf"
+        val exception = RuntimeException("Download failed")
+
+        coEvery { receiptStorageService.downloadAndStore(remoteUrl) } throws exception
+
+        // When
+        val result = useCase(expenseId, remoteUrl)
+
+        // Then
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        coVerify(exactly = 1) { receiptStorageService.downloadAndStore(remoteUrl) }
+        coVerify(exactly = 0) { expenseRepository.updateReceiptLocalUri(any(), any()) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetExpenseByIdFlowUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetExpenseByIdFlowUseCaseTest.kt
@@ -1,0 +1,49 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetExpenseByIdFlowUseCaseTest {
+
+    private lateinit var expenseRepository: ExpenseRepository
+    private lateinit var useCase: GetExpenseByIdFlowUseCase
+
+    private val testExpense = Expense(
+        id = "expense-123",
+        groupId = "group-456",
+        title = "Dinner",
+        sourceAmount = 5000L,
+        sourceCurrency = "EUR",
+        groupAmount = 5000L,
+        groupCurrency = "EUR",
+        paymentMethod = PaymentMethod.CREDIT_CARD
+    )
+
+    @BeforeEach
+    fun setUp() {
+        expenseRepository = mockk()
+        useCase = GetExpenseByIdFlowUseCase(expenseRepository)
+    }
+
+    @Test
+    fun `invoke returns flow of expense from repository`() = runTest {
+        val flow = flowOf(testExpense)
+        every { expenseRepository.getExpenseByIdFlow("expense-123") } returns flow
+
+        val result = useCase("expense-123").toList()
+
+        assertEquals(1, result.size)
+        assertEquals(testExpense, result[0])
+        verify(exactly = 1) { expenseRepository.getExpenseByIdFlow("expense-123") }
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
@@ -20,6 +20,7 @@ import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AttachReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.DownloadReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetAvailableWithdrawalPoolsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpenseConfigUseCase
@@ -293,6 +294,7 @@ val expensesUiModule = module {
             getCashWithdrawalsFlowUseCase = get<GetCashWithdrawalsFlowUseCase>(),
             getGroupSubunitsUseCase = get<GetGroupSubunitsUseCase>(),
             deleteExpenseUseCase = get<DeleteExpenseUseCase>(),
+            downloadReceiptUseCase = get<DownloadReceiptUseCase>(),
             authenticationService = get<AuthenticationService>(),
             expenseDetailUiMapper = get<ExpenseDetailUiMapper>()
         )

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/navigation/ExpensesNavigation.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/navigation/ExpensesNavigation.kt
@@ -35,9 +35,17 @@ fun NavGraphBuilder.expensesGraph() {
 
     sharedComposable(
         route = Routes.RECEIPT_VIEWER,
-        arguments = listOf(navArgument("receiptUri") { type = NavType.StringType })
+        arguments = listOf(
+            navArgument("receiptUri") { type = NavType.StringType },
+            navArgument("mimeType") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            }
+        )
     ) { backStackEntry ->
         val receiptUri = backStackEntry.arguments?.getString("receiptUri") ?: return@sharedComposable
-        ReceiptViewerFeature(receiptUri = receiptUri)
+        val mimeType = backStackEntry.arguments?.getString("mimeType")
+        ReceiptViewerFeature(receiptUri = receiptUri, mimeType = mimeType)
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/HeroSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/detail/HeroSection.kt
@@ -53,7 +53,6 @@ import es.pedrazamiguez.splittrip.core.designsystem.transition.receiptSharedElem
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.extensions.toIconVector
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseDetailUiModel
-import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -214,50 +213,60 @@ private fun isPdf(uriString: String, mimeType: String?): Boolean {
     return false
 }
 
-private fun renderPdfFirstPage(file: File): Bitmap? {
-    if (!file.exists() || file.length() == 0L) return null
+private fun renderPdfFirstPage(context: android.content.Context, uri: Uri): Bitmap? {
     var pfd: ParcelFileDescriptor? = null
     var renderer: PdfRenderer? = null
     var page: PdfRenderer.Page? = null
     try {
-        pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-        renderer = PdfRenderer(pfd)
-        if (renderer.pageCount > 0) {
-            page = renderer.openPage(0)
-            val aspectRatio = page.width.toFloat() / page.height.toFloat()
-            val targetWidth = (aspectRatio * 480).toInt()
-            val destBitmap = Bitmap.createBitmap(
-                targetWidth.coerceAtLeast(1),
-                480,
-                Bitmap.Config.ARGB_8888
-            )
-            val canvas = android.graphics.Canvas(destBitmap)
-            canvas.drawColor(android.graphics.Color.WHITE)
-            page.render(destBitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-            return destBitmap
+        pfd = context.contentResolver.openFileDescriptor(uri, "r")
+        if (pfd != null) {
+            renderer = PdfRenderer(pfd)
+            if (renderer.pageCount > 0) {
+                page = renderer.openPage(0)
+                val aspectRatio = page.width.toFloat() / page.height.toFloat()
+                val targetWidth = (aspectRatio * 480).toInt()
+                val destBitmap = Bitmap.createBitmap(
+                    targetWidth.coerceAtLeast(1),
+                    480,
+                    Bitmap.Config.ARGB_8888
+                )
+                val canvas = android.graphics.Canvas(destBitmap)
+                canvas.drawColor(android.graphics.Color.WHITE)
+                page.render(destBitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                return destBitmap
+            }
         }
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to render PDF page for $uri")
     } finally {
-        page?.close()
-        renderer?.close()
-        pfd?.close()
+        try {
+            page?.close()
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
+        try {
+            renderer?.close()
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
+        try {
+            pfd?.close()
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
     }
     return null
 }
 
 @Composable
 private fun rememberPdfThumbnail(pdfUriString: String): Bitmap? {
+    val context = LocalContext.current
     var bitmap by remember(pdfUriString) { mutableStateOf<Bitmap?>(null) }
     LaunchedEffect(pdfUriString) {
         val rendered = withContext(Dispatchers.IO) {
             try {
                 val uri = Uri.parse(pdfUriString)
-                val isLocalFile = uri.scheme == "file" || uri.scheme.isNullOrEmpty()
-                if (isLocalFile) {
-                    val filePath = if (uri.scheme == "file") uri.path.orEmpty() else pdfUriString
-                    renderPdfFirstPage(File(filePath))
-                } else {
-                    null
-                }
+                renderPdfFirstPage(context, uri)
             } catch (e: Exception) {
                 Timber.e(e, "Failed to render PDF thumbnail for $pdfUriString")
                 null
@@ -283,7 +292,7 @@ private fun ReceiptThumbnail(
             .clip(MaterialTheme.shapes.large)
             .background(MaterialTheme.colorScheme.surfaceContainerHighest)
             .then(
-                if (onClick != null && !isPdf) {
+                if (onClick != null) {
                     Modifier.clickable(onClick = onClick)
                 } else {
                     Modifier

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/AddExpenseFeature.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/AddExpenseFeature.kt
@@ -96,7 +96,10 @@ fun AddExpenseFeature(
                 is AddExpenseUiEvent.ViewReceiptFullScreen -> {
                     state.receiptUri?.let { uri ->
                         navController.navigate(
-                            es.pedrazamiguez.splittrip.core.designsystem.navigation.Routes.receiptViewerRoute(uri)
+                            es.pedrazamiguez.splittrip.core.designsystem.navigation.Routes.receiptViewerRoute(
+                                uri,
+                                state.receiptAttachment?.mimeType
+                            )
                         )
                     }
                 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ExpenseDetailFeature.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ExpenseDetailFeature.kt
@@ -44,10 +44,11 @@ fun ExpenseDetailFeature(
         }
     }
 
+    val expense = uiState.expense
     ExpenseDetailScreen(
         uiState = uiState,
-        onReceiptTap = uiState.expense?.receiptUri?.let { uri ->
-            { navController.navigate(Routes.receiptViewerRoute(uri)) }
+        onReceiptTap = expense?.receiptUri?.let { uri ->
+            { navController.navigate(Routes.receiptViewerRoute(uri, expense.receiptMimeType)) }
         }
     )
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ReceiptViewerFeature.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ReceiptViewerFeature.kt
@@ -8,12 +8,14 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.screen.ReceiptVi
 @Composable
 fun ReceiptViewerFeature(
     receiptUri: String,
+    mimeType: String?,
     modifier: Modifier = Modifier
 ) {
     val navController = LocalTabNavController.current
 
     ReceiptViewerScreen(
         receiptUri = receiptUri,
+        mimeType = mimeType,
         onClose = { navController.popBackStack() },
         modifier = modifier
     )

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
@@ -1,0 +1,267 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.screen
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Receipt
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.EmptyStateView
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.ShimmerLoadingList
+import es.pedrazamiguez.splittrip.features.expense.R
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+private const val MIN_ZOOM_SCALE = 1f
+private const val MAX_ZOOM_SCALE = 5f
+private const val ZOOM_EPSILON = 0.01f
+private const val HTTP_TIMEOUT_MS = 10000
+
+@Composable
+internal fun PdfViewerContent(
+    pdfUriString: String,
+    hazeState: HazeState,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    var pages by remember { mutableStateOf<List<Bitmap>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var hasError by remember { mutableStateOf(false) }
+
+    LaunchedEffect(pdfUriString) {
+        isLoading = true
+        hasError = false
+        withContext(Dispatchers.IO) {
+            try {
+                pages = loadPdfPages(context, pdfUriString)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load/render PDF in viewer")
+                hasError = true
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    when {
+        isLoading -> PdfLoadingView(hazeState = hazeState, modifier = modifier)
+        hasError || pages.isEmpty() -> PdfErrorView(hazeState = hazeState, modifier = modifier)
+        else -> PdfPagesListView(
+            pages = pages,
+            hazeState = hazeState,
+            onClose = onClose,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun PdfLoadingView(hazeState: HazeState, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .hazeSource(state = hazeState),
+        contentAlignment = Alignment.Center
+    ) {
+        ShimmerLoadingList()
+    }
+}
+
+@Composable
+private fun PdfErrorView(hazeState: HazeState, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .hazeSource(state = hazeState),
+        contentAlignment = Alignment.Center
+    ) {
+        EmptyStateView(
+            title = stringResource(R.string.receipt_viewer_pdf_error),
+            icon = TablerIcons.Outline.Receipt
+        )
+    }
+}
+
+@Composable
+private fun PdfPagesListView(
+    pages: List<Bitmap>,
+    hazeState: HazeState,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var scale by remember { mutableFloatStateOf(MIN_ZOOM_SCALE) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .hazeSource(state = hazeState)
+            .pointerInput(Unit) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    val targetScale = (scale * zoom).coerceIn(MIN_ZOOM_SCALE, MAX_ZOOM_SCALE)
+                    if (targetScale <= MIN_ZOOM_SCALE + ZOOM_EPSILON) {
+                        scale = MIN_ZOOM_SCALE
+                        offset = Offset.Zero
+                    } else {
+                        scale = targetScale
+                        offset += pan
+                    }
+                }
+            }
+            .graphicsLayer(
+                scaleX = scale,
+                scaleY = scale,
+                translationX = offset.x,
+                translationY = offset.y
+            )
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = {
+                    if (scale <= MIN_ZOOM_SCALE + ZOOM_EPSILON) {
+                        onClose()
+                    }
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(vertical = 80.dp, horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            userScrollEnabled = scale <= MIN_ZOOM_SCALE + ZOOM_EPSILON
+        ) {
+            items(pages.size) { index ->
+                PdfPageItem(bitmap = pages[index], pageNumber = index + 1)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PdfPageItem(bitmap: Bitmap, pageNumber: Int, modifier: Modifier = Modifier) {
+    FlatCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        ghostBorder = true
+    ) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = stringResource(R.string.receipt_viewer_pdf_page_cd, pageNumber),
+            modifier = Modifier.fillMaxWidth(),
+            contentScale = ContentScale.FillWidth
+        )
+    }
+}
+
+private suspend fun loadPdfPages(context: Context, pdfUriString: String): List<Bitmap> {
+    val uri = Uri.parse(pdfUriString)
+    val targetUri = if (uri.scheme == "http" || uri.scheme == "https") {
+        val tempFile = File(context.cacheDir, "temp_viewer_${UUID.randomUUID()}.pdf")
+        downloadUrlToFile(pdfUriString, tempFile)
+        Uri.fromFile(tempFile)
+    } else {
+        uri
+    }
+
+    val pfd = context.contentResolver.openFileDescriptor(targetUri, "r") ?: return emptyList()
+    var renderer: PdfRenderer? = null
+    try {
+        renderer = PdfRenderer(pfd)
+        val list = mutableListOf<Bitmap>()
+        for (i in 0 until renderer.pageCount) {
+            list.add(renderPageToBitmap(renderer, i))
+        }
+        return list
+    } finally {
+        closeRendererAndPfd(renderer, pfd)
+    }
+}
+
+private fun renderPageToBitmap(renderer: PdfRenderer, pageIndex: Int): Bitmap {
+    var page: PdfRenderer.Page? = null
+    try {
+        page = renderer.openPage(pageIndex)
+        val width = page.width * 2
+        val height = page.height * 2
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = android.graphics.Canvas(bitmap)
+        canvas.drawColor(android.graphics.Color.WHITE)
+        page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+        return bitmap
+    } finally {
+        page?.close()
+    }
+}
+
+private fun downloadUrlToFile(remoteUrl: String, tempFile: File) {
+    val url = java.net.URL(remoteUrl)
+    val connection = url.openConnection() as java.net.HttpURLConnection
+    try {
+        connection.connectTimeout = HTTP_TIMEOUT_MS
+        connection.readTimeout = HTTP_TIMEOUT_MS
+        connection.requestMethod = "GET"
+        connection.connect()
+        if (connection.responseCode != java.net.HttpURLConnection.HTTP_OK) {
+            error("HTTP error code: ${connection.responseCode}")
+        }
+        connection.inputStream.use { input ->
+            FileOutputStream(tempFile).use { output ->
+                input.copyTo(output)
+            }
+        }
+    } finally {
+        connection.disconnect()
+    }
+}
+
+private fun closeRendererAndPfd(renderer: PdfRenderer?, pfd: ParcelFileDescriptor) {
+    try {
+        renderer?.close()
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to close PdfRenderer")
+    }
+    try {
+        pfd.close()
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to close ParcelFileDescriptor")
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
@@ -2,6 +2,8 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.screen
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.pdf.PdfRenderer
 import android.net.Uri
 import android.os.ParcelFileDescriptor
@@ -16,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
+import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
 import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Receipt
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.EmptyStateView
@@ -43,6 +47,8 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layou
 import es.pedrazamiguez.splittrip.features.expense.R
 import java.io.File
 import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -164,8 +170,9 @@ private fun PdfPagesListView(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(vertical = 80.dp, horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            // vertical = 80.dp leaves room for the floating top bar / close button
+            contentPadding = PaddingValues(vertical = 80.dp, horizontal = MaterialTheme.spacing.Default),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Default),
             userScrollEnabled = scale <= MIN_ZOOM_SCALE + ZOOM_EPSILON
         ) {
             items(pages.size) { index ->
@@ -194,25 +201,35 @@ private fun PdfPageItem(bitmap: Bitmap, pageNumber: Int, modifier: Modifier = Mo
 
 private suspend fun loadPdfPages(context: Context, pdfUriString: String): List<Bitmap> {
     val uri = Uri.parse(pdfUriString)
-    val targetUri = if (uri.scheme == "http" || uri.scheme == "https") {
-        val tempFile = File(context.cacheDir, "temp_viewer_${UUID.randomUUID()}.pdf")
-        downloadUrlToFile(pdfUriString, tempFile)
-        Uri.fromFile(tempFile)
+    val isRemote = uri.scheme == "http" || uri.scheme == "https"
+    val tempFile = if (isRemote) {
+        File(context.cacheDir, "temp_viewer_${UUID.randomUUID()}.pdf")
     } else {
-        uri
+        null
     }
 
-    val pfd = context.contentResolver.openFileDescriptor(targetUri, "r") ?: return emptyList()
-    var renderer: PdfRenderer? = null
     try {
-        renderer = PdfRenderer(pfd)
-        val list = mutableListOf<Bitmap>()
-        for (i in 0 until renderer.pageCount) {
-            list.add(renderPageToBitmap(renderer, i))
+        val targetUri = if (tempFile != null) {
+            downloadUrlToFile(pdfUriString, tempFile)
+            Uri.fromFile(tempFile)
+        } else {
+            uri
         }
-        return list
+
+        val pfd = context.contentResolver.openFileDescriptor(targetUri, "r") ?: return emptyList()
+        var renderer: PdfRenderer? = null
+        try {
+            renderer = PdfRenderer(pfd)
+            val list = mutableListOf<Bitmap>()
+            for (i in 0 until renderer.pageCount) {
+                list.add(renderPageToBitmap(renderer, i))
+            }
+            return list
+        } finally {
+            closeRendererAndPfd(renderer, pfd)
+        }
     } finally {
-        closeRendererAndPfd(renderer, pfd)
+        tempFile?.delete()
     }
 }
 
@@ -220,11 +237,18 @@ private fun renderPageToBitmap(renderer: PdfRenderer, pageIndex: Int): Bitmap {
     var page: PdfRenderer.Page? = null
     try {
         page = renderer.openPage(pageIndex)
-        val width = page.width * 2
-        val height = page.height * 2
+        val maxDimension = 2048
+        var width = page.width * 2
+        var height = page.height * 2
+        val maxDim = maxOf(width, height)
+        if (maxDim > maxDimension) {
+            val scale = maxDimension.toDouble() / maxDim
+            width = (width * scale).toInt().coerceAtLeast(1)
+            height = (height * scale).toInt().coerceAtLeast(1)
+        }
         val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-        val canvas = android.graphics.Canvas(bitmap)
-        canvas.drawColor(android.graphics.Color.WHITE)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
         page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
         return bitmap
     } finally {
@@ -233,14 +257,14 @@ private fun renderPageToBitmap(renderer: PdfRenderer, pageIndex: Int): Bitmap {
 }
 
 private fun downloadUrlToFile(remoteUrl: String, tempFile: File) {
-    val url = java.net.URL(remoteUrl)
-    val connection = url.openConnection() as java.net.HttpURLConnection
+    val url = URL(remoteUrl)
+    val connection = url.openConnection() as HttpURLConnection
     try {
         connection.connectTimeout = HTTP_TIMEOUT_MS
         connection.readTimeout = HTTP_TIMEOUT_MS
         connection.requestMethod = "GET"
         connection.connect()
-        if (connection.responseCode != java.net.HttpURLConnection.HTTP_OK) {
+        if (connection.responseCode != HttpURLConnection.HTTP_OK) {
             error("HTTP error code: ${connection.responseCode}")
         }
         connection.inputStream.use { input ->

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.statusBars
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -38,6 +40,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
@@ -55,6 +58,8 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -62,6 +67,28 @@ private const val MIN_ZOOM_SCALE = 1f
 private const val MAX_ZOOM_SCALE = 5f
 private const val ZOOM_EPSILON = 0.01f
 private const val HTTP_TIMEOUT_MS = 10000
+private const val A4_ASPECT_RATIO = 0.707f
+private val FLOATING_TOP_BAR_HEIGHT = 64.dp
+
+private class PdfResourceHolder(
+    val renderer: PdfRenderer,
+    val pfd: ParcelFileDescriptor,
+    val tempFile: File?
+) {
+    fun close() {
+        try {
+            renderer.close()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to close PdfRenderer")
+        }
+        try {
+            pfd.close()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to close ParcelFileDescriptor")
+        }
+        tempFile?.delete()
+    }
+}
 
 @Composable
 internal fun PdfViewerContent(
@@ -71,7 +98,7 @@ internal fun PdfViewerContent(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    var pages by remember { mutableStateOf<List<Bitmap>>(emptyList()) }
+    var resourceHolder by remember { mutableStateOf<PdfResourceHolder?>(null) }
     var isLoading by remember { mutableStateOf(true) }
     var hasError by remember { mutableStateOf(false) }
 
@@ -80,9 +107,11 @@ internal fun PdfViewerContent(
         hasError = false
         withContext(Dispatchers.IO) {
             try {
-                pages = loadPdfPages(context, pdfUriString)
+                resourceHolder = initializePdfResources(context, pdfUriString)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
-                Timber.e(e, "Failed to load/render PDF in viewer")
+                Timber.e(e, "Failed to initialize PDF resource holder")
                 hasError = true
             } finally {
                 isLoading = false
@@ -90,15 +119,49 @@ internal fun PdfViewerContent(
         }
     }
 
+    DisposableEffect(pdfUriString) {
+        onDispose {
+            resourceHolder?.close()
+            resourceHolder = null
+        }
+    }
+
+    val currentResourceHolder = resourceHolder
+
     when {
         isLoading -> PdfLoadingView(hazeState = hazeState, modifier = modifier)
-        hasError || pages.isEmpty() -> PdfErrorView(hazeState = hazeState, modifier = modifier)
+        hasError || currentResourceHolder == null -> PdfErrorView(hazeState = hazeState, modifier = modifier)
         else -> PdfPagesListView(
-            pages = pages,
+            resourceHolder = currentResourceHolder,
             hazeState = hazeState,
             onClose = onClose,
             modifier = modifier
         )
+    }
+}
+
+private fun initializePdfResources(context: Context, pdfUriString: String): PdfResourceHolder {
+    var localTempFile: File? = null
+    var localPfd: ParcelFileDescriptor? = null
+    var localRenderer: PdfRenderer? = null
+    try {
+        val uri = Uri.parse(pdfUriString)
+        val isRemote = uri.scheme == "http" || uri.scheme == "https"
+        if (isRemote) {
+            localTempFile = File(context.cacheDir, "temp_viewer_${UUID.randomUUID()}.pdf")
+            downloadUrlToFile(pdfUriString, localTempFile)
+        }
+        val targetUri = if (localTempFile != null) Uri.fromFile(localTempFile) else uri
+        localPfd = checkNotNull(context.contentResolver.openFileDescriptor(targetUri, "r")) {
+            "Could not open file descriptor"
+        }
+        localRenderer = PdfRenderer(localPfd)
+        return PdfResourceHolder(localRenderer, localPfd, localTempFile)
+    } catch (e: Exception) {
+        localRenderer?.close()
+        localPfd?.close()
+        localTempFile?.delete()
+        throw e
     }
 }
 
@@ -131,7 +194,7 @@ private fun PdfErrorView(hazeState: HazeState, modifier: Modifier = Modifier) {
 
 @Composable
 private fun PdfPagesListView(
-    pages: List<Bitmap>,
+    resourceHolder: PdfResourceHolder,
     hazeState: HazeState,
     onClose: () -> Unit,
     modifier: Modifier = Modifier
@@ -140,8 +203,9 @@ private fun PdfPagesListView(
     var offset by remember { mutableStateOf(Offset.Zero) }
     val bottomPadding = LocalBottomPadding.current
     val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-    val topPadding = 64.dp + statusBarHeight + MaterialTheme.spacing.Default
+    val topPadding = FLOATING_TOP_BAR_HEIGHT + statusBarHeight + MaterialTheme.spacing.Default
     val finalBottomPadding = bottomPadding + MaterialTheme.spacing.Default
+    val mutex = remember { Mutex() }
 
     Box(
         modifier = modifier
@@ -176,72 +240,108 @@ private fun PdfPagesListView(
             ),
         contentAlignment = Alignment.Center
     ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-                top = topPadding,
-                bottom = finalBottomPadding,
-                start = MaterialTheme.spacing.Default,
-                end = MaterialTheme.spacing.Default
-            ),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Default),
-            userScrollEnabled = scale <= MIN_ZOOM_SCALE + ZOOM_EPSILON
-        ) {
-            items(pages.size) { index ->
-                PdfPageItem(bitmap = pages[index], pageNumber = index + 1)
-            }
+        PdfLazyColumn(
+            resourceHolder = resourceHolder,
+            topPadding = topPadding,
+            bottomPadding = finalBottomPadding,
+            scrollEnabled = scale <= MIN_ZOOM_SCALE + ZOOM_EPSILON,
+            mutex = mutex
+        )
+    }
+}
+
+@Composable
+private fun PdfLazyColumn(
+    resourceHolder: PdfResourceHolder,
+    topPadding: Dp,
+    bottomPadding: Dp,
+    scrollEnabled: Boolean,
+    mutex: Mutex,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(
+            top = topPadding,
+            bottom = bottomPadding,
+            start = MaterialTheme.spacing.Default,
+            end = MaterialTheme.spacing.Default
+        ),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Default),
+        userScrollEnabled = scrollEnabled
+    ) {
+        items(resourceHolder.renderer.pageCount) { index ->
+            PdfPageItem(
+                renderer = resourceHolder.renderer,
+                mutex = mutex,
+                pageIndex = index
+            )
         }
     }
 }
 
 @Composable
-private fun PdfPageItem(bitmap: Bitmap, pageNumber: Int, modifier: Modifier = Modifier) {
+private fun PdfPageItem(
+    renderer: PdfRenderer,
+    mutex: Mutex,
+    pageIndex: Int,
+    modifier: Modifier = Modifier
+) {
+    var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+    var hasError by remember { mutableStateOf(false) }
+
+    LaunchedEffect(pageIndex) {
+        withContext(Dispatchers.IO) {
+            try {
+                mutex.withLock {
+                    bitmap = renderPageToBitmap(renderer, pageIndex)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to render PDF page $pageIndex")
+                hasError = true
+            }
+        }
+    }
+
     FlatCard(
         modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight(),
         ghostBorder = true
     ) {
-        Image(
-            bitmap = bitmap.asImageBitmap(),
-            contentDescription = stringResource(R.string.receipt_viewer_pdf_page_cd, pageNumber),
-            modifier = Modifier.fillMaxWidth(),
-            contentScale = ContentScale.FillWidth
-        )
-    }
-}
-
-private suspend fun loadPdfPages(context: Context, pdfUriString: String): List<Bitmap> {
-    val uri = Uri.parse(pdfUriString)
-    val isRemote = uri.scheme == "http" || uri.scheme == "https"
-    val tempFile = if (isRemote) {
-        File(context.cacheDir, "temp_viewer_${UUID.randomUUID()}.pdf")
-    } else {
-        null
-    }
-
-    try {
-        val targetUri = if (tempFile != null) {
-            downloadUrlToFile(pdfUriString, tempFile)
-            Uri.fromFile(tempFile)
-        } else {
-            uri
-        }
-
-        val pfd = context.contentResolver.openFileDescriptor(targetUri, "r") ?: return emptyList()
-        var renderer: PdfRenderer? = null
-        try {
-            renderer = PdfRenderer(pfd)
-            val list = mutableListOf<Bitmap>()
-            for (i in 0 until renderer.pageCount) {
-                list.add(renderPageToBitmap(renderer, i))
+        when {
+            hasError -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(A4_ASPECT_RATIO),
+                    contentAlignment = Alignment.Center
+                ) {
+                    EmptyStateView(
+                        title = stringResource(R.string.receipt_viewer_pdf_error),
+                        icon = TablerIcons.Outline.Receipt
+                    )
+                }
             }
-            return list
-        } finally {
-            closeRendererAndPfd(renderer, pfd)
+            bitmap == null -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(A4_ASPECT_RATIO),
+                    contentAlignment = Alignment.Center
+                ) {
+                    ShimmerLoadingList()
+                }
+            }
+            else -> {
+                Image(
+                    bitmap = bitmap!!.asImageBitmap(),
+                    contentDescription = stringResource(R.string.receipt_viewer_pdf_page_cd, pageIndex + 1),
+                    modifier = Modifier.fillMaxWidth(),
+                    contentScale = ContentScale.FillWidth
+                )
+            }
         }
-    } finally {
-        tempFile?.delete()
     }
 }
 
@@ -286,18 +386,5 @@ private fun downloadUrlToFile(remoteUrl: String, tempFile: File) {
         }
     } finally {
         connection.disconnect()
-    }
-}
-
-private fun closeRendererAndPfd(renderer: PdfRenderer?, pfd: ParcelFileDescriptor) {
-    try {
-        renderer?.close()
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to close PdfRenderer")
-    }
-    try {
-        pfd.close()
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to close ParcelFileDescriptor")
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
@@ -14,8 +14,11 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.MaterialTheme
@@ -41,6 +44,7 @@ import dev.chrisbanes.haze.hazeSource
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
 import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Receipt
+import es.pedrazamiguez.splittrip.core.designsystem.navigation.LocalBottomPadding
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.EmptyStateView
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.FlatCard
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.ShimmerLoadingList
@@ -134,6 +138,10 @@ private fun PdfPagesListView(
 ) {
     var scale by remember { mutableFloatStateOf(MIN_ZOOM_SCALE) }
     var offset by remember { mutableStateOf(Offset.Zero) }
+    val bottomPadding = LocalBottomPadding.current
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val topPadding = 64.dp + statusBarHeight + MaterialTheme.spacing.Default
+    val finalBottomPadding = bottomPadding + MaterialTheme.spacing.Default
 
     Box(
         modifier = modifier
@@ -170,8 +178,12 @@ private fun PdfPagesListView(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            // vertical = 80.dp leaves room for the floating top bar / close button
-            contentPadding = PaddingValues(vertical = 80.dp, horizontal = MaterialTheme.spacing.Default),
+            contentPadding = PaddingValues(
+                top = topPadding,
+                bottom = finalBottomPadding,
+                start = MaterialTheme.spacing.Default,
+                end = MaterialTheme.spacing.Default
+            ),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Default),
             userScrollEnabled = scale <= MIN_ZOOM_SCALE + ZOOM_EPSILON
         ) {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ReceiptViewerScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ReceiptViewerScreen.kt
@@ -51,17 +51,22 @@ private fun isPdf(uriString: String): Boolean {
     if (path.lowercase().endsWith(".pdf")) return true
     val lastSegment = uri.lastPathSegment.orEmpty().lowercase()
     if (lastSegment.endsWith(".pdf") || lastSegment.contains(".pdf?")) return true
+    val decodedPath = Uri.decode(uriString).lowercase()
+    if (decodedPath.substringBefore('?').endsWith(".pdf")) return true
     return false
 }
 
 @Composable
 fun ReceiptViewerScreen(
     receiptUri: String,
+    mimeType: String? = null,
     onClose: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val hazeState = remember { HazeState() }
-    val isPdf = remember(receiptUri) { isPdf(receiptUri) }
+    val isPdf = remember(receiptUri, mimeType) {
+        mimeType == "application/pdf" || isPdf(receiptUri)
+    }
 
     Surface(
         color = MaterialTheme.colorScheme.background,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ReceiptViewerScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ReceiptViewerScreen.kt
@@ -45,6 +45,15 @@ private const val MIN_ZOOM_SCALE = 1f
 private const val MAX_ZOOM_SCALE = 5f
 private const val ZOOM_EPSILON = 0.01f
 
+private fun isPdf(uriString: String): Boolean {
+    val uri = Uri.parse(uriString)
+    val path = if (uri.scheme == "file") uri.path.orEmpty() else uriString
+    if (path.lowercase().endsWith(".pdf")) return true
+    val lastSegment = uri.lastPathSegment.orEmpty().lowercase()
+    if (lastSegment.endsWith(".pdf") || lastSegment.contains(".pdf?")) return true
+    return false
+}
+
 @Composable
 fun ReceiptViewerScreen(
     receiptUri: String,
@@ -52,6 +61,7 @@ fun ReceiptViewerScreen(
     modifier: Modifier = Modifier
 ) {
     val hazeState = remember { HazeState() }
+    val isPdf = remember(receiptUri) { isPdf(receiptUri) }
 
     Surface(
         color = MaterialTheme.colorScheme.background,
@@ -66,11 +76,20 @@ fun ReceiptViewerScreen(
                     onClick = onClose
                 )
         ) {
-            ZoomableImageContainer(
-                receiptUri = receiptUri,
-                hazeState = hazeState,
-                onClose = onClose
-            )
+            if (isPdf) {
+                PdfViewerContent(
+                    pdfUriString = receiptUri,
+                    hazeState = hazeState,
+                    onClose = onClose,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                ZoomableImageContainer(
+                    receiptUri = receiptUri,
+                    hazeState = hazeState,
+                    onClose = onClose
+                )
+            }
 
             ReceiptViewerTopBar(
                 hazeState = hazeState,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import es.pedrazamiguez.splittrip.core.common.constant.AppConstants
 import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.exception.TerminalDownloadException
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.model.User
@@ -188,6 +189,7 @@ class ExpenseDetailViewModel(
     fun onEvent(event: ExpenseDetailUiEvent) {
         when (event) {
             ExpenseDetailUiEvent.DeleteConfirmed -> handleDelete()
+            ExpenseDetailUiEvent.RetryReceiptDownload -> handleRetryReceiptDownload()
         }
     }
 
@@ -212,14 +214,54 @@ class ExpenseDetailViewModel(
         }
     }
 
+    private fun handleRetryReceiptDownload() {
+        val expenseId = _expenseId.value
+        if (expenseId.isBlank()) return
+        failedDownloads.remove(expenseId)
+        viewModelScope.launch {
+            try {
+                val expense = getExpenseByIdFlowUseCase(expenseId).first()
+                if (expense != null) {
+                    val attachment = expense.receiptAttachment
+                    if (shouldDownloadPdf(attachment)) {
+                        triggerReceiptDownload(expense.id, attachment?.remoteUrl.orEmpty())
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to retry receipt download for expense $expenseId")
+            }
+        }
+    }
+
     private fun triggerReceiptDownload(expenseId: String, remoteUrl: String) {
-        if (downloadJobs.containsKey(expenseId)) return
+        if (downloadJobs.containsKey(expenseId)) {
+            return
+        }
         downloadJobs[expenseId] = viewModelScope.launch {
             try {
-                downloadReceiptUseCase(expenseId, remoteUrl)
+                val result = downloadReceiptUseCase(expenseId, remoteUrl)
+                result.onFailure { e ->
+                    val isTerminal = when (e) {
+                        is TerminalDownloadException -> e.responseCode in 400..499
+                        else -> false
+                    }
+                    if (isTerminal) {
+                        failedDownloads.add(expenseId)
+                    }
+                    _actions.send(
+                        ExpenseDetailUiAction.ShowError(
+                            UiText.StringResource(R.string.expense_detail_receipt_download_failed)
+                        )
+                    )
+                }
             } catch (e: Exception) {
-                Timber.e(e, "Failed to download remote PDF receipt for expense $expenseId")
+                Timber.e(e, "Failed to download receipt")
                 failedDownloads.add(expenseId)
+                _actions.send(
+                    ExpenseDetailUiAction.ShowError(
+                        UiText.StringResource(R.string.expense_detail_receipt_download_failed)
+                    )
+                )
             } finally {
                 downloadJobs.remove(expenseId)
             }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import es.pedrazamiguez.splittrip.core.common.constant.AppConstants
 import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
+import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
+import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
@@ -17,8 +20,10 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.ExpenseDe
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.ExpenseDetailUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.event.ExpenseDetailUiEvent
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.ExpenseDetailUiState
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -54,7 +59,8 @@ class ExpenseDetailViewModel(
     private val expenseDetailUiMapper: ExpenseDetailUiMapper
 ) : ViewModel() {
 
-    private val downloadJobs = java.util.concurrent.ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+    private val downloadJobs = ConcurrentHashMap<String, Job>()
+    private val failedDownloads = ConcurrentHashMap.newKeySet<String>()
 
     private val _expenseId = MutableStateFlow("")
 
@@ -65,9 +71,9 @@ class ExpenseDetailViewModel(
         .filter { it.isNotBlank() }
         .flatMapLatest { expenseId ->
             var cachedUserIds = emptySet<String>()
-            var cachedProfiles = emptyMap<String, es.pedrazamiguez.splittrip.domain.model.User>()
+            var cachedProfiles = emptyMap<String, User>()
             var cachedWithdrawalIds = emptySet<String>()
-            var cachedWithdrawals = emptyMap<String, es.pedrazamiguez.splittrip.domain.model.CashWithdrawal>()
+            var cachedWithdrawals = emptyMap<String, CashWithdrawal>()
             var cachedSubunitGroupId = ""
             var cachedSubunits = emptyMap<String, String>()
 
@@ -80,7 +86,7 @@ class ExpenseDetailViewModel(
                     }
 
                     val attachment = expense.receiptAttachment
-                    if (shouldDownloadPdf(attachment)) {
+                    if (shouldDownloadPdf(attachment) && !failedDownloads.contains(expense.id)) {
                         triggerReceiptDownload(expense.id, attachment?.remoteUrl.orEmpty())
                     }
 
@@ -205,6 +211,7 @@ class ExpenseDetailViewModel(
             }
         }
     }
+
     private fun triggerReceiptDownload(expenseId: String, remoteUrl: String) {
         if (downloadJobs.containsKey(expenseId)) return
         downloadJobs[expenseId] = viewModelScope.launch {
@@ -212,13 +219,14 @@ class ExpenseDetailViewModel(
                 downloadReceiptUseCase(expenseId, remoteUrl)
             } catch (e: Exception) {
                 Timber.e(e, "Failed to download remote PDF receipt for expense $expenseId")
+                failedDownloads.add(expenseId)
             } finally {
                 downloadJobs.remove(expenseId)
             }
         }
     }
 
-    private fun shouldDownloadPdf(attachment: es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment?): Boolean {
+    private fun shouldDownloadPdf(attachment: ReceiptAttachment?): Boolean {
         if (attachment == null) return false
         val isPdf = attachment.mimeType == "application/pdf"
         val hasNoLocal = attachment.localUri.isBlank()

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
@@ -8,6 +8,7 @@ import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.DownloadReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
@@ -48,9 +49,12 @@ class ExpenseDetailViewModel(
     private val getCashWithdrawalsFlowUseCase: GetCashWithdrawalsFlowUseCase,
     private val getGroupSubunitsUseCase: GetGroupSubunitsUseCase,
     private val deleteExpenseUseCase: DeleteExpenseUseCase,
+    private val downloadReceiptUseCase: DownloadReceiptUseCase,
     private val authenticationService: AuthenticationService,
     private val expenseDetailUiMapper: ExpenseDetailUiMapper
 ) : ViewModel() {
+
+    private val downloadJobs = java.util.concurrent.ConcurrentHashMap<String, kotlinx.coroutines.Job>()
 
     private val _expenseId = MutableStateFlow("")
 
@@ -73,6 +77,11 @@ class ExpenseDetailViewModel(
                         return@flatMapLatest flowOf(
                             ExpenseDetailUiState(isLoading = false, hasError = true)
                         )
+                    }
+
+                    val attachment = expense.receiptAttachment
+                    if (shouldDownloadPdf(attachment)) {
+                        triggerReceiptDownload(expense.id, attachment?.remoteUrl.orEmpty())
                     }
 
                     val allUserIds = buildSet {
@@ -195,5 +204,25 @@ class ExpenseDetailViewModel(
                 )
             }
         }
+    }
+    private fun triggerReceiptDownload(expenseId: String, remoteUrl: String) {
+        if (downloadJobs.containsKey(expenseId)) return
+        downloadJobs[expenseId] = viewModelScope.launch {
+            try {
+                downloadReceiptUseCase(expenseId, remoteUrl)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to download remote PDF receipt for expense $expenseId")
+            } finally {
+                downloadJobs.remove(expenseId)
+            }
+        }
+    }
+
+    private fun shouldDownloadPdf(attachment: es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment?): Boolean {
+        if (attachment == null) return false
+        val isPdf = attachment.mimeType == "application/pdf"
+        val hasNoLocal = attachment.localUri.isBlank()
+        val hasRemote = !attachment.remoteUrl.isNullOrBlank()
+        return isPdf && hasNoLocal && hasRemote
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/ExpenseDetailUiEvent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/ExpenseDetailUiEvent.kt
@@ -3,4 +3,7 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.event
 sealed interface ExpenseDetailUiEvent {
     /** User confirmed the destructive delete dialog in the TopBar. */
     data object DeleteConfirmed : ExpenseDetailUiEvent
+
+    /** User requested a retry of the background receipt download. */
+    data object RetryReceiptDownload : ExpenseDetailUiEvent
 }

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -299,4 +299,6 @@
     <string name="add_expense_subunit_cash_split_warning">Estás usando %1$s.\nAsegúrate de que es tu intención compartir este gasto con los demás.</string>
     <string name="receipt_viewer_image_cd">Imagen del recibo</string>
     <string name="receipt_viewer_close_cd">Cerrar visor</string>
+    <string name="receipt_viewer_pdf_error">Error al cargar el recibo PDF</string>
+    <string name="receipt_viewer_pdf_page_cd">Página PDF %1$d</string>
 </resources>

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -277,6 +277,7 @@
     <string name="expense_detail_exchange_rate_full">1 %1$s = %2$s %3$s</string>
     <string name="expense_detail_receipt_thumbnail_cd">Foto del recibo</string>
     <string name="expense_detail_receipt_pdf_label">PDF adjunto</string>
+    <string name="expense_detail_receipt_download_failed">No se pudo descargar el recibo remoto</string>
     <string name="expense_detail_addon_mode_included">Incluido</string>
     <string name="expense_detail_addon_mode_on_top">Sumado</string>
 

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="expense_detail_exchange_rate_full">1 %1$s = %2$s %3$s</string>
     <string name="expense_detail_receipt_thumbnail_cd">Receipt photo</string>
     <string name="expense_detail_receipt_pdf_label">PDF attached</string>
+    <string name="expense_detail_receipt_download_failed">Failed to download remote receipt</string>
     <string name="expense_detail_addon_mode_included">Included</string>
     <string name="expense_detail_addon_mode_on_top">On top</string>
 

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -298,4 +298,6 @@
     <string name="add_expense_subunit_cash_split_warning">You\'re spending from %1$s.\nMake sure it\'s intentional to share this with others.</string>
     <string name="receipt_viewer_image_cd">Receipt full image</string>
     <string name="receipt_viewer_close_cd">Close viewer</string>
+    <string name="receipt_viewer_pdf_error">Failed to load PDF receipt</string>
+    <string name="receipt_viewer_pdf_page_cd">PDF page %1$d</string>
 </resources>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel
 
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
+import es.pedrazamiguez.splittrip.domain.exception.TerminalDownloadException
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.model.User
@@ -479,7 +480,7 @@ class ExpenseDetailViewModelTest {
         }
 
         @Test
-        fun `does not retry download when previous download failed`() = runTest(testDispatcher) {
+        fun `does not retry download when previous download failed with terminal error`() = runTest(testDispatcher) {
             // Given
             val pdfAttachment = ReceiptAttachment(
                 localUri = "",
@@ -488,9 +489,10 @@ class ExpenseDetailViewModelTest {
                 remoteUrl = "https://example.com/receipt.pdf"
             )
             val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
-            coEvery { downloadReceiptUseCase(testExpenseId, any()) } throws RuntimeException("Network Error")
+            val exception = TerminalDownloadException(404, "Not Found")
+            coEvery { downloadReceiptUseCase(testExpenseId, any()) } returns Result.failure(exception)
 
-            val flow = kotlinx.coroutines.flow.MutableSharedFlow<Expense?>()
+            val flow = kotlinx.coroutines.flow.MutableSharedFlow<Expense?>(replay = 1)
             every { getExpenseByIdFlowUseCase(testExpenseId) } returns flow
             val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
 
@@ -504,8 +506,75 @@ class ExpenseDetailViewModelTest {
             flow.emit(expenseWithPdf)
             advanceUntilIdle()
 
-            // Then - download should only be triggered once
+            // Then - download should only be triggered once (blacklisted)
             coVerify(exactly = 1) { downloadReceiptUseCase(testExpenseId, "https://example.com/receipt.pdf") }
+
+            collectJob.cancel()
+        }
+
+        @Test
+        fun `retries download when previous download failed with recoverable error`() = runTest(testDispatcher) {
+            // Given
+            val pdfAttachment = ReceiptAttachment(
+                localUri = "",
+                mimeType = "application/pdf",
+                capturedAtMillis = 1000L,
+                remoteUrl = "https://example.com/receipt.pdf"
+            )
+            val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
+            // Transient 503 Service Unavailable or general exception is recoverable
+            val exception = TerminalDownloadException(503, "Service Unavailable")
+            coEvery { downloadReceiptUseCase(testExpenseId, any()) } returns Result.failure(exception)
+
+            val flow = kotlinx.coroutines.flow.MutableSharedFlow<Expense?>(replay = 1)
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flow
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            viewModel.setExpenseId(testExpenseId)
+
+            // First emission
+            flow.emit(expenseWithPdf)
+            advanceUntilIdle()
+
+            // Second emission (re-trigger)
+            flow.emit(expenseWithPdf)
+            advanceUntilIdle()
+
+            // Then - download should be retried (not blacklisted)
+            coVerify(exactly = 2) { downloadReceiptUseCase(testExpenseId, "https://example.com/receipt.pdf") }
+
+            collectJob.cancel()
+        }
+
+        @Test
+        fun `retries download when RetryReceiptDownload event is received`() = runTest(testDispatcher) {
+            // Given
+            val pdfAttachment = ReceiptAttachment(
+                localUri = "",
+                mimeType = "application/pdf",
+                capturedAtMillis = 1000L,
+                remoteUrl = "https://example.com/receipt.pdf"
+            )
+            val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
+            val exception = TerminalDownloadException(404, "Not Found")
+            coEvery { downloadReceiptUseCase(testExpenseId, any()) } returns Result.failure(exception)
+
+            val flow = kotlinx.coroutines.flow.MutableSharedFlow<Expense?>(replay = 1)
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flow
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            viewModel.setExpenseId(testExpenseId)
+
+            // First emission triggers first download and blacklists it
+            flow.emit(expenseWithPdf)
+            advanceUntilIdle()
+
+            // Trigger retry event
+            viewModel.onEvent(ExpenseDetailUiEvent.RetryReceiptDownload)
+            advanceUntilIdle()
+
+            // Then - download should be triggered twice
+            coVerify(exactly = 2) { downloadReceiptUseCase(testExpenseId, "https://example.com/receipt.pdf") }
 
             collectJob.cancel()
         }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
@@ -3,10 +3,12 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.DeleteExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.DownloadReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
@@ -52,6 +54,7 @@ class ExpenseDetailViewModelTest {
     private lateinit var getCashWithdrawalsFlowUseCase: GetCashWithdrawalsFlowUseCase
     private lateinit var getGroupSubunitsUseCase: GetGroupSubunitsUseCase
     private lateinit var deleteExpenseUseCase: DeleteExpenseUseCase
+    private lateinit var downloadReceiptUseCase: DownloadReceiptUseCase
     private lateinit var authenticationService: AuthenticationService
     private lateinit var expenseDetailUiMapper: ExpenseDetailUiMapper
     private lateinit var viewModel: ExpenseDetailViewModel
@@ -106,6 +109,7 @@ class ExpenseDetailViewModelTest {
         getCashWithdrawalsFlowUseCase = mockk()
         getGroupSubunitsUseCase = mockk()
         deleteExpenseUseCase = mockk()
+        downloadReceiptUseCase = mockk(relaxed = true)
         authenticationService = mockk()
         expenseDetailUiMapper = mockk()
 
@@ -375,12 +379,113 @@ class ExpenseDetailViewModelTest {
         }
     }
 
+    @Nested
+    inner class ReceiptDownload {
+
+        @Test
+        fun `triggers downloadReceiptUseCase when PDF receipt has remoteUrl and blank localUri`() = runTest(
+            testDispatcher
+        ) {
+            // Given
+            val pdfAttachment = ReceiptAttachment(
+                localUri = "",
+                mimeType = "application/pdf",
+                capturedAtMillis = 1000L,
+                remoteUrl = "https://example.com/receipt.pdf"
+            )
+            val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flowOf(expenseWithPdf)
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            // When
+            viewModel.setExpenseId(testExpenseId)
+            advanceUntilIdle()
+
+            // Then
+            coVerify(exactly = 1) { downloadReceiptUseCase(testExpenseId, "https://example.com/receipt.pdf") }
+
+            collectJob.cancel()
+        }
+
+        @Test
+        fun `does not trigger downloadReceiptUseCase when PDF receipt already has localUri`() = runTest(
+            testDispatcher
+        ) {
+            // Given
+            val pdfAttachment = ReceiptAttachment(
+                localUri = "file:///local/receipt.pdf",
+                mimeType = "application/pdf",
+                capturedAtMillis = 1000L,
+                remoteUrl = "https://example.com/receipt.pdf"
+            )
+            val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flowOf(expenseWithPdf)
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            // When
+            viewModel.setExpenseId(testExpenseId)
+            advanceUntilIdle()
+
+            // Then
+            coVerify(exactly = 0) { downloadReceiptUseCase(any(), any()) }
+
+            collectJob.cancel()
+        }
+
+        @Test
+        fun `does not trigger downloadReceiptUseCase when PDF receipt has no remoteUrl`() = runTest(testDispatcher) {
+            // Given
+            val pdfAttachment = ReceiptAttachment(
+                localUri = "",
+                mimeType = "application/pdf",
+                capturedAtMillis = 1000L,
+                remoteUrl = null
+            )
+            val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flowOf(expenseWithPdf)
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            // When
+            viewModel.setExpenseId(testExpenseId)
+            advanceUntilIdle()
+
+            // Then
+            coVerify(exactly = 0) { downloadReceiptUseCase(any(), any()) }
+
+            collectJob.cancel()
+        }
+
+        @Test
+        fun `does not trigger downloadReceiptUseCase when receipt is not PDF`() = runTest(testDispatcher) {
+            // Given
+            val imageAttachment = ReceiptAttachment(
+                localUri = "",
+                mimeType = "image/webp",
+                capturedAtMillis = 1000L,
+                remoteUrl = "https://example.com/receipt.webp"
+            )
+            val expenseWithImage = testExpense.copy(receiptAttachment = imageAttachment)
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flowOf(expenseWithImage)
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            // When
+            viewModel.setExpenseId(testExpenseId)
+            advanceUntilIdle()
+
+            // Then
+            coVerify(exactly = 0) { downloadReceiptUseCase(any(), any()) }
+
+            collectJob.cancel()
+        }
+    }
+
     private fun createViewModel() = ExpenseDetailViewModel(
         getExpenseByIdFlowUseCase = getExpenseByIdFlowUseCase,
         getMemberProfilesUseCase = getMemberProfilesUseCase,
         getCashWithdrawalsFlowUseCase = getCashWithdrawalsFlowUseCase,
         getGroupSubunitsUseCase = getGroupSubunitsUseCase,
         deleteExpenseUseCase = deleteExpenseUseCase,
+        downloadReceiptUseCase = downloadReceiptUseCase,
         authenticationService = authenticationService,
         expenseDetailUiMapper = expenseDetailUiMapper
     )

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
@@ -477,6 +477,38 @@ class ExpenseDetailViewModelTest {
 
             collectJob.cancel()
         }
+
+        @Test
+        fun `does not retry download when previous download failed`() = runTest(testDispatcher) {
+            // Given
+            val pdfAttachment = ReceiptAttachment(
+                localUri = "",
+                mimeType = "application/pdf",
+                capturedAtMillis = 1000L,
+                remoteUrl = "https://example.com/receipt.pdf"
+            )
+            val expenseWithPdf = testExpense.copy(receiptAttachment = pdfAttachment)
+            coEvery { downloadReceiptUseCase(testExpenseId, any()) } throws RuntimeException("Network Error")
+
+            val flow = kotlinx.coroutines.flow.MutableSharedFlow<Expense?>()
+            every { getExpenseByIdFlowUseCase(testExpenseId) } returns flow
+            val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+
+            viewModel.setExpenseId(testExpenseId)
+
+            // First emission
+            flow.emit(expenseWithPdf)
+            advanceUntilIdle()
+
+            // Second emission (re-trigger)
+            flow.emit(expenseWithPdf)
+            advanceUntilIdle()
+
+            // Then - download should only be triggered once
+            coVerify(exactly = 1) { downloadReceiptUseCase(testExpenseId, "https://example.com/receipt.pdf") }
+
+            collectJob.cancel()
+        }
     }
 
     private fun createViewModel() = ExpenseDetailViewModel(


### PR DESCRIPTION
Implement downloading remote receipt files and offline-first PDF viewing.

- Add downloadAndStore to ReceiptStorageServiceImpl (HTTP download, mime detection, image compression or file copy, temp file handling, connection timeout constant).
- Persist stable local URIs: add DAO updateReceiptLocalUri, LocalExpenseDataSourceImpl and ExpenseRepositoryImpl plumbing, and domain interfaces.
- Add DownloadReceiptUseCase and wire it into DI modules; it downloads a remote receipt and updates the repository localUri.
- Trigger background PDF downloads from ExpenseDetailViewModel (only for PDF attachments with remoteUrl and blank localUri) with job deduplication and error logging.
- Add PdfViewerContent composable to render multi-page PDFs (downloads remote PDF to cache if needed) and integrate into ReceiptViewerScreen; update HeroSection PDF thumbnail rendering to use content resolver and more robust resource cleanup.
- Add strings for PDF viewer and update tests: ReceiptStorageServiceImplTest, DownloadReceiptUseCaseTest, and ExpenseDetailViewModel tests for download behavior.

This enables background retrieval of remote PDF receipts, stores them under app files/receipts, updates Room with local file URIs, and provides an in-app PDF viewer for offline access.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1113 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
