### PR TITLE
[SPLTRP-1136]: Allow Custom Date and Time Selection for Paid Expenses in Wizard

### DIFF
--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationService.kt
@@ -15,6 +15,13 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
         else -> ValidationResult.Valid
     }
 
+    fun validateExpenseDate(dateMillis: Long): ValidationResult = when {
+        dateMillis > System.currentTimeMillis() -> ValidationResult.Invalid(
+            "Expense date and time cannot be in the future"
+        )
+        else -> ValidationResult.Valid
+    }
+
     fun validateAmount(amountString: String): ValidationResult {
         val result = CurrencyConverter.parseToCents(amountString)
         return if (result.isSuccess) {

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
@@ -394,7 +394,7 @@ class ExpenseValidationServiceTest {
             val future = System.currentTimeMillis() + 100000L
             val result = service.validateExpenseDate(future)
             assertTrue(result is ValidationResult.Invalid)
-            assertEquals("Expense date and time cannot be in the future", (result as ValidationResult.Invalid).message)
+            assertTrue((result as ValidationResult.Invalid).message.isNotBlank())
         }
     }
 }

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
@@ -377,4 +377,24 @@ class ExpenseValidationServiceTest {
             assertTrue(result is ValidationResult.Invalid)
         }
     }
+
+    @Nested
+    inner class ValidateExpenseDate {
+
+        @Test
+        fun `current or past date returns Valid`() {
+            val now = System.currentTimeMillis()
+            val past = now - 100000L
+            assertEquals(ValidationResult.Valid, service.validateExpenseDate(now))
+            assertEquals(ValidationResult.Valid, service.validateExpenseDate(past))
+        }
+
+        @Test
+        fun `future date returns Invalid`() {
+            val future = System.currentTimeMillis() + 100000L
+            val result = service.validateExpenseDate(future)
+            assertTrue(result is ValidationResult.Invalid)
+            assertEquals("Expense date and time cannot be in the future", (result as ValidationResult.Invalid).message)
+        }
+    }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
@@ -211,6 +211,7 @@ val expensesUiModule = module {
             authenticationService = get<AuthenticationService>(),
             addExpenseOptionsMapper = addExpenseOptionsUiMapper,
             addExpenseSplitMapper = addExpenseSplitUiMapper,
+            addExpenseUiMapper = addExpenseUiMapper,
             receiptExtractionService = get<ReceiptExtractionService>()
         )
 
