### PR TITLE
Add service close and preserve AI engine on reset

### DIFF
--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImpl.kt
@@ -18,6 +18,7 @@ import java.util.Locale
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -31,9 +32,10 @@ internal class ReceiptExtractionServiceImpl(
     private val liteRtInferenceRepository: Lazy<AiInferenceRepository>,
     private val userPreferenceRepository: UserPreferenceRepository,
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
-) : ReceiptExtractionService {
+) : ReceiptExtractionService, AutoCloseable {
 
-    private val serviceScope = CoroutineScope(defaultDispatcher)
+    private val serviceJob = SupervisorJob()
+    private val serviceScope = CoroutineScope(serviceJob + defaultDispatcher)
 
     @Volatile
     private var activeEngine: AiEngineType = AiEngineType.AI_CORE_GEMMA_4
@@ -124,6 +126,10 @@ internal class ReceiptExtractionServiceImpl(
         } else {
             ExtractionCapability.UNSUPPORTED
         }
+    }
+
+    override fun close() {
+        serviceJob.cancel()
     }
 
     private fun loadPromptTemplate(): String {

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImplTest.kt
@@ -75,6 +75,7 @@ class ReceiptExtractionServiceImplTest {
 
     @AfterEach
     fun tearDown() {
+        service.close()
         clearAllMocks()
         unmockkAll()
     }

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModel.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModel.kt
@@ -248,7 +248,10 @@ class DeveloperServicesViewModel(
 
     private fun reset() {
         lastRawReceiptText = null
-        _uiState.value = DeveloperServicesUiState(selectedTab = _uiState.value.selectedTab)
+        _uiState.value = DeveloperServicesUiState(
+            selectedTab = _uiState.value.selectedTab,
+            selectedAiEngine = _uiState.value.selectedAiEngine
+        )
     }
 
     private fun Throwable.toUiText(fallbackRes: Int): UiText {

--- a/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModelTest.kt
+++ b/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModelTest.kt
@@ -213,10 +213,12 @@ class DeveloperServicesViewModelTest {
     inner class ResetEvent {
 
         @Test
-        fun `clears all state but preserves selected tab`() = runTest(testDispatcher) {
+        fun `clears all state but preserves selected tab and AI engine`() = runTest(testDispatcher) {
             val viewModel = createViewModel()
             advanceUntilIdle()
             viewModel.onEvent(DeveloperServicesUiEvent.SwitchTab(DeveloperServicesTab.AiExtraction))
+            viewModel.onEvent(DeveloperServicesUiEvent.SelectAiEngine(AiEngineType.LITE_RT_LM))
+            advanceUntilIdle()
             viewModel.onEvent(
                 DeveloperServicesUiEvent.FileSelected(
                     uri = "content://media/external/file/123",
@@ -246,6 +248,7 @@ class DeveloperServicesViewModelTest {
             assertTrue(state.textBlocks.isEmpty())
             assertNull(state.errorMessage)
             assertEquals(DeveloperServicesTab.AiExtraction, state.selectedTab)
+            assertEquals(AiEngineType.LITE_RT_LM, state.selectedAiEngine)
         }
     }
 


### PR DESCRIPTION
Make ReceiptExtractionServiceImpl AutoCloseable: create a SupervisorJob-backed scope and cancel it in close() to properly clean up coroutines; update tests to call service.close() in tearDown. Also update DeveloperServicesViewModel.reset() to retain the selectedAiEngine when resetting UI state and adjust tests to assert the AI engine is preserved.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #XXX

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
