### PR TITLE
[SPLTRP-1102]: Delete expense receipts from local storage and Firebase Storage on expense deletion

### DIFF
--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImpl.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.firebase.storage
 import com.google.firebase.storage.FirebaseStorage
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudStorageDataSource
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 
@@ -52,6 +53,8 @@ internal class CloudStorageDataSourceImpl(
                 item.delete().await()
                 Timber.d("Deleted remote receipt file: ${item.path}")
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.w(e, "Failed to delete remote receipt files for expense $expenseId")
             throw e

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImpl.kt
@@ -44,6 +44,20 @@ internal class CloudStorageDataSourceImpl(
         return downloadUrl
     }
 
+    override suspend fun deleteReceipt(expenseId: String) {
+        val folderRef = storage.reference.child("$RECEIPTS_PREFIX/$expenseId")
+        try {
+            val listResult = folderRef.listAll().await()
+            listResult.items.forEach { item ->
+                item.delete().await()
+                Timber.d("Deleted remote receipt file: ${item.path}")
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to delete remote receipt files for expense $expenseId")
+            throw e
+        }
+    }
+
     private companion object {
         const val RECEIPTS_PREFIX = "receipts"
     }

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImplTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/storage/CloudStorageDataSourceImplTest.kt
@@ -89,4 +89,32 @@ class CloudStorageDataSourceImplTest {
         assertEquals("https://firebase.storage/receipt.jpg", url)
         verify(exactly = 1) { rootRef.child("receipts/expense-456/receipt.jpg") }
     }
+
+    @Test
+    fun `deleteReceipt lists and deletes all files under prefix`() = runTest {
+        val mockListResult = mockk<com.google.firebase.storage.ListResult>()
+        val mockListTask = mockk<Task<com.google.firebase.storage.ListResult>>()
+
+        val mockItem1 = mockk<StorageReference>()
+        val mockItem2 = mockk<StorageReference>()
+        every { mockItem1.path } returns "receipts/expense-123/receipt.jpg"
+        every { mockItem2.path } returns "receipts/expense-123/thumbnail.jpg"
+
+        val mockDeleteTask1 = mockk<Task<Void>>()
+        val mockDeleteTask2 = mockk<Task<Void>>()
+        every { mockItem1.delete() } returns mockDeleteTask1
+        every { mockItem2.delete() } returns mockDeleteTask2
+        coEvery { mockDeleteTask1.await() } returns mockk()
+        coEvery { mockDeleteTask2.await() } returns mockk()
+
+        every { childRef.listAll() } returns mockListTask
+        coEvery { mockListTask.await() } returns mockListResult
+        every { mockListResult.items } returns listOf(mockItem1, mockItem2)
+
+        dataSource.deleteReceipt("expense-123")
+
+        verify(exactly = 1) { rootRef.child("receipts/expense-123") }
+        verify(exactly = 1) { mockItem1.delete() }
+        verify(exactly = 1) { mockItem2.delete() }
+    }
 }

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
@@ -13,7 +13,7 @@ import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
-import java.net.URL
+import java.net.URI
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -40,7 +40,7 @@ internal fun interface HttpConnectionFactory {
 internal class ReceiptStorageServiceImpl(
     private val context: Context,
     private val connectionFactory: HttpConnectionFactory = HttpConnectionFactory { url ->
-        URL(url).openConnection() as HttpURLConnection
+        URI(url).toURL().openConnection() as HttpURLConnection
     }
 ) : ReceiptStorageService {
 
@@ -139,25 +139,38 @@ internal class ReceiptStorageServiceImpl(
     override suspend fun deleteLocalFile(localUri: String) {
         withContext(Dispatchers.IO) {
             try {
-                val uri = Uri.parse(localUri)
-                val path = uri.path
-                if (path != null) {
-                    val file = File(path)
-                    if (file.exists()) {
-                        if (file.delete()) {
-                            Timber.d("Successfully deleted local receipt file: $path")
-                        } else {
-                            Timber.w("Failed to delete local receipt file: $path")
-                        }
-                    } else {
-                        Timber.d("Local receipt file does not exist: $path")
-                    }
-                } else {
-                    Timber.w("Could not extract path from localUri: $localUri")
-                }
+                performDeleteLocalFile(localUri)
             } catch (e: Exception) {
                 Timber.e(e, "Error deleting local receipt file for URI: $localUri")
             }
+        }
+    }
+
+    private fun performDeleteLocalFile(localUri: String) {
+        val uri = Uri.parse(localUri)
+        if (uri.scheme != "file") {
+            Timber.w("Refusing to delete file: scheme is not 'file' in localUri: $localUri")
+            return
+        }
+        val path = uri.path
+        if (path == null) {
+            Timber.w("Could not extract path from localUri: $localUri")
+            return
+        }
+        val file = File(path).canonicalFile
+        val receiptsDir = File(context.filesDir, RECEIPTS_DIR).canonicalFile
+        if (!file.path.startsWith(receiptsDir.path + File.separator)) {
+            Timber.w("Refusing to delete file outside receipts directory: $path")
+            return
+        }
+        if (!file.exists()) {
+            Timber.d("Local receipt file does not exist: $path")
+            return
+        }
+        if (file.delete()) {
+            Timber.d("Successfully deleted local receipt file: $path")
+        } else {
+            Timber.w("Failed to delete local receipt file: $path")
         }
     }
 

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImpl.kt
@@ -136,6 +136,31 @@ internal class ReceiptStorageServiceImpl(
             }
         }
 
+    override suspend fun deleteLocalFile(localUri: String) {
+        withContext(Dispatchers.IO) {
+            try {
+                val uri = Uri.parse(localUri)
+                val path = uri.path
+                if (path != null) {
+                    val file = File(path)
+                    if (file.exists()) {
+                        if (file.delete()) {
+                            Timber.d("Successfully deleted local receipt file: $path")
+                        } else {
+                            Timber.w("Failed to delete local receipt file: $path")
+                        }
+                    } else {
+                        Timber.d("Local receipt file does not exist: $path")
+                    }
+                } else {
+                    Timber.w("Could not extract path from localUri: $localUri")
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error deleting local receipt file for URI: $localUri")
+            }
+        }
+    }
+
     private fun resolveMimeType(uri: Uri, sourceUri: String): String {
         val resolver = context.contentResolver
         var mimeType = resolver.getType(uri)

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
@@ -301,4 +301,32 @@ class ReceiptStorageServiceImplTest {
         // Should not throw any exception
         service.deleteLocalFile(localUri)
     }
+
+    @Test
+    fun deleteLocalFile_invalidScheme_refusesToDelete() = runTest {
+        // Given
+        val receiptsDir = File(context.filesDir, "receipts").also { it.mkdirs() }
+        val testFile = File(receiptsDir, "test_receipt.pdf").also { it.writeText("test content") }
+        val invalidUri = "http://example.com/receipts/test_receipt.pdf"
+
+        // When
+        service.deleteLocalFile(invalidUri)
+
+        // Then
+        assertTrue("File should NOT be deleted", testFile.exists())
+    }
+
+    @Test
+    fun deleteLocalFile_outsideReceiptsDirectory_refusesToDelete() = runTest {
+        // Given
+        val outsideFile = File(context.filesDir, "outside_file.pdf").also { it.writeText("sensitive content") }
+        val localUri = outsideFile.toURI().toString()
+
+        // When
+        service.deleteLocalFile(localUri)
+
+        // Then
+        assertTrue("File outside receipts directory should NOT be deleted", outsideFile.exists())
+        outsideFile.delete() // clean up
+    }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/service/ReceiptStorageServiceImplTest.kt
@@ -277,4 +277,28 @@ class ReceiptStorageServiceImplTest {
         tempFilesDir.deleteRecursively()
         tempCacheDir.deleteRecursively()
     }
+
+    @Test
+    fun deleteLocalFile_existingFile_deletesFile() = runTest {
+        // Given
+        val receiptsDir = File(context.filesDir, "receipts").also { it.mkdirs() }
+        val testFile = File(receiptsDir, "test_receipt.pdf").also { it.writeText("test content") }
+        val localUri = testFile.toURI().toString()
+
+        // When
+        service.deleteLocalFile(localUri)
+
+        // Then
+        assertTrue("File should be deleted", !testFile.exists())
+    }
+
+    @Test
+    fun deleteLocalFile_nonExistentFile_completesWithoutError() = runTest {
+        // Given
+        val localUri = "file:///non/existent/file.pdf"
+
+        // When/Then
+        // Should not throw any exception
+        service.deleteLocalFile(localUri)
+    }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/di/ExpensesDataModule.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/di/ExpensesDataModule.kt
@@ -14,6 +14,7 @@ import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptOcrService
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import kotlinx.coroutines.Dispatchers
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
@@ -26,6 +27,7 @@ val expensesDataModule = module {
             localExpenseDataSource = get<LocalExpenseDataSource>(),
             authenticationService = get<AuthenticationService>(),
             cloudStorageDataSource = get<CloudStorageDataSource>(),
+            receiptStorageService = get<ReceiptStorageService>(),
             ioDispatcher = Dispatchers.IO
         )
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -143,33 +143,21 @@ class ExpenseRepositoryImpl(
 
         // Delete local file immediately (best-effort, non-fatal)
         if (attachment != null && attachment.localUri.isNotBlank()) {
-            try {
-                receiptStorageService.deleteLocalFile(attachment.localUri)
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to delete local receipt file: ${attachment.localUri}")
-            }
+            deleteLocalReceiptFileBestEffort(receiptStorageService, attachment.localUri)
         }
 
         // Always queue cloud deletion, even for PENDING_SYNC entities.
         // Firestore SDK guarantees write ordering: the queued SET (from addExpense)
         // executes before this DELETE when connectivity is restored.
-        syncScope.launch {
-            try {
-                cloudExpenseDataSource.deleteExpense(groupId, expenseId)
-                Timber.d("Expense deletion synced to cloud: $expenseId")
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to sync expense deletion to cloud, will retry later")
-            }
-
-            if (attachment != null && !attachment.remoteUrl.isNullOrBlank()) {
-                try {
-                    cloudStorageDataSource.deleteReceipt(expenseId)
-                    Timber.d("Cloud receipt deletion synced to cloud: $expenseId")
-                } catch (e: Exception) {
-                    Timber.w(e, "Failed to delete remote receipt for expense $expenseId")
-                }
-            }
-        }
+        val remoteUrl = attachment?.remoteUrl?.takeIf { it.isNotBlank() }
+        launchCloudExpenseDeletion(
+            syncScope = syncScope,
+            cloudExpenseDataSource = cloudExpenseDataSource,
+            cloudStorageDataSource = cloudStorageDataSource,
+            groupId = groupId,
+            expenseId = expenseId,
+            remoteUrl = remoteUrl
+        )
     }
 
     /**
@@ -355,5 +343,49 @@ class ExpenseRepositoryImpl(
             lastUpdatedAt = currentTimestamp,
             syncStatus = SyncStatus.PENDING_SYNC
         )
+    }
+}
+
+private suspend fun deleteLocalReceiptFileBestEffort(
+    receiptStorageService: ReceiptStorageService,
+    localUri: String
+) {
+    try {
+        receiptStorageService.deleteLocalFile(localUri)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Timber.w(e, "Failed to delete local receipt file: $localUri")
+    }
+}
+
+private fun launchCloudExpenseDeletion(
+    syncScope: CoroutineScope,
+    cloudExpenseDataSource: CloudExpenseDataSource,
+    cloudStorageDataSource: CloudStorageDataSource,
+    groupId: String,
+    expenseId: String,
+    remoteUrl: String?
+) {
+    syncScope.launch {
+        try {
+            cloudExpenseDataSource.deleteExpense(groupId, expenseId)
+            Timber.d("Expense deletion synced to cloud: $expenseId")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to sync expense deletion to cloud, will retry later")
+        }
+
+        if (remoteUrl != null) {
+            try {
+                cloudStorageDataSource.deleteReceipt(expenseId)
+                Timber.d("Cloud receipt deletion synced to cloud: $expenseId")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to delete remote receipt for expense $expenseId")
+            }
+        }
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImpl.kt
@@ -8,6 +8,7 @@ import es.pedrazamiguez.splittrip.domain.exception.CashConflictException
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
@@ -25,6 +26,7 @@ class ExpenseRepositoryImpl(
     private val localExpenseDataSource: LocalExpenseDataSource,
     private val authenticationService: AuthenticationService,
     private val cloudStorageDataSource: CloudStorageDataSource,
+    private val receiptStorageService: ReceiptStorageService,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ExpenseRepository {
 
@@ -133,8 +135,20 @@ class ExpenseRepositoryImpl(
     )
 
     override suspend fun deleteExpense(groupId: String, expenseId: String) {
+        val expense = localExpenseDataSource.getExpenseById(expenseId)
+        val attachment = expense?.receiptAttachment
+
         // Delete from local first - UI updates instantly via Flow
         localExpenseDataSource.deleteExpense(expenseId)
+
+        // Delete local file immediately (best-effort, non-fatal)
+        if (attachment != null && attachment.localUri.isNotBlank()) {
+            try {
+                receiptStorageService.deleteLocalFile(attachment.localUri)
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to delete local receipt file: ${attachment.localUri}")
+            }
+        }
 
         // Always queue cloud deletion, even for PENDING_SYNC entities.
         // Firestore SDK guarantees write ordering: the queued SET (from addExpense)
@@ -145,6 +159,15 @@ class ExpenseRepositoryImpl(
                 Timber.d("Expense deletion synced to cloud: $expenseId")
             } catch (e: Exception) {
                 Timber.w(e, "Failed to sync expense deletion to cloud, will retry later")
+            }
+
+            if (attachment != null && !attachment.remoteUrl.isNullOrBlank()) {
+                try {
+                    cloudStorageDataSource.deleteReceipt(expenseId)
+                    Timber.d("Cloud receipt deletion synced to cloud: $expenseId")
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to delete remote receipt for expense $expenseId")
+                }
             }
         }
     }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplCashConflictTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplCashConflictTest.kt
@@ -7,6 +7,7 @@ import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.exception.CashConflictException
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -39,6 +40,7 @@ class ExpenseRepositoryImplCashConflictTest {
     private lateinit var authenticationService: AuthenticationService
     private lateinit var cloudStorageDataSource:
         es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudStorageDataSource
+    private lateinit var receiptStorageService: ReceiptStorageService
     private lateinit var testDispatcher: TestDispatcher
     private lateinit var repository: ExpenseRepositoryImpl
 
@@ -69,12 +71,14 @@ class ExpenseRepositoryImplCashConflictTest {
         localExpenseDataSource = mockk(relaxed = true)
         authenticationService = mockk()
         cloudStorageDataSource = mockk(relaxed = true)
+        receiptStorageService = mockk(relaxed = true)
         every { authenticationService.currentUserId() } returns testUserId
         repository = ExpenseRepositoryImpl(
             cloudExpenseDataSource,
             localExpenseDataSource,
             authenticationService,
             cloudStorageDataSource,
+            receiptStorageService,
             testDispatcher
         )
     }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ReceiptStorageService
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,6 +42,7 @@ class ExpenseRepositoryImplTest {
     private lateinit var authenticationService: AuthenticationService
     private lateinit var cloudStorageDataSource:
         es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudStorageDataSource
+    private lateinit var receiptStorageService: ReceiptStorageService
     private lateinit var testDispatcher: TestDispatcher
     private lateinit var repository: ExpenseRepositoryImpl
 
@@ -82,12 +84,14 @@ class ExpenseRepositoryImplTest {
         localExpenseDataSource = mockk(relaxed = true)
         authenticationService = mockk()
         cloudStorageDataSource = mockk(relaxed = true)
+        receiptStorageService = mockk(relaxed = true)
         every { authenticationService.currentUserId() } returns testUserId
         repository = ExpenseRepositoryImpl(
             cloudExpenseDataSource,
             localExpenseDataSource,
             authenticationService,
             cloudStorageDataSource,
+            receiptStorageService,
             testDispatcher
         )
     }
@@ -624,6 +628,7 @@ class ExpenseRepositoryImplTest {
                 localExpenseDataSource,
                 authenticationService,
                 cloudStorageDataSource,
+                receiptStorageService,
                 testDispatcher
             )
 
@@ -692,6 +697,104 @@ class ExpenseRepositoryImplTest {
             coVerify(exactly = 1) {
                 cloudExpenseDataSource.deleteExpense(testGroupId, expenseId)
             }
+        }
+
+        @Test
+        fun `deleteExpense with receipt deletes local file and cloud storage receipt`() = runTest(testDispatcher) {
+            val expenseId = "expense-with-receipt"
+            val expense = testExpense.copy(
+                id = expenseId,
+                receiptAttachment = es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment(
+                    localUri = "file:///path/to/local/file.jpg",
+                    mimeType = "image/jpeg",
+                    capturedAtMillis = 123456789L,
+                    remoteUrl = "https://remote.url/file.jpg"
+                )
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns expense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { receiptStorageService.deleteLocalFile(any()) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
+            coEvery { cloudStorageDataSource.deleteReceipt(any()) } just Runs
+
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { receiptStorageService.deleteLocalFile("file:///path/to/local/file.jpg") }
+            coVerify(exactly = 1) { cloudStorageDataSource.deleteReceipt(expenseId) }
+            coVerify(exactly = 1) { cloudExpenseDataSource.deleteExpense(testGroupId, expenseId) }
+        }
+
+        @Test
+        fun `deleteExpense with no receipt completes without deleting files`() = runTest(testDispatcher) {
+            val expenseId = "expense-no-receipt"
+            val expense = testExpense.copy(
+                id = expenseId,
+                receiptAttachment = null
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns expense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
+
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { receiptStorageService.deleteLocalFile(any()) }
+            coVerify(exactly = 0) { cloudStorageDataSource.deleteReceipt(any()) }
+            coVerify(exactly = 1) { cloudExpenseDataSource.deleteExpense(testGroupId, expenseId) }
+        }
+
+        @Test
+        fun `deleteExpense with local-only receipt deletes local file and skips cloud delete`() = runTest(
+            testDispatcher
+        ) {
+            val expenseId = "expense-local-only"
+            val expense = testExpense.copy(
+                id = expenseId,
+                receiptAttachment = es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment(
+                    localUri = "file:///path/to/local/file.jpg",
+                    mimeType = "image/jpeg",
+                    capturedAtMillis = 123456789L,
+                    remoteUrl = null
+                )
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns expense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { receiptStorageService.deleteLocalFile(any()) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
+
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { receiptStorageService.deleteLocalFile("file:///path/to/local/file.jpg") }
+            coVerify(exactly = 0) { cloudStorageDataSource.deleteReceipt(any()) }
+            coVerify(exactly = 1) { cloudExpenseDataSource.deleteExpense(testGroupId, expenseId) }
+        }
+
+        @Test
+        fun `deleteExpense with cloud receipt delete failure completes successfully`() = runTest(testDispatcher) {
+            val expenseId = "expense-cloud-fail"
+            val expense = testExpense.copy(
+                id = expenseId,
+                receiptAttachment = es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment(
+                    localUri = "file:///path/to/local/file.jpg",
+                    mimeType = "image/jpeg",
+                    capturedAtMillis = 123456789L,
+                    remoteUrl = "https://remote.url/file.jpg"
+                )
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns expense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { receiptStorageService.deleteLocalFile(any()) } just Runs
+            coEvery { cloudExpenseDataSource.deleteExpense(any(), any()) } just Runs
+            coEvery { cloudStorageDataSource.deleteReceipt(any()) } throws RuntimeException("Cloud error")
+
+            repository.deleteExpense(testGroupId, expenseId)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { receiptStorageService.deleteLocalFile("file:///path/to/local/file.jpg") }
+            coVerify(exactly = 1) { cloudStorageDataSource.deleteReceipt(expenseId) }
+            coVerify(exactly = 1) { cloudExpenseDataSource.deleteExpense(testGroupId, expenseId) }
         }
     }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/ExpenseRepositoryImplTest.kt
@@ -17,6 +17,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import java.io.IOException
 import java.time.LocalDateTime
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -795,6 +796,32 @@ class ExpenseRepositoryImplTest {
             coVerify(exactly = 1) { receiptStorageService.deleteLocalFile("file:///path/to/local/file.jpg") }
             coVerify(exactly = 1) { cloudStorageDataSource.deleteReceipt(expenseId) }
             coVerify(exactly = 1) { cloudExpenseDataSource.deleteExpense(testGroupId, expenseId) }
+        }
+
+        @Test
+        fun `deleteExpense propagates CancellationException when deleteLocalFile throws it`() = runTest(
+            testDispatcher
+        ) {
+            val expenseId = "expense-cancel"
+            val expense = testExpense.copy(
+                id = expenseId,
+                receiptAttachment = es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment(
+                    localUri = "file:///path/to/local/file.jpg",
+                    mimeType = "image/jpeg",
+                    capturedAtMillis = 123456789L,
+                    remoteUrl = null
+                )
+            )
+            coEvery { localExpenseDataSource.getExpenseById(expenseId) } returns expense
+            coEvery { localExpenseDataSource.deleteExpense(expenseId) } just Runs
+            coEvery { receiptStorageService.deleteLocalFile(any()) } throws CancellationException("Cancelled")
+
+            try {
+                repository.deleteExpense(testGroupId, expenseId)
+                org.junit.jupiter.api.Assertions.fail("Expected CancellationException")
+            } catch (e: CancellationException) {
+                assertEquals("Cancelled", e.message)
+            }
         }
     }
 

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudStorageDataSource.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/datasource/cloud/CloudStorageDataSource.kt
@@ -21,4 +21,11 @@ interface CloudStorageDataSource {
      * @return A publicly accessible HTTPS download URL.
      */
     suspend fun uploadReceipt(expenseId: String, localPath: String, mimeType: String): String
+
+    /**
+     * Deletes all remote receipt objects associated with the given [expenseId].
+     *
+     * @param expenseId Unique expense identifier.
+     */
+    suspend fun deleteReceipt(expenseId: String)
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ReceiptStorageService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ReceiptStorageService.kt
@@ -30,4 +30,11 @@ interface ReceiptStorageService {
      * @return A [ReceiptAttachment] with the stable `file://` local URI.
      */
     suspend fun downloadAndStore(remoteUrl: String): ReceiptAttachment
+
+    /**
+     * Deletes the local receipt file at the specified [localUri].
+     *
+     * @param localUri Stable local URI (file://) of the receipt.
+     */
+    suspend fun deleteLocalFile(localUri: String)
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/PdfViewerContent.kt
@@ -55,7 +55,7 @@ import es.pedrazamiguez.splittrip.features.expense.R
 import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
-import java.net.URL
+import java.net.URI
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -86,7 +86,11 @@ private class PdfResourceHolder(
         } catch (e: Exception) {
             Timber.e(e, "Failed to close ParcelFileDescriptor")
         }
-        tempFile?.delete()
+        tempFile?.let { file ->
+            if (file.exists() && !file.delete()) {
+                Timber.w("Failed to delete temp PDF file: ${file.absolutePath}")
+            }
+        }
     }
 }
 
@@ -160,7 +164,11 @@ private fun initializePdfResources(context: Context, pdfUriString: String): PdfR
     } catch (e: Exception) {
         localRenderer?.close()
         localPfd?.close()
-        localTempFile?.delete()
+        localTempFile?.let { file ->
+            if (file.exists() && !file.delete()) {
+                Timber.w("Failed to delete temp PDF file: ${file.absolutePath}")
+            }
+        }
         throw e
     }
 }
@@ -369,7 +377,7 @@ private fun renderPageToBitmap(renderer: PdfRenderer, pageIndex: Int): Bitmap {
 }
 
 private fun downloadUrlToFile(remoteUrl: String, tempFile: File) {
-    val url = URL(remoteUrl)
+    val url = URI(remoteUrl).toURL()
     val connection = url.openConnection() as HttpURLConnection
     try {
         connection.connectTimeout = HTTP_TIMEOUT_MS

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/ExpenseDetailScreenUiProviderImpl.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/ExpenseDetailScreenUiProviderImpl.kt
@@ -43,7 +43,7 @@ class ExpenseDetailScreenUiProviderImpl(
                 onBack = { navController.popBackStack() },
                 actions = {
                     // Edit — placeholder until the edit screen is implemented
-                    IconButton(onClick = { /* TODO: navigate to edit screen */ }) {
+                    IconButton(onClick = { /* Navigate to edit screen once implemented */ }) {
                         Icon(
                             imageVector = TablerIcons.Outline.Edit,
                             contentDescription = stringResource(R.string.action_edit_expense)


### PR DESCRIPTION
Add end-to-end receipt deletion: introduce CloudStorageDataSource.deleteReceipt and implement it to list and remove all files under receipts/<expenseId> (with logging and error propagation). Add ReceiptStorageService.deleteLocalFile to domain and implement local file deletion (best-effort, IO Dispatcher, logs failures). Wire ReceiptStorageService into DI. Update ExpenseRepositoryImpl.deleteExpense to fetch the expense, delete it locally, attempt best-effort local file removal, queue the cloud expense deletion and attempt remote receipt deletion when syncing (errors are logged but non-fatal). Tests updated/added for CloudStorageDataSourceImpl, ReceiptStorageServiceImpl, and ExpenseRepositoryImpl to cover local-only, remote, and failure scenarios.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1102 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