@@ -266,7 +267,8 @@ val expensesUiModule = module {
         val receiptAutoFillEventHandler = ReceiptAutoFillEventHandler(
             extractReceiptFieldsUseCase = get<ExtractReceiptFieldsUseCase>(),
             receiptExtractionService = get<ReceiptExtractionService>(),
-            formattingHelper = formattingHelper
+            formattingHelper = formattingHelper,
+            addExpenseUiMapper = addExpenseUiMapper
         )
 
         AddExpenseViewModel(

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
@@ -1,0 +1,175 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.component.form
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SelectableDates
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Calendar
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.input.StyledOutlinedTextField
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.CardSectionLabelText
+import es.pedrazamiguez.splittrip.features.expense.R
+import java.util.Calendar as JavaCalendar
+
+/**
+ * Expense date and time picker section.
+ * Shows a read-only text field that opens a Material 3 DatePickerDialog on tap,
+ * followed by a TimePicker in an AlertDialog.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ExpenseDateSection(
+    formattedExpenseDate: String,
+    isExpenseDateValid: Boolean,
+    expenseDateMillis: Long?,
+    onDateSelected: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
+    var tempSelectedDateMillis by remember { mutableStateOf<Long?>(null) }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Medium)
+    ) {
+        CardSectionLabelText(
+            text = stringResource(R.string.add_expense_date_time_title)
+        )
+        StyledOutlinedTextField(
+            value = formattedExpenseDate,
+            onValueChange = {},
+            readOnly = true,
+            label = stringResource(R.string.add_expense_date_time_label),
+            trailingIcon = { Icon(TablerIcons.Outline.Calendar, null) },
+            onClick = { showDatePicker = true },
+            modifier = Modifier.fillMaxWidth(),
+            isError = !isExpenseDateValid
+        )
+    }
+
+    if (showDatePicker) {
+        ExpenseDatePickerDialog(
+            initialDateMillis = expenseDateMillis,
+            onDismiss = { showDatePicker = false },
+            onDateSelected = { selectedDate ->
+                tempSelectedDateMillis = selectedDate
+                showDatePicker = false
+                showTimePicker = true
+            }
+        )
+    }
+
+    if (showTimePicker) {
+        ExpenseTimePickerDialog(
+            initialTimeMillis = expenseDateMillis,
+            onDismiss = { showTimePicker = false },
+            onTimeSelected = { hour, minute ->
+                val dateMillis = tempSelectedDateMillis ?: System.currentTimeMillis()
+                val combinedMillis = dateMillis + hour * 3600000L + minute * 60000L
+                onDateSelected(combinedMillis)
+                showTimePicker = false
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ExpenseDatePickerDialog(
+    initialDateMillis: Long?,
+    onDismiss: () -> Unit,
+    onDateSelected: (Long) -> Unit
+) {
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = initialDateMillis ?: System.currentTimeMillis(),
+        selectableDates = object : SelectableDates {
+            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                return utcTimeMillis <= System.currentTimeMillis()
+            }
+
+            override fun isSelectableYear(year: Int): Boolean {
+                return year <= JavaCalendar.getInstance().get(JavaCalendar.YEAR)
+            }
+        }
+    )
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    datePickerState.selectedDateMillis?.let {
+                        onDateSelected(it)
+                    }
+                }
+            ) {
+                Text(stringResource(R.string.expense_date_time_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.expense_date_time_cancel))
+            }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ExpenseTimePickerDialog(
+    initialTimeMillis: Long?,
+    onDismiss: () -> Unit,
+    onTimeSelected: (hour: Int, minute: Int) -> Unit
+) {
+    val calendar = JavaCalendar.getInstance().apply {
+        initialTimeMillis?.let { timeInMillis = it }
+    }
+    val initialHour = calendar.get(JavaCalendar.HOUR_OF_DAY)
+    val initialMinute = calendar.get(JavaCalendar.MINUTE)
+    val timePickerState = rememberTimePickerState(
+        initialHour = initialHour,
+        initialMinute = initialMinute,
+        is24Hour = true
+    )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onTimeSelected(timePickerState.hour, timePickerState.minute)
+                }
+            ) {
+                Text(stringResource(R.string.expense_date_time_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.expense_date_time_cancel))
+            }
+        },
+        text = {
+            TimePicker(state = timePickerState)
+        }
+    )
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
@@ -28,6 +28,11 @@ import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Calendar
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.input.StyledOutlinedTextField
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.CardSectionLabelText
 import es.pedrazamiguez.splittrip.features.expense.R
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
 import java.util.Calendar as JavaCalendar
 
 /**
@@ -81,11 +86,14 @@ internal fun ExpenseDateSection(
 
     if (showTimePicker) {
         ExpenseTimePickerDialog(
+            selectedDateMillis = tempSelectedDateMillis ?: System.currentTimeMillis(),
             initialTimeMillis = expenseDateMillis,
             onDismiss = { showTimePicker = false },
             onTimeSelected = { hour, minute ->
                 val dateMillis = tempSelectedDateMillis ?: System.currentTimeMillis()
-                val combinedMillis = dateMillis + hour * 3600000L + minute * 60000L
+                val localDate = Instant.ofEpochMilli(dateMillis).atZone(ZoneOffset.UTC).toLocalDate()
+                val localDateTime = localDate.atTime(hour, minute)
+                val combinedMillis = localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli()
                 onDateSelected(combinedMillis)
                 showTimePicker = false
             }
@@ -108,7 +116,7 @@ private fun ExpenseDatePickerDialog(
             }
 
             override fun isSelectableYear(year: Int): Boolean {
-                return year <= JavaCalendar.getInstance().get(JavaCalendar.YEAR)
+                return year <= LocalDate.now(ZoneOffset.UTC).year
             }
         }
     )
@@ -138,11 +146,12 @@ private fun ExpenseDatePickerDialog(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpenseTimePickerDialog(
+    selectedDateMillis: Long,
     initialTimeMillis: Long?,
     onDismiss: () -> Unit,
     onTimeSelected: (hour: Int, minute: Int) -> Unit
 ) {
-    val calendar = JavaCalendar.getInstance().apply {
+    val calendar = JavaCalendar.getInstance(java.util.TimeZone.getTimeZone("UTC")).apply {
         initialTimeMillis?.let { timeInMillis = it }
     }
     val initialHour = calendar.get(JavaCalendar.HOUR_OF_DAY)
@@ -152,13 +161,28 @@ private fun ExpenseTimePickerDialog(
         initialMinute = initialMinute,
         is24Hour = true
     )
+
+    // Validate selectable times for today to prevent future times
+    val selectedLocalDate = Instant.ofEpochMilli(selectedDateMillis).atZone(ZoneOffset.UTC).toLocalDate()
+    val nowUtc = LocalDateTime.now(ZoneOffset.UTC)
+    val isToday = selectedLocalDate == nowUtc.toLocalDate()
+
+    val isValidTime = if (isToday) {
+        val selectedTime = LocalTime.of(timePickerState.hour, timePickerState.minute)
+        val nowTime = nowUtc.toLocalTime()
+        !selectedTime.isAfter(nowTime)
+    } else {
+        true
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
             TextButton(
                 onClick = {
                     onTimeSelected(timePickerState.hour, timePickerState.minute)
-                }
+                },
+                enabled = isValidTime
             ) {
                 Text(stringResource(R.string.expense_date_time_ok))
             }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/PaymentStatusStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/PaymentStatusStep.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard.WizardStepLayout
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.DueDateSection
+import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.ExpenseDateSection
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.payment.PaymentStatusSection
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.event.AddExpenseUiEvent
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
@@ -32,6 +33,15 @@ fun PaymentStatusStep(
                 isDueDateValid = uiState.isDueDateValid,
                 dueDateMillis = uiState.dueDateMillis,
                 onDateSelected = { onEvent(AddExpenseUiEvent.DueDateSelected(it)) }
+            )
+        }
+
+        AnimatedVisibility(visible = !uiState.showDueDateSection) {
+            ExpenseDateSection(
+                formattedExpenseDate = uiState.formattedExpenseDate,
+                isExpenseDateValid = uiState.isExpenseDateValid,
+                expenseDateMillis = uiState.expenseDateMillis,
+                onDateSelected = { onEvent(AddExpenseUiEvent.ExpenseDateSelected(it)) }
             )
         }
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
@@ -56,6 +56,21 @@ class AddExpenseUiMapper(
         return dateTime.format(formatter)
     }
 
+    /**
+     * Formats an expense date millis value to a locale-aware display string (medium date + short time).
+     */
+    fun formatExpenseDateForDisplay(dateMillis: Long): String {
+        val locale = localeProvider.getCurrentLocale()
+        val dateTime = LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(dateMillis),
+            ZoneOffset.UTC
+        )
+        val formatter = java.time.format.DateTimeFormatter
+            .ofLocalizedDateTime(java.time.format.FormatStyle.MEDIUM, java.time.format.FormatStyle.SHORT)
+            .withLocale(locale)
+        return dateTime.format(formatter)
+    }
+
     // ── UI State → Domain Mapping ──────────────────────────────────────────
 
     // Sequential field-by-field parsing of UiState → domain model;

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
@@ -265,6 +265,9 @@ class AddExpenseViewModel(
             is AddExpenseUiEvent.DueDateSelected ->
                 formEventHandler.handleDueDateSelected(event.dateMillis)
 
+            is AddExpenseUiEvent.ExpenseDateSelected ->
+                formEventHandler.handleExpenseDateSelected(event.dateMillis)
+
             is AddExpenseUiEvent.ReceiptImageSelected ->
                 formEventHandler.handleReceiptImageChanged(event.uri)
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/AddExpenseUiEvent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/AddExpenseUiEvent.kt
@@ -31,6 +31,7 @@ sealed interface AddExpenseUiEvent {
     data class NotesChanged(val notes: String) : AddExpenseUiEvent
     data class PaymentStatusSelected(val statusId: String) : AddExpenseUiEvent
     data class DueDateSelected(val dateMillis: Long) : AddExpenseUiEvent
+    data class ExpenseDateSelected(val dateMillis: Long) : AddExpenseUiEvent
     data class ReceiptImageSelected(val uri: String) : AddExpenseUiEvent
     data object RemoveReceiptImage : AddExpenseUiEvent
     data class SetAiModeActive(val active: Boolean) : AddExpenseUiEvent

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
@@ -21,6 +21,7 @@ import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseOptionsUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseSplitUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.CategoryUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.FundingSourceUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentMethodUiModel
@@ -57,6 +58,7 @@ class ConfigEventHandler(
     private val authenticationService: AuthenticationService,
     private val addExpenseOptionsMapper: AddExpenseOptionsUiMapper,
     private val addExpenseSplitMapper: AddExpenseSplitUiMapper,
+    private val addExpenseUiMapper: AddExpenseUiMapper,
     private val receiptExtractionService: ReceiptExtractionService
 ) : AddExpenseEventHandler {
 
@@ -146,6 +148,8 @@ class ConfigEventHandler(
         val userSubunitOptions = filterSubunitsForCurrentUser(currentUserId, config)
 
         val isAiCapable = receiptExtractionService.capability() == ExtractionCapability.ON_DEVICE_AI
+        val currentMillis = System.currentTimeMillis()
+        val formattedDate = addExpenseUiMapper.formatExpenseDateForDisplay(currentMillis)
 
         _uiState.update {
             it.copy(
@@ -158,6 +162,10 @@ class ConfigEventHandler(
                 currentStep = if (isAiCapable) AddExpenseStep.RECEIPT else AddExpenseStep.TITLE,
                 groupName = config.group.name,
                 currentUserId = currentUserId,
+                expenseDateMillis = currentMillis,
+                formattedExpenseDate = formattedDate,
+                isExpenseDateValid = true,
+                isExpenseDateModifiedByUser = false,
                 groupCurrency = defaults.mappedGroupCurrency,
                 availableCurrencies = defaults.mappedCurrencies,
                 paymentMethods = defaults.reorderedPaymentMethods,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/FormEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/FormEventHandler.kt
@@ -26,6 +26,7 @@ import timber.log.Timber
  * is routed via [formPostCallback], following the same pattern as
  * [ConfigEventHandler]'s [PostConfigAction] callback.
  */
+@Suppress("TooManyFunctions")
 class FormEventHandler(
     private val addExpenseUiMapper: AddExpenseUiMapper,
     private val attachReceiptUseCase: AttachReceiptUseCase
@@ -191,6 +192,20 @@ class FormEventHandler(
                 dueDateMillis = dateMillis,
                 formattedDueDate = formattedDate,
                 isDueDateValid = true
+            )
+        }
+    }
+
+    fun handleExpenseDateSelected(dateMillis: Long) {
+        val isValid = dateMillis <= System.currentTimeMillis()
+        val formattedDate = addExpenseUiMapper.formatExpenseDateForDisplay(dateMillis)
+        _uiState.update {
+            it.copy(
+                expenseDateMillis = dateMillis,
+                formattedExpenseDate = formattedDate,
+                isExpenseDateValid = isValid,
+                isExpenseDateModifiedByUser = true,
+                error = if (!isValid) UiText.StringResource(R.string.expense_error_date_future) else null
             )
         }
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
@@ -10,6 +10,7 @@ import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.usecase.expense.ExtractReceiptFieldsUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentMethodUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
@@ -29,7 +30,8 @@ import timber.log.Timber
 class ReceiptAutoFillEventHandler(
     private val extractReceiptFieldsUseCase: ExtractReceiptFieldsUseCase,
     private val receiptExtractionService: ReceiptExtractionService,
-    private val formattingHelper: FormattingHelper
+    private val formattingHelper: FormattingHelper,
+    private val addExpenseUiMapper: AddExpenseUiMapper
 ) : AddExpenseEventHandler {
 
     private lateinit var _uiState: MutableStateFlow<AddExpenseUiState>
@@ -202,7 +204,7 @@ class ReceiptAutoFillEventHandler(
     ) {
         val extractedDate = extracted.date
         val currentState = _uiState.value
-        if (currentState.expenseDateMillis == null && extractedDate != null) {
+        if (!currentState.isExpenseDateModifiedByUser && extractedDate != null) {
             val extractedTime = extracted.time
             val localDateTime = if (extractedTime != null) {
                 extractedDate.atTime(extractedTime)
@@ -210,7 +212,14 @@ class ReceiptAutoFillEventHandler(
                 extractedDate.atStartOfDay()
             }
             val dateMillis = localDateTime.atZone(ZoneOffset.UTC).toInstant().toEpochMilli()
-            _uiState.update { it.copy(expenseDateMillis = dateMillis) }
+            val formattedDate = addExpenseUiMapper.formatExpenseDateForDisplay(dateMillis)
+            _uiState.update {
+                it.copy(
+                    expenseDateMillis = dateMillis,
+                    formattedExpenseDate = formattedDate,
+                    isExpenseDateValid = true
+                )
+            }
             bannerFields.add(UiText.StringResource(R.string.add_expense_date))
             if (extractedTime != null) {
                 bannerFields.add(UiText.StringResource(R.string.expense_field_time))

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -60,7 +60,7 @@ class SubmitEventHandler(
 
     // Sequential validation → map → submit → error-handling pipeline;
     // each branch is a distinct validation/error case
-    @Suppress("CognitiveComplexMethod", "LongMethod")
+    @Suppress("CognitiveComplexMethod", "LongMethod", "ReturnCount")
     fun submitExpense(groupId: String?, onSuccess: () -> Unit) {
         if (groupId == null) return
 
@@ -101,6 +101,22 @@ class SubmitEventHandler(
                 )
             }
             return
+        }
+
+        // Validate expense date/time when not scheduled
+        if (!currentState.showDueDateSection) {
+            val dateValidation = expenseValidationService.validateExpenseDate(
+                currentState.expenseDateMillis ?: System.currentTimeMillis()
+            )
+            if (dateValidation is ValidationResult.Invalid) {
+                _uiState.update {
+                    it.copy(
+                        isExpenseDateValid = false,
+                        error = UiText.StringResource(R.string.expense_error_date_future)
+                    )
+                }
+                return
+            }
         }
 
         // Validate add-ons (only those with non-empty input)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -178,6 +178,9 @@ data class AddExpenseUiState(
     val isTitleValid: Boolean = true,
     val isAmountValid: Boolean = true,
     val isDueDateValid: Boolean = true,
+    val formattedExpenseDate: String = "",
+    val isExpenseDateValid: Boolean = true,
+    val isExpenseDateModifiedByUser: Boolean = false,
 
     // ── AI Auto-fill ────────────────────────────────────────────────────
     val isAiCapable: Boolean = false,

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -324,4 +324,9 @@
     <string name="expense_field_payment_method">Método de pago</string>
     <string name="expense_field_time">Hora</string>
     <string name="expense_field_notes">Notas</string>
+    <string name="add_expense_date_time_title">Fecha y hora del gasto</string>
+    <string name="add_expense_date_time_label">Fecha y hora</string>
+    <string name="expense_date_time_ok">OK</string>
+    <string name="expense_date_time_cancel">Cancelar</string>
+    <string name="expense_error_date_future">La fecha y hora del gasto no pueden ser futuras</string>
 </resources>

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -323,4 +323,9 @@
     <string name="expense_field_payment_method">Payment method</string>
     <string name="expense_field_time">Time</string>
     <string name="expense_field_notes">Notes</string>
+    <string name="add_expense_date_time_title">Expense date and time</string>
+    <string name="add_expense_date_time_label">Date and time</string>
+    <string name="expense_date_time_ok">OK</string>
+    <string name="expense_date_time_cancel">Cancel</string>
+    <string name="expense_error_date_future">Expense date and time cannot be in the future</string>
 </resources>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
@@ -264,6 +264,7 @@ class AddExpenseViewModelTest {
             authenticationService = authenticationService,
             addExpenseOptionsMapper = addExpenseOptionsMapper,
             addExpenseSplitMapper = addExpenseSplitMapper,
+            addExpenseUiMapper = addExpenseUiMapper,
             receiptExtractionService = mockReceiptExtractionService
         )
 
@@ -329,7 +330,8 @@ class AddExpenseViewModelTest {
         val receiptAutoFillEventHandler = ReceiptAutoFillEventHandler(
             extractReceiptFieldsUseCase = mockk<ExtractReceiptFieldsUseCase>(relaxed = true),
             receiptExtractionService = mockk<ReceiptExtractionService>(relaxed = true),
-            formattingHelper = formattingHelper
+            formattingHelper = formattingHelper,
+            addExpenseUiMapper = addExpenseUiMapper
         )
 
         viewModel = AddExpenseViewModel(

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandlerTest.kt
@@ -16,8 +16,10 @@ import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCategor
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedPaymentMethodUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseAddOnUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseOptionsUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseSplitUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import io.mockk.coEvery
@@ -50,6 +52,7 @@ class ConfigEventHandlerTest {
     private lateinit var getGroupLastUsedCategoryUseCase: GetGroupLastUsedCategoryUseCase
     private lateinit var getMemberProfilesUseCase: GetMemberProfilesUseCase
     private lateinit var authenticationService: AuthenticationService
+    private lateinit var addExpenseUiMapper: AddExpenseUiMapper
     private val capturedActions = mutableListOf<PostConfigAction>()
 
     private lateinit var uiState: MutableStateFlow<AddExpenseUiState>
@@ -89,6 +92,20 @@ class ConfigEventHandlerTest {
         val splitPreviewService = SplitPreviewService()
         val remainderDistributionService = RemainderDistributionService()
 
+        val addExpenseSplitMapper = AddExpenseSplitUiMapper(
+            localeProvider,
+            FormattingHelper(localeProvider),
+            splitPreviewService,
+            EntitySplitFlattenDelegate(splitPreviewService, remainderDistributionService)
+        )
+        addExpenseUiMapper = AddExpenseUiMapper(
+            localeProvider = localeProvider,
+            resourceProvider = resourceProvider,
+            splitMapper = addExpenseSplitMapper,
+            addOnMapper = AddExpenseAddOnUiMapper(),
+            splitPreviewService = splitPreviewService
+        )
+
         handler = ConfigEventHandler(
             getGroupExpenseConfigUseCase = getGroupExpenseConfigUseCase,
             getGroupLastUsedCurrencyUseCase = getGroupLastUsedCurrencyUseCase,
@@ -97,12 +114,8 @@ class ConfigEventHandlerTest {
             getMemberProfilesUseCase = getMemberProfilesUseCase,
             authenticationService = authenticationService,
             addExpenseOptionsMapper = AddExpenseOptionsUiMapper(resourceProvider, mockk(relaxed = true)),
-            addExpenseSplitMapper = AddExpenseSplitUiMapper(
-                localeProvider,
-                FormattingHelper(localeProvider),
-                splitPreviewService,
-                EntitySplitFlattenDelegate(splitPreviewService, remainderDistributionService)
-            ),
+            addExpenseSplitMapper = addExpenseSplitMapper,
+            addExpenseUiMapper = addExpenseUiMapper,
             receiptExtractionService = mockk(relaxed = true)
         )
         handler.setPostConfigCallback { capturedActions.add(it) }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
@@ -11,6 +11,7 @@ import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.usecase.expense.ExtractReceiptFieldsUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.CategoryUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentMethodUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
@@ -44,6 +45,7 @@ class ReceiptAutoFillEventHandlerTest {
     private lateinit var extractReceiptFieldsUseCase: ExtractReceiptFieldsUseCase
     private lateinit var receiptExtractionService: ReceiptExtractionService
     private lateinit var formattingHelper: FormattingHelper
+    private lateinit var addExpenseUiMapper: AddExpenseUiMapper
     private lateinit var uiState: MutableStateFlow<AddExpenseUiState>
     private lateinit var actions: MutableSharedFlow<AddExpenseUiAction>
 
@@ -70,10 +72,12 @@ class ReceiptAutoFillEventHandlerTest {
         capturedCategorySelections.clear()
         capturedPaymentMethodSelections.clear()
 
+        addExpenseUiMapper = mockk(relaxed = true)
         handler = ReceiptAutoFillEventHandler(
             extractReceiptFieldsUseCase = extractReceiptFieldsUseCase,
             receiptExtractionService = receiptExtractionService,
-            formattingHelper = formattingHelper
+            formattingHelper = formattingHelper,
+            addExpenseUiMapper = addExpenseUiMapper
         )
         handler.setOnCurrencySelected { capturedCurrencySelections.add(it) }
         handler.setOnAmountChanged { capturedAmountChanges.add(it) }
@@ -279,6 +283,7 @@ class ReceiptAutoFillEventHandlerTest {
                 notes = "Pre-populated Notes",
                 sourceAmount = "10.00",
                 expenseDateMillis = 9999L,
+                isExpenseDateModifiedByUser = true,
                 selectedCurrency = usd,
                 selectedPaymentMethod = cashPaymentMethod
             )
@@ -336,6 +341,7 @@ class ReceiptAutoFillEventHandlerTest {
                     vendor = "In-flight Vendor",
                     notes = "In-flight Notes",
                     expenseDateMillis = 8888L,
+                    isExpenseDateModifiedByUser = true,
                     selectedCurrency = usd,
                     selectedPaymentMethod = cashPaymentMethod
                 )

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
@@ -190,6 +190,7 @@ class ReceiptAutoFillEventHandlerTest {
                 )
             )
             every { formattingHelper.formatCentsValue(1250L, 2) } returns "12.50"
+            every { addExpenseUiMapper.formatExpenseDateForDisplay(1735727400000L) } returns "Jan 1, 2025, 10:30 AM"
 
             handler.handleReceiptAttached(attachment)
 
@@ -198,6 +199,7 @@ class ReceiptAutoFillEventHandlerTest {
             assertEquals("my locator", uiState.value.notes)
             // 2025-01-01T10:30 UTC epoch millis = 1735727400000L
             assertEquals(1735727400000L, uiState.value.expenseDateMillis)
+            assertEquals("Jan 1, 2025, 10:30 AM", uiState.value.formattedExpenseDate)
             assertEquals("USD", capturedCurrencySelections.single())
             assertEquals("12.50", capturedAmountChanges.single())
             assertEquals("FOOD", capturedCategorySelections.single())

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
@@ -570,6 +570,21 @@ class SubmitEventHandlerTest {
         }
 
         @Test
+        fun `future expense date sets isExpenseDateValid false and error`() = runTest(testDispatcher) {
+            handler.bind(stateFlow, actionsFlow, this)
+            stateFlow.value = AddExpenseUiState(
+                expenseTitle = "Dinner",
+                sourceAmount = "50",
+                expenseDateMillis = System.currentTimeMillis() + 1000000L
+            )
+
+            handler.submitExpense("group-1") {}
+
+            assertFalse(stateFlow.value.isExpenseDateValid)
+            assertNotNull(stateFlow.value.error)
+        }
+
+        @Test
         fun `add-on with zero resolved amount sets addOnError`() = runTest(testDispatcher) {
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(


### PR DESCRIPTION
Introduce expense date/time support across the feature:

- Add ExpenseDateSection composable providing date + time pickers and read-only field.
- Add formatExpenseDateForDisplay in AddExpenseUiMapper to produce localized date/time strings.
- Wire AddExpenseUiMapper into DI and tests.
- Extend AddExpenseUiState with formattedExpenseDate, isExpenseDateValid and isExpenseDateModifiedByUser.
- Add AddExpenseUiEvent.ExpenseDateSelected and handle it in AddExpenseViewModel/FormEventHandler (with user-modified flag and error handling).
- Update ReceiptAutoFillEventHandler to populate expense date only when the user hasn't modified it and format the displayed date.
- Validate expense date in SubmitEventHandler (reject future dates) and add domain-level validateExpenseDate with unit tests.
- Add localized strings for date/time UI and error messages.
- Update unit tests to cover new behavior and wiring.

These changes add UI, mapping, validation and tests to allow users to pick and validate expense date/time, and to let receipt auto-fill populate the date when appropriate.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1136 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
