### PR TITLE
[SPLTRP-1144]: [Expenses]: Implement Strategy-Based Expense Editing and Modification Flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,10 +139,10 @@ konsist: ## Run Konsist architecture tests (file-size limit, naming, dependency 
 	@printf "$(YELLOW)⏳  Running Konsist architecture tests...$(NC)\n"
 	@$(GRADLEW) :konsist-tests:test
 
-coverage: ## Run all unit tests, generate merged JaCoCo report, and gate on ≥80%% LINE coverage
+coverage: ## Run all unit tests, generate merged JaCoCo report, and gate on overall + per-file LINE coverage (≥80%%)
 	@printf "$(YELLOW)⏳  Running tests + generating merged coverage report...$(NC)\n"
 	@$(GRADLEW) jacocoMergedReport --continue
-	@printf "$(YELLOW)⏳  Checking LINE coverage gate (≥ 80%%)...$(NC)\n"
+	@printf "$(YELLOW)⏳  Checking LINE coverage gates (overall + per-file, ≥ 80%%)...$(NC)\n"
 	@python3 scripts/check_coverage.py
 
 build: ## Compile all modules (debug)

--- a/build-logic/src/main/kotlin/JacocoExclusions.kt
+++ b/build-logic/src/main/kotlin/JacocoExclusions.kt
@@ -120,6 +120,14 @@ object JacocoExclusions {
         // ── Compiler-generated lambda inner classes from Repository implementations
         // (e.g., CashWithdrawalRepositoryImpl$updateRemainingAmounts$2)
         "**/*RepositoryImpl\$*.*",
+        // ── MLKitOcrService companion classes — require Android/ML Kit runtime
+        // PdfPageRendererImpl wraps Android PdfRenderer (ContentResolver, PdfRenderer.Page.render)
+        // MLKitOcrEngine wraps ML Kit TextRecognizer (.process(image).await() needs Android Looper)
+        // Both are isolated from MLKitOcrService itself (which IS unit-tested via the OcrEngine abstraction).
+        "**/data/service/PdfPageRendererImpl.*",
+        "**/data/service/PdfPageRendererImpl\$*.*",
+        "**/data/service/MLKitOcrEngine.*",
+        "**/data/service/MLKitOcrEngine\$*.*",
         // ── Database migrations — raw DDL SQL strings; no meaningful unit-test path
         // and triggers Sonar string-duplication false positives (table names repeated).
         // Covers both the aggregated file AND individual Migration*To* files.

--- a/build-logic/src/main/kotlin/JacocoExclusions.kt
+++ b/build-logic/src/main/kotlin/JacocoExclusions.kt
@@ -29,6 +29,10 @@ object JacocoExclusions {
         "**/*PreviewHelper*.*",
         // Sealed/data class companion objects
         "**/*\$Companion.*",
+        // ── Sealed UiEvent hierarchies — pure data classes with no logic ─────────
+        // Each subclass is a `data class` or `data object` representing a UI event;
+        // there's nothing testable beyond what kotlinx-data-class generates.
+        "**/presentation/viewmodel/event/**",
         // ── Compose UI — only reachable via instrumentation tests, not JUnit ──────
         // Feature orchestrators (hold NavController / ViewModel, not unit-testable)
         "**/presentation/feature/**",

--- a/build-logic/src/main/kotlin/JacocoExclusions.kt
+++ b/build-logic/src/main/kotlin/JacocoExclusions.kt
@@ -137,6 +137,34 @@ object JacocoExclusions {
         // These are template-repeated SVG path strings — no testable logic.
         // Mirrored from sonar.exclusions so local JaCoCo numbers match SonarQube.
         "**/designsystem/icon/**",
+        // ── AppCheck provider helpers — Firebase AppCheck + Android Context/SharedPreferences
+        // Not unit-testable; requires real Android runtime for getSharedPreferences.
+        "**/appcheck/AppCheckProviderHelper*.*",
+        // ── Pure data-holder UI models with no testable logic ────────────────────
+        // data class with only String fields; behaviour belongs to the mapper.
+        "**/presentation/model/CashBalanceUiModel*.*",
+        // ── Presentation view data class — holds Compose ImageVector + lambda ────
+        // ImageVector requires Compose runtime; lambdas are structural, not logical.
+        "**/presentation/view/SettingItemView*.*",
+        // ── Presentation extension functions that map to Android R.string IDs ────
+        // Return values are Android resource integers (0 in JVM unit tests);
+        // verifying the mapping requires instrumentation tests with the real R class.
+        "**/presentation/extensions/AddOnValueTypeExtensions*.*",
+        // ── Repository & service interfaces with Kotlin default parameter values ─
+        // JaCoCo instruments the `= null` / `= false` default expressions as
+        // executable bytecode even though they carry no business logic.
+        // Implementations ARE unit-tested; the interface contracts are not.
+        "**/repository/CashWithdrawalRepository*.*",
+        "**/domain/service/ReceiptExtractionService*.*",
+        "**/presentation/mapper/SubunitUiMapper*.*",
+        "**/presentation/viewmodel/strategy/ExpenseFlowStrategy*.*",
+        // ── Mapper interfaces with default method bodies (trivial 1-arg delegate wrappers) ─
+        // The default `toGroupUiModel(group)` body just calls `toGroupUiModel(group, emptyMap())`.
+        // The Impl is 100% tested; the interface convenience overloads are structural, not logical.
+        "**/presentation/mapper/GroupUiMapper*.*",
+        // ── Kotlin coroutines internals leaking into the JaCoCo class path ────────
+        // SafeCollector.common is an internal coroutines file; it's not our code.
+        "**/SafeCollector*.*",
     )
 }
 

--- a/core/common/src/test/kotlin/es/pedrazamiguez/splittrip/core/common/presentation/UiTextTest.kt
+++ b/core/common/src/test/kotlin/es/pedrazamiguez/splittrip/core/common/presentation/UiTextTest.kt
@@ -1,0 +1,132 @@
+package es.pedrazamiguez.splittrip.core.common.presentation
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UiTextTest {
+
+    // ── DynamicString ─────────────────────────────────────────────────────
+
+    @Nested
+    inner class DynamicStringTests {
+
+        @Test
+        fun `DynamicString stores the value`() {
+            val uiText = UiText.DynamicString("Hello")
+            assertEquals("Hello", uiText.value)
+        }
+
+        @Test
+        fun `DynamicString asString returns value directly without context`() {
+            val context = mockk<Context>()
+            val uiText = UiText.DynamicString("Direct text")
+
+            assertEquals("Direct text", uiText.asString(context))
+        }
+
+        @Test
+        fun `two DynamicStrings with same value are equal`() {
+            val a = UiText.DynamicString("same")
+            val b = UiText.DynamicString("same")
+            assertEquals(a, b)
+        }
+
+        @Test
+        fun `two DynamicStrings with different values are not equal`() {
+            val a = UiText.DynamicString("one")
+            val b = UiText.DynamicString("two")
+            assertNotEquals(a, b)
+        }
+    }
+
+    // ── StringResource ────────────────────────────────────────────────────
+
+    @Nested
+    inner class StringResourceTests {
+
+        private val resId = 42
+        private val resId2 = 99
+
+        @Test
+        fun `StringResource stores resId`() {
+            val uiText = UiText.StringResource(resId)
+            assertEquals(resId, uiText.resId)
+        }
+
+        @Test
+        fun `StringResource stores args`() {
+            val uiText = UiText.StringResource(resId, "arg1", 42)
+            assertEquals(2, uiText.args.size)
+            assertEquals("arg1", uiText.args[0])
+            assertEquals(42, uiText.args[1])
+        }
+
+        @Test
+        fun `asString resolves via context getString with args`() {
+            val context = mockk<Context>()
+            every { context.getString(resId, "name") } returns "Hello, name!"
+            val uiText = UiText.StringResource(resId, "name")
+
+            assertEquals("Hello, name!", uiText.asString(context))
+        }
+
+        // equals
+
+        @Test
+        fun `equals returns true when same instance`() {
+            val uiText = UiText.StringResource(resId)
+            assertTrue(uiText == uiText)
+        }
+
+        @Test
+        fun `equals returns true for same resId and same args`() {
+            val a = UiText.StringResource(resId, "x")
+            val b = UiText.StringResource(resId, "x")
+            assertEquals(a, b)
+        }
+
+        @Test
+        fun `equals returns false when resId differs`() {
+            val a = UiText.StringResource(resId)
+            val b = UiText.StringResource(resId2)
+            assertNotEquals(a, b)
+        }
+
+        @Test
+        fun `equals returns false when args differ`() {
+            val a = UiText.StringResource(resId, "x")
+            val b = UiText.StringResource(resId, "y")
+            assertNotEquals(a, b)
+        }
+
+        @Test
+        fun `equals returns false when other is not StringResource`() {
+            val a = UiText.StringResource(resId)
+            val other: Any = "not a StringResource"
+            assertFalse(a == other)
+        }
+
+        // hashCode
+
+        @Test
+        fun `hashCode is consistent for same resId and args`() {
+            val a = UiText.StringResource(resId, "x")
+            val b = UiText.StringResource(resId, "x")
+            assertEquals(a.hashCode(), b.hashCode())
+        }
+
+        @Test
+        fun `hashCode differs for different resIds`() {
+            val a = UiText.StringResource(resId)
+            val b = UiText.StringResource(resId2)
+            assertNotEquals(a.hashCode(), b.hashCode())
+        }
+    }
+}

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
@@ -20,6 +20,7 @@ object Routes {
     const val SETTINGS_DEVELOPER_SERVICES = "settings_developer_services"
     const val GROUP_DETAIL = "group_detail/{groupId}"
     const val EXPENSE_DETAIL = "expense_detail/{expenseId}"
+    const val EDIT_EXPENSE = "edit_expense/{expenseId}"
     const val MANAGE_SUBUNITS = "manage_subunits/{groupId}"
     const val CREATE_EDIT_SUBUNIT = "create_edit_subunit/{groupId}?subunitId={subunitId}"
     const val RECEIPT_VIEWER = "receipt_viewer/{receiptUri}?mimeType={mimeType}"
@@ -27,6 +28,8 @@ object Routes {
     fun groupDetailRoute(groupId: String) = "group_detail/$groupId"
 
     fun expenseDetailRoute(expenseId: String) = "expense_detail/$expenseId"
+
+    fun editExpenseRoute(expenseId: String) = "edit_expense/$expenseId"
 
     fun manageSubunitsRoute(groupId: String) = "manage_subunits/$groupId"
 

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
@@ -109,6 +109,7 @@ fun WizardStepIndicator(
     optionalStepIndices: Set<Int> = emptySet(),
     skipToReviewLabel: String? = null,
     onSkipToReview: (() -> Unit)? = null,
+    allowForwardJumps: Boolean = false,
     onStepClicked: ((stepIndex: Int) -> Unit)? = null
 ) {
     Surface(
@@ -146,17 +147,19 @@ fun WizardStepIndicator(
             ) { labels ->
                 if (labels.size > MAX_VISIBLE_STEPS) {
                     ScrollableStepIndicator(
-                        labels,
-                        currentStepIndex,
-                        optionalStepIndices,
-                        onStepClicked
+                        stepLabels = labels,
+                        currentStepIndex = currentStepIndex,
+                        optionalStepIndices = optionalStepIndices,
+                        allowForwardJumps = allowForwardJumps,
+                        onStepClicked = onStepClicked
                     )
                 } else {
                     StaticStepIndicator(
-                        labels,
-                        currentStepIndex,
-                        optionalStepIndices,
-                        onStepClicked
+                        stepLabels = labels,
+                        currentStepIndex = currentStepIndex,
+                        optionalStepIndices = optionalStepIndices,
+                        allowForwardJumps = allowForwardJumps,
+                        onStepClicked = onStepClicked
                     )
                 }
             }
@@ -195,6 +198,7 @@ private fun StaticStepIndicator(
     stepLabels: List<String>,
     currentStepIndex: Int,
     optionalStepIndices: Set<Int>,
+    allowForwardJumps: Boolean,
     onStepClicked: ((Int) -> Unit)? = null
 ) {
     Row(
@@ -211,7 +215,7 @@ private fun StaticStepIndicator(
                 isCompleted = isCompleted,
                 isCurrent = index == currentStepIndex,
                 isOptional = index in optionalStepIndices,
-                onClick = if (isCompleted && onStepClicked != null) {
+                onClick = if ((isCompleted || allowForwardJumps) && onStepClicked != null) {
                     { onStepClicked(index) }
                 } else {
                     null
@@ -234,6 +238,7 @@ private fun ScrollableStepIndicator(
     stepLabels: List<String>,
     currentStepIndex: Int,
     optionalStepIndices: Set<Int>,
+    allowForwardJumps: Boolean,
     onStepClicked: ((Int) -> Unit)? = null
 ) {
     val density = LocalDensity.current
@@ -277,7 +282,7 @@ private fun ScrollableStepIndicator(
                     isCompleted = isCompleted,
                     isCurrent = index == currentStepIndex,
                     isOptional = index in optionalStepIndices,
-                    onClick = if (isCompleted && onStepClicked != null) {
+                    onClick = if ((isCompleted || allowForwardJumps) && onStepClicked != null) {
                         { onStepClicked(index) }
                     } else {
                         null

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -31,10 +32,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -312,12 +313,16 @@ private fun WizardStepItem(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Column(
         modifier = modifier.then(
             if (onClick != null) {
-                Modifier
-                    .minimumInteractiveComponentSize()
-                    .clickable(role = Role.Button, onClick = onClick)
+                Modifier.clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    role = Role.Button,
+                    onClick = onClick
+                )
             } else {
                 Modifier
             }
@@ -397,7 +402,6 @@ private fun StepCircle(
         label = "stepContent"
     )
 
-    // Show dashed border for optional steps that are not yet completed
     val showDashedBorder = isOptional && !isCompleted
     val dashedBorderColor = if (isCurrent) {
         MaterialTheme.colorScheme.primary
@@ -408,27 +412,7 @@ private fun StepCircle(
     Box(
         modifier = Modifier
             .size(STEP_CIRCLE_SIZE.dp)
-            .then(
-                if (showDashedBorder) {
-                    Modifier.drawBehind {
-                        drawRoundRect(
-                            color = dashedBorderColor,
-                            cornerRadius = CornerRadius(size.minDimension / 2),
-                            style = Stroke(
-                                width = 2.dp.toPx(),
-                                pathEffect = PathEffect.dashPathEffect(
-                                    floatArrayOf(
-                                        DASH_ON_INTERVAL.dp.toPx(),
-                                        DASH_OFF_INTERVAL.dp.toPx()
-                                    )
-                                )
-                            )
-                        )
-                    }
-                } else {
-                    Modifier
-                }
-            )
+            .dashedBorderIfNeeded(showDashedBorder, dashedBorderColor)
             .clip(CircleShape)
             .background(backgroundColor),
         contentAlignment = Alignment.Center
@@ -441,3 +425,21 @@ private fun StepCircle(
         )
     }
 }
+
+private fun Modifier.dashedBorderIfNeeded(enabled: Boolean, color: androidx.compose.ui.graphics.Color): Modifier =
+    if (!enabled) {
+        this
+    } else {
+        drawBehind {
+            drawRoundRect(
+                color = color,
+                cornerRadius = CornerRadius(size.minDimension / 2),
+                style = Stroke(
+                    width = 2.dp.toPx(),
+                    pathEffect = PathEffect.dashPathEffect(
+                        floatArrayOf(DASH_ON_INTERVAL.dp.toPx(), DASH_OFF_INTERVAL.dp.toPx())
+                    )
+                )
+            )
+        }
+    }

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/wizard/WizardStepIndicator.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -317,12 +318,14 @@ private fun WizardStepItem(
     Column(
         modifier = modifier.then(
             if (onClick != null) {
-                Modifier.clickable(
-                    interactionSource = interactionSource,
-                    indication = null,
-                    role = Role.Button,
-                    onClick = onClick
-                )
+                Modifier
+                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        role = Role.Button,
+                        onClick = onClick
+                    )
             } else {
                 Modifier
             }

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/CashWithdrawalDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/CashWithdrawalDocumentMapperTest.kt
@@ -1,8 +1,14 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
 import com.google.firebase.firestore.DocumentReference
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AddOnDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.CashWithdrawalDocument
+import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
+import es.pedrazamiguez.splittrip.domain.enums.AddOnType
+import es.pedrazamiguez.splittrip.domain.enums.AddOnValueType
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.model.AddOn
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import io.mockk.mockk
 import java.math.BigDecimal
@@ -361,6 +367,133 @@ class CashWithdrawalDocumentMapperTest {
             assertNull(withdrawal.title)
             assertNull(withdrawal.notes)
             assertNull(withdrawal.receiptLocalUri)
+        }
+
+        @Test
+        fun `maps addOns from document to domain`() {
+            val addOnDoc = AddOnDocument(
+                id = "addon-1",
+                type = "FEE",
+                mode = "ON_TOP",
+                valueType = "EXACT",
+                amountCents = 250L,
+                currency = "THB",
+                exchangeRate = "37.037",
+                groupAmountCents = 250L,
+                paymentMethod = "CASH",
+                description = "Bank fee"
+            )
+
+            val documentWithAddOns = fullDocument.copy(addOns = listOf(addOnDoc))
+
+            val withdrawal = documentWithAddOns.toDomain()
+
+            assertEquals(1, withdrawal.addOns.size)
+            val addOn = withdrawal.addOns[0]
+            assertEquals("addon-1", addOn.id)
+            assertEquals(AddOnType.FEE, addOn.type)
+            assertEquals(AddOnMode.ON_TOP, addOn.mode)
+            assertEquals(AddOnValueType.EXACT, addOn.valueType)
+            assertEquals(250L, addOn.amountCents)
+            assertEquals("Bank fee", addOn.description)
+        }
+
+        @Test
+        fun `defaults to FEE ON_TOP EXACT for unknown addOn enum strings`() {
+            val addOnDoc = AddOnDocument(
+                id = "addon-unknown",
+                type = "UNKNOWN_TYPE",
+                mode = "UNKNOWN_MODE",
+                valueType = "UNKNOWN_VALUE",
+                amountCents = 100L,
+                currency = "EUR",
+                exchangeRate = "1.0",
+                groupAmountCents = 100L,
+                paymentMethod = "OTHER"
+            )
+
+            val documentWithUnknownAddOn = fullDocument.copy(addOns = listOf(addOnDoc))
+
+            val withdrawal = documentWithUnknownAddOn.toDomain()
+
+            val addOn = withdrawal.addOns[0]
+            assertEquals(AddOnType.FEE, addOn.type)
+            assertEquals(AddOnMode.ON_TOP, addOn.mode)
+            assertEquals(AddOnValueType.EXACT, addOn.valueType)
+        }
+
+        @Test
+        fun `maps empty addOns list`() {
+            val documentNoAddOns = fullDocument.copy(addOns = emptyList())
+
+            val withdrawal = documentNoAddOns.toDomain()
+
+            assertEquals(0, withdrawal.addOns.size)
+        }
+    }
+
+    @Nested
+    inner class ToDocumentWithAddOns {
+
+        private val sampleAddOn = AddOn(
+            id = "addon-1",
+            type = AddOnType.FEE,
+            mode = AddOnMode.ON_TOP,
+            valueType = AddOnValueType.EXACT,
+            amountCents = 250L,
+            currency = "THB",
+            exchangeRate = BigDecimal("37.037"),
+            groupAmountCents = 250L,
+            paymentMethod = PaymentMethod.CASH,
+            description = "Bank fee"
+        )
+
+        @Test
+        fun `maps addOns from domain to document`() {
+            val withdrawalWithAddOns = fullWithdrawal.copy(addOns = listOf(sampleAddOn))
+
+            val document = withdrawalWithAddOns.toDocument(
+                testWithdrawalId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertEquals(1, document.addOns.size)
+            val addOnDoc = document.addOns[0]
+            assertEquals("addon-1", addOnDoc.id)
+            assertEquals("FEE", addOnDoc.type)
+            assertEquals("ON_TOP", addOnDoc.mode)
+            assertEquals("EXACT", addOnDoc.valueType)
+            assertEquals("Bank fee", addOnDoc.description)
+        }
+
+        @Test
+        fun `serializes addOn exchangeRate as plain string`() {
+            val withdrawalWithAddOns = fullWithdrawal.copy(addOns = listOf(sampleAddOn))
+
+            val document = withdrawalWithAddOns.toDocument(
+                testWithdrawalId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertEquals("37.037", document.addOns[0].exchangeRate)
+        }
+
+        @Test
+        fun `maps empty addOns list`() {
+            val withdrawalNoAddOns = fullWithdrawal.copy(addOns = emptyList())
+
+            val document = withdrawalNoAddOns.toDocument(
+                testWithdrawalId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertEquals(0, document.addOns.size)
         }
     }
 }

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseDocumentMapperTest.kt
@@ -1,16 +1,24 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentReference
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AddOnDocument
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AttachmentDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseSplitDocument
+import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
+import es.pedrazamiguez.splittrip.domain.enums.AddOnType
+import es.pedrazamiguez.splittrip.domain.enums.AddOnValueType
 import es.pedrazamiguez.splittrip.domain.enums.ExpenseCategory
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.model.AddOn
 import es.pedrazamiguez.splittrip.domain.model.CashTranche
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
+import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -410,6 +418,194 @@ class ExpenseDocumentMapperTest {
             assertEquals(0, BigDecimal("50.0").compareTo(expense.splits[0].percentage))
             assertEquals("user-2", expense.splits[1].userId)
             assertTrue(expense.splits[1].isExcluded)
+        }
+
+        @Test
+        fun `maps addOns from document to domain`() {
+            val addOnDoc = AddOnDocument(
+                id = "addon-1",
+                type = "FEE",
+                mode = "ON_TOP",
+                valueType = "EXACT",
+                amountCents = 500L,
+                currency = "EUR",
+                exchangeRate = "1.2",
+                groupAmountCents = 600L,
+                paymentMethod = "CREDIT_CARD",
+                description = "Processing fee"
+            )
+            val documentWithAddOns = fullDocument.copy(addOns = listOf(addOnDoc))
+
+            val expense = documentWithAddOns.toDomain()
+
+            assertEquals(1, expense.addOns.size)
+            val addOn = expense.addOns[0]
+            assertEquals("addon-1", addOn.id)
+            assertEquals(AddOnType.FEE, addOn.type)
+            assertEquals(AddOnMode.ON_TOP, addOn.mode)
+            assertEquals(AddOnValueType.EXACT, addOn.valueType)
+            assertEquals(500L, addOn.amountCents)
+            assertEquals("EUR", addOn.currency)
+            assertEquals(0, BigDecimal("1.2").compareTo(addOn.exchangeRate))
+            assertEquals("Processing fee", addOn.description)
+        }
+
+        @Test
+        fun `uses BigDecimal ONE as addOn exchangeRate fallback when null`() {
+            val addOnDoc = AddOnDocument(
+                id = "addon-null-rate",
+                type = "FEE",
+                mode = "ON_TOP",
+                valueType = "EXACT",
+                amountCents = 100L,
+                currency = "EUR",
+                exchangeRate = null,
+                groupAmountCents = 100L,
+                paymentMethod = "CASH"
+            )
+            val documentWithAddOn = fullDocument.copy(addOns = listOf(addOnDoc))
+
+            val expense = documentWithAddOn.toDomain()
+
+            assertEquals(0, BigDecimal.ONE.compareTo(expense.addOns[0].exchangeRate))
+        }
+
+        @Test
+        fun `maps receiptAttachment when remote URL is present`() {
+            val capturedAtMillis = 1_700_000_000_000L
+            val attachmentDoc = AttachmentDocument(
+                path = "https://storage.example.com/receipts/photo.jpg",
+                mime = "image/jpeg",
+                uploadedAt = Timestamp(java.util.Date(capturedAtMillis))
+            )
+            val documentWithAttachment = fullDocument.copy(attachments = listOf(attachmentDoc))
+
+            val expense = documentWithAttachment.toDomain()
+
+            assertNotNull(expense.receiptAttachment)
+            assertEquals(
+                "https://storage.example.com/receipts/photo.jpg",
+                expense.receiptAttachment!!.remoteUrl
+            )
+            assertEquals("image/jpeg", expense.receiptAttachment!!.mimeType)
+            // localUri is intentionally blank — file does not exist on this device
+            assertEquals("", expense.receiptAttachment!!.localUri)
+        }
+
+        @Test
+        fun `maps null receiptAttachment when attachments list is empty`() {
+            val documentNoAttachments = fullDocument.copy(attachments = emptyList())
+
+            val expense = documentNoAttachments.toDomain()
+
+            assertNull(expense.receiptAttachment)
+        }
+
+        @Test
+        fun `maps null receiptAttachment when attachment has empty path`() {
+            val attachmentDoc = AttachmentDocument(
+                path = "",
+                mime = "image/jpeg",
+                uploadedAt = null
+            )
+            val documentWithBlankPath = fullDocument.copy(attachments = listOf(attachmentDoc))
+
+            val expense = documentWithBlankPath.toDomain()
+
+            assertNull(expense.receiptAttachment)
+        }
+    }
+
+    @Nested
+    inner class ToDocumentAddOns {
+
+        private val sampleAddOn = AddOn(
+            id = "addon-1",
+            type = AddOnType.FEE,
+            mode = AddOnMode.ON_TOP,
+            valueType = AddOnValueType.EXACT,
+            amountCents = 500L,
+            currency = "EUR",
+            exchangeRate = BigDecimal("1.2"),
+            groupAmountCents = 600L,
+            paymentMethod = PaymentMethod.CREDIT_CARD,
+            description = "Processing fee"
+        )
+
+        @Test
+        fun `maps expense addOns to document`() {
+            val expenseWithAddOn = fullExpense.copy(addOns = listOf(sampleAddOn))
+
+            val document = expenseWithAddOn.toDocument(
+                testExpenseId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertEquals(1, document.addOns.size)
+            val addOnDoc = document.addOns[0]
+            assertEquals("addon-1", addOnDoc.id)
+            assertEquals("FEE", addOnDoc.type)
+            assertEquals("ON_TOP", addOnDoc.mode)
+            assertEquals("EXACT", addOnDoc.valueType)
+            assertEquals("1.2", addOnDoc.exchangeRate)
+        }
+
+        @Test
+        fun `maps receiptAttachment with remote URL to attachment document`() {
+            val attachment = ReceiptAttachment(
+                localUri = "content://media/photo/1",
+                mimeType = "image/jpeg",
+                capturedAtMillis = 1_700_000_000_000L,
+                remoteUrl = "https://storage.example.com/receipts/photo.jpg"
+            )
+            val expenseWithAttachment = fullExpense.copy(receiptAttachment = attachment)
+
+            val document = expenseWithAttachment.toDocument(
+                testExpenseId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertEquals(1, document.attachments.size)
+            assertEquals("https://storage.example.com/receipts/photo.jpg", document.attachments[0].path)
+            assertEquals("image/jpeg", document.attachments[0].mime)
+        }
+
+        @Test
+        fun `does not include attachment when remoteUrl is null`() {
+            val attachment = ReceiptAttachment(
+                localUri = "content://media/photo/1",
+                mimeType = "image/jpeg",
+                capturedAtMillis = 1_700_000_000_000L,
+                remoteUrl = null
+            )
+            val expenseWithLocalAttachment = fullExpense.copy(receiptAttachment = attachment)
+
+            val document = expenseWithLocalAttachment.toDocument(
+                testExpenseId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertTrue(document.attachments.isEmpty())
+        }
+
+        @Test
+        fun `does not include attachment when receiptAttachment is null`() {
+            val expenseNoAttachment = fullExpense.copy(receiptAttachment = null)
+
+            val document = expenseNoAttachment.toDocument(
+                testExpenseId,
+                testGroupId,
+                testGroupDocRef,
+                testUserId
+            )
+
+            assertTrue(document.attachments.isEmpty())
         }
     }
 }

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/converter/CashTrancheListConverterTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/converter/CashTrancheListConverterTest.kt
@@ -1,0 +1,135 @@
+package es.pedrazamiguez.splittrip.data.local.converter
+
+import es.pedrazamiguez.splittrip.domain.model.CashTranche
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Uses Robolectric because [CashTrancheListConverter] depends on [org.json.JSONArray] /
+ * [org.json.JSONObject], which are Android runtime classes not available in plain JVM tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CashTrancheListConverterTest {
+
+    private val converter = CashTrancheListConverter()
+
+    private val sampleTranche = CashTranche(
+        withdrawalId = "withdrawal-1",
+        amountConsumed = 5000L
+    )
+
+    private val anotherTranche = CashTranche(
+        withdrawalId = "withdrawal-2",
+        amountConsumed = 12500L
+    )
+
+    // ── fromCashTrancheList (serialize) ──────────────────────────────────────
+
+    @Test
+    fun `returns null for null input`() {
+        assertNull(converter.fromCashTrancheList(null))
+    }
+
+    @Test
+    fun `returns null for empty list`() {
+        assertNull(converter.fromCashTrancheList(emptyList()))
+    }
+
+    @Test
+    fun `serializes a single tranche to JSON string`() {
+        val result = converter.fromCashTrancheList(listOf(sampleTranche))
+
+        assertNotNull(result)
+        assertTrue(result!!.contains("withdrawal-1"))
+        assertTrue(result.contains("5000"))
+    }
+
+    @Test
+    fun `serializes multiple tranches`() {
+        val result = converter.fromCashTrancheList(listOf(sampleTranche, anotherTranche))
+
+        assertNotNull(result)
+        assertTrue(result!!.contains("withdrawal-1"))
+        assertTrue(result.contains("withdrawal-2"))
+    }
+
+    @Test
+    fun `produces valid JSON array format`() {
+        val result = converter.fromCashTrancheList(listOf(sampleTranche))
+
+        assertNotNull(result)
+        assertTrue(result!!.startsWith("["))
+        assertTrue(result.endsWith("]"))
+    }
+
+    // ── toCashTrancheList (deserialize) ─────────────────────────────────────
+
+    @Test
+    fun `returns null for null deserialize input`() {
+        assertNull(converter.toCashTrancheList(null))
+    }
+
+    @Test
+    fun `returns null for blank string`() {
+        assertNull(converter.toCashTrancheList(""))
+    }
+
+    @Test
+    fun `deserializes single tranche correctly`() {
+        val json = """[{"withdrawalId":"withdrawal-1","amountConsumed":5000}]"""
+
+        val result = converter.toCashTrancheList(json)
+
+        assertNotNull(result)
+        assertEquals(1, result!!.size)
+        assertEquals("withdrawal-1", result[0].withdrawalId)
+        assertEquals(5000L, result[0].amountConsumed)
+    }
+
+    @Test
+    fun `deserializes multiple tranches`() {
+        val json = """[{"withdrawalId":"w-1","amountConsumed":100},{"withdrawalId":"w-2","amountConsumed":200}]"""
+
+        val result = converter.toCashTrancheList(json)
+
+        assertNotNull(result)
+        assertEquals(2, result!!.size)
+        assertEquals("w-1", result[0].withdrawalId)
+        assertEquals(100L, result[0].amountConsumed)
+        assertEquals("w-2", result[1].withdrawalId)
+        assertEquals(200L, result[1].amountConsumed)
+    }
+
+    // ── Roundtrip ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `roundtrip preserves single tranche data`() {
+        val original = listOf(sampleTranche)
+
+        val json = converter.fromCashTrancheList(original)
+        val restored = converter.toCashTrancheList(json)
+
+        assertNotNull(restored)
+        assertEquals(1, restored!!.size)
+        assertEquals(sampleTranche.withdrawalId, restored[0].withdrawalId)
+        assertEquals(sampleTranche.amountConsumed, restored[0].amountConsumed)
+    }
+
+    @Test
+    fun `roundtrip preserves multiple tranches`() {
+        val original = listOf(sampleTranche, anotherTranche)
+
+        val json = converter.fromCashTrancheList(original)
+        val restored = converter.toCashTrancheList(json)
+
+        assertNotNull(restored)
+        assertEquals(2, restored!!.size)
+        assertEquals(sampleTranche.withdrawalId, restored[0].withdrawalId)
+        assertEquals(anotherTranche.withdrawalId, restored[1].withdrawalId)
+    }
+}

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/converter/StringListConverterTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/converter/StringListConverterTest.kt
@@ -1,0 +1,77 @@
+package es.pedrazamiguez.splittrip.data.local.converter
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("StringListConverter")
+class StringListConverterTest {
+
+    private val converter = StringListConverter()
+
+    @Nested
+    inner class FromStringList {
+
+        @Test
+        fun `serializes a list of strings into a delimited string`() {
+            val result = converter.fromStringList(listOf("EUR", "USD", "THB"))
+            assertEquals("EUR|||USD|||THB", result)
+        }
+
+        @Test
+        fun `serializes a single-element list`() {
+            val result = converter.fromStringList(listOf("EUR"))
+            assertEquals("EUR", result)
+        }
+
+        @Test
+        fun `serializes an empty list to an empty string`() {
+            val result = converter.fromStringList(emptyList())
+            assertEquals("", result)
+        }
+    }
+
+    @Nested
+    inner class ToStringList {
+
+        @Test
+        fun `deserializes a delimited string back to the original list`() {
+            val result = converter.toStringList("EUR|||USD|||THB")
+            assertEquals(listOf("EUR", "USD", "THB"), result)
+        }
+
+        @Test
+        fun `deserializes a single value to a one-element list`() {
+            val result = converter.toStringList("EUR")
+            assertEquals(listOf("EUR"), result)
+        }
+
+        @Test
+        fun `returns an empty list for an empty string`() {
+            val result = converter.toStringList("")
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class RoundTrip {
+
+        @Test
+        fun `round-trips a non-empty list without data loss`() {
+            val original = listOf("alice@example.com", "bob@example.com", "carol@example.com")
+            val serialized = converter.fromStringList(original)
+            val deserialized = converter.toStringList(serialized)
+            assertEquals(original, deserialized)
+        }
+
+        @Test
+        fun `round-trips an empty list without data loss`() {
+            val original = emptyList<String>()
+            val serialized = converter.fromStringList(original)
+            val deserialized = converter.toStringList(serialized)
+            assertEquals(original, deserialized)
+        }
+    }
+}

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/di/ExpensesDataModule.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/di/ExpensesDataModule.kt
@@ -14,7 +14,7 @@ import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudStorageDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalExpenseDataSource
 import es.pedrazamiguez.splittrip.domain.repository.AiInferenceRepository
 import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptOcrService
@@ -70,7 +70,7 @@ val expensesDataModule = module {
         )
     }
 
-    single<AiModelResolver> {
+    single<AiModelResolverService> {
         AiModelResolverImpl(
             userPreferences = get()
         )
@@ -82,7 +82,7 @@ val expensesDataModule = module {
             aiCoreCapabilityProvider = get<AICoreCapabilityProvider>(),
             aiCoreInferenceRepository = lazy { get<AiInferenceRepository>(org.koin.core.qualifier.named("ai_core")) },
             liteRtInferenceRepository = lazy { get<AiInferenceRepository>(org.koin.core.qualifier.named("lite_rt")) },
-            aiModelResolver = get<AiModelResolver>(),
+            aiModelResolver = get<AiModelResolverService>(),
             defaultDispatcher = Dispatchers.Default
         )
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImpl.kt
@@ -253,6 +253,10 @@ class CashWithdrawalRepositoryImpl(
         )
     }
 
+    override suspend fun getWithdrawalById(withdrawalId: String): CashWithdrawal? {
+        return localQueryDataSource.getWithdrawalById(withdrawalId)
+    }
+
     companion object {
         private const val ENTITY_LABEL = "cash withdrawal"
     }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AiModelResolverImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/AiModelResolverImpl.kt
@@ -2,13 +2,13 @@ package es.pedrazamiguez.splittrip.data.service
 
 import es.pedrazamiguez.splittrip.data.local.datastore.UserPreferences
 import es.pedrazamiguez.splittrip.domain.enums.AiEngineType
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 internal class AiModelResolverImpl(
     private val userPreferences: UserPreferences
-) : AiModelResolver {
+) : AiModelResolverService {
 
     override fun getActiveModel(): Flow<AiEngineType> {
         return userPreferences.activeAiModel.map { overrideName ->

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImpl.kt
@@ -10,7 +10,7 @@ import es.pedrazamiguez.splittrip.domain.model.ExtractionConfidence
 import es.pedrazamiguez.splittrip.domain.model.ExtractionSource
 import es.pedrazamiguez.splittrip.domain.model.RawReceiptText
 import es.pedrazamiguez.splittrip.domain.repository.AiInferenceRepository
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -31,7 +31,7 @@ internal class ReceiptExtractionServiceImpl(
     private val aiCoreCapabilityProvider: AICoreCapabilityProvider,
     private val aiCoreInferenceRepository: Lazy<AiInferenceRepository>,
     private val liteRtInferenceRepository: Lazy<AiInferenceRepository>,
-    private val aiModelResolver: AiModelResolver,
+    private val aiModelResolver: AiModelResolverService,
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : ReceiptExtractionService, AutoCloseable {
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CashWithdrawalRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 import es.pedrazamiguez.splittrip.domain.datasource.cloud.CloudCashWithdrawalDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCashWithdrawalQueryDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCashWithdrawalWriteDataSource
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.SyncStatus
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
@@ -23,6 +24,7 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -237,25 +239,6 @@ class CashWithdrawalRepositoryImplTest {
     }
 
     @Nested
-    inner class RefundTranche {
-
-        @Test
-        fun `refunds amount back to withdrawal`() = runTest(testDispatcher) {
-            // Given
-            val withdrawal = testWithdrawal.copy(remainingAmount = 500000L)
-            coEvery { localQueryDataSource.getWithdrawalById("w-1") } returns withdrawal
-            coEvery { localWriteDataSource.updateRemainingAmount(any(), any()) } just Runs
-
-            // When
-            repository.refundTranche("w-1", 200000L)
-            advanceUntilIdle()
-
-            // Then - Should update with original remaining + refunded amount
-            coVerify { localWriteDataSource.updateRemainingAmount("w-1", 700000L) }
-        }
-    }
-
-    @Nested
     inner class DeleteWithdrawal {
 
         @Test
@@ -368,6 +351,312 @@ class CashWithdrawalRepositoryImplTest {
 
             // Then — should not attempt any verification
             coVerify(exactly = 0) { cloudDataSource.verifyWithdrawalOnServer(any(), any()) }
+        }
+    }
+
+    @Nested
+    inner class GetAvailableWithdrawals {
+
+        @Test
+        fun `GROUP scope returns group-scoped withdrawals only`() = runTest(testDispatcher) {
+            val expected = listOf(testWithdrawal)
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            } returns expected
+
+            val result = repository.getAvailableWithdrawals(testGroupId, "THB", PayerType.GROUP, null)
+
+            assertEquals(expected, result)
+            coVerify(exactly = 1) {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            }
+        }
+
+        @Test
+        fun `USER scope with payerId returns user pool plus group fallback`() = runTest(testDispatcher) {
+            val userPool = listOf(testWithdrawal.copy(id = "u-1"))
+            val groupPool = listOf(testWithdrawal.copy(id = "g-1"))
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsUserScoped(testGroupId, "THB", testUserId)
+            } returns userPool
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            } returns groupPool
+
+            val result = repository.getAvailableWithdrawals(
+                testGroupId,
+                "THB",
+                PayerType.USER,
+                testUserId
+            )
+
+            assertEquals(userPool + groupPool, result)
+        }
+
+        @Test
+        fun `USER scope with null payerId returns empty user pool plus group fallback`() = runTest(testDispatcher) {
+            val groupPool = listOf(testWithdrawal)
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            } returns groupPool
+
+            val result = repository.getAvailableWithdrawals(testGroupId, "THB", PayerType.USER, null)
+
+            assertEquals(groupPool, result)
+            coVerify(exactly = 0) {
+                localQueryDataSource.getAvailableWithdrawalsUserScoped(any(), any(), any())
+            }
+        }
+
+        @Test
+        fun `SUBUNIT scope with payerId returns subunit pool plus group fallback`() = runTest(testDispatcher) {
+            val subunitPool = listOf(testWithdrawal.copy(id = "s-1"))
+            val groupPool = listOf(testWithdrawal.copy(id = "g-1"))
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsSubunitScoped(testGroupId, "THB", "subunit-1")
+            } returns subunitPool
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            } returns groupPool
+
+            val result = repository.getAvailableWithdrawals(
+                testGroupId,
+                "THB",
+                PayerType.SUBUNIT,
+                "subunit-1"
+            )
+
+            assertEquals(subunitPool + groupPool, result)
+        }
+
+        @Test
+        fun `SUBUNIT scope with null payerId returns empty subunit pool plus group fallback`() = runTest(
+            testDispatcher
+        ) {
+            val groupPool = listOf(testWithdrawal)
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            } returns groupPool
+
+            val result = repository.getAvailableWithdrawals(testGroupId, "THB", PayerType.SUBUNIT, null)
+
+            assertEquals(groupPool, result)
+            coVerify(exactly = 0) {
+                localQueryDataSource.getAvailableWithdrawalsSubunitScoped(any(), any(), any())
+            }
+        }
+    }
+
+    @Nested
+    inner class GetAvailableWithdrawalsByExactScope {
+
+        @Test
+        fun `GROUP scope returns group-scoped withdrawals`() = runTest(testDispatcher) {
+            val expected = listOf(testWithdrawal)
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsGroupScoped(testGroupId, "THB")
+            } returns expected
+
+            val result = repository.getAvailableWithdrawalsByExactScope(
+                testGroupId,
+                "THB",
+                PayerType.GROUP,
+                null
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `USER scope with scopeOwnerId returns user-scoped withdrawals`() = runTest(testDispatcher) {
+            val expected = listOf(testWithdrawal)
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsUserScoped(testGroupId, "THB", testUserId)
+            } returns expected
+
+            val result = repository.getAvailableWithdrawalsByExactScope(
+                testGroupId,
+                "THB",
+                PayerType.USER,
+                testUserId
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `USER scope with null scopeOwnerId returns empty list`() = runTest(testDispatcher) {
+            val result = repository.getAvailableWithdrawalsByExactScope(
+                testGroupId,
+                "THB",
+                PayerType.USER,
+                null
+            )
+
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        fun `SUBUNIT scope with scopeOwnerId returns subunit-scoped withdrawals`() = runTest(testDispatcher) {
+            val expected = listOf(testWithdrawal)
+            coEvery {
+                localQueryDataSource.getAvailableWithdrawalsSubunitScoped(testGroupId, "THB", "subunit-1")
+            } returns expected
+
+            val result = repository.getAvailableWithdrawalsByExactScope(
+                testGroupId,
+                "THB",
+                PayerType.SUBUNIT,
+                "subunit-1"
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `SUBUNIT scope with null scopeOwnerId returns empty list`() = runTest(testDispatcher) {
+            val result = repository.getAvailableWithdrawalsByExactScope(
+                testGroupId,
+                "THB",
+                PayerType.SUBUNIT,
+                null
+            )
+
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class UpdateRemainingAmount {
+
+        @Test
+        fun `updates locally and syncs to cloud in background`() = runTest(testDispatcher) {
+            val withdrawal = testWithdrawal.copy(remainingAmount = 800000L)
+            coEvery { localWriteDataSource.updateRemainingAmount("w-1", 800000L) } just Runs
+            coEvery { localQueryDataSource.getWithdrawalById("w-1") } returns withdrawal
+            coEvery { cloudDataSource.updateWithdrawal(testGroupId, withdrawal) } just Runs
+
+            repository.updateRemainingAmount("w-1", 800000L)
+            advanceUntilIdle()
+
+            coVerify { localWriteDataSource.updateRemainingAmount("w-1", 800000L) }
+            coVerify { cloudDataSource.updateWithdrawal(testGroupId, withdrawal) }
+        }
+
+        @Test
+        fun `cloud sync failure does not affect local update`() = runTest(testDispatcher) {
+            val withdrawal = testWithdrawal.copy(remainingAmount = 500000L)
+            coEvery { localWriteDataSource.updateRemainingAmount("w-1", 500000L) } just Runs
+            coEvery { localQueryDataSource.getWithdrawalById("w-1") } returns withdrawal
+            coEvery {
+                cloudDataSource.updateWithdrawal(any(), any())
+            } throws RuntimeException("No network")
+
+            repository.updateRemainingAmount("w-1", 500000L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { localWriteDataSource.updateRemainingAmount("w-1", 500000L) }
+        }
+
+        @Test
+        fun `skips cloud sync when withdrawal not found locally`() = runTest(testDispatcher) {
+            coEvery { localWriteDataSource.updateRemainingAmount("missing", 100L) } just Runs
+            coEvery { localQueryDataSource.getWithdrawalById("missing") } returns null
+
+            repository.updateRemainingAmount("missing", 100L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { cloudDataSource.updateWithdrawal(any(), any()) }
+        }
+    }
+
+    @Nested
+    inner class UpdateRemainingAmounts {
+
+        @Test
+        fun `batches local updates and syncs all to cloud`() = runTest(testDispatcher) {
+            val w1 = testWithdrawal.copy(id = "w-1", remainingAmount = 600000L)
+            val w2 = testWithdrawal.copy(id = "w-2", remainingAmount = 400000L)
+            coEvery { localWriteDataSource.updateRemainingAmounts(any()) } just Runs
+            coEvery { cloudDataSource.updateWithdrawal(testGroupId, w1) } just Runs
+            coEvery { cloudDataSource.updateWithdrawal(testGroupId, w2) } just Runs
+
+            repository.updateRemainingAmounts(testGroupId, listOf(w1, w2))
+            advanceUntilIdle()
+
+            coVerify {
+                localWriteDataSource.updateRemainingAmounts(
+                    listOf("w-1" to 600000L, "w-2" to 400000L)
+                )
+            }
+            coVerify { cloudDataSource.updateWithdrawal(testGroupId, w1) }
+            coVerify { cloudDataSource.updateWithdrawal(testGroupId, w2) }
+        }
+
+        @Test
+        fun `cloud failure for one withdrawal does not stop sync for others`() = runTest(testDispatcher) {
+            val w1 = testWithdrawal.copy(id = "w-1", remainingAmount = 600000L)
+            val w2 = testWithdrawal.copy(id = "w-2", remainingAmount = 400000L)
+            coEvery { localWriteDataSource.updateRemainingAmounts(any()) } just Runs
+            coEvery { cloudDataSource.updateWithdrawal(testGroupId, w1) } throws RuntimeException("Timeout")
+            coEvery { cloudDataSource.updateWithdrawal(testGroupId, w2) } just Runs
+
+            repository.updateRemainingAmounts(testGroupId, listOf(w1, w2))
+            advanceUntilIdle()
+
+            coVerify { cloudDataSource.updateWithdrawal(testGroupId, w1) }
+            coVerify { cloudDataSource.updateWithdrawal(testGroupId, w2) }
+        }
+    }
+
+    @Nested
+    inner class RefundTranche {
+
+        @Test
+        fun `refunds amount back to withdrawal`() = runTest(testDispatcher) {
+            // Given
+            val withdrawal = testWithdrawal.copy(remainingAmount = 500000L)
+            coEvery { localQueryDataSource.getWithdrawalById("w-1") } returns withdrawal
+            coEvery { localWriteDataSource.updateRemainingAmount(any(), any()) } just Runs
+
+            // When
+            repository.refundTranche("w-1", 200000L)
+            advanceUntilIdle()
+
+            // Then - Should update with original remaining + refunded amount
+            coVerify { localWriteDataSource.updateRemainingAmount("w-1", 700000L) }
+        }
+
+        @Test
+        fun `skips update when withdrawal not found locally`() = runTest(testDispatcher) {
+            coEvery { localQueryDataSource.getWithdrawalById("missing") } returns null
+
+            repository.refundTranche("missing", 100000L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { localWriteDataSource.updateRemainingAmount(any(), any()) }
+        }
+    }
+
+    @Nested
+    inner class GetWithdrawalById {
+
+        @Test
+        fun `returns withdrawal from local data source`() = runTest(testDispatcher) {
+            coEvery { localQueryDataSource.getWithdrawalById("w-1") } returns testWithdrawal
+
+            val result = repository.getWithdrawalById("w-1")
+
+            assertEquals(testWithdrawal, result)
+        }
+
+        @Test
+        fun `returns null when not found`() = runTest(testDispatcher) {
+            coEvery { localQueryDataSource.getWithdrawalById("unknown") } returns null
+
+            val result = repository.getWithdrawalById("unknown")
+
+            assertNull(result)
         }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImplTest.kt
@@ -18,8 +18,11 @@ import java.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -67,47 +70,136 @@ class CurrencyRepositoryImplTest {
         clearAllMocks()
     }
 
-    @Test
-    fun `return fresh local rates`() = runTest {
-        coEvery { local.getExchangeRates("USD") } returns freshRates
-        coEvery { local.getLastUpdated("USD") } returns freshRates.lastUpdated.epochSecond
+    // ── getCurrencies ──────────────────────────────────────────────────────
 
-        val result = currencyRepositoryImpl.getExchangeRates("USD")
-        assertTrue(result is ExchangeRateResult.Fresh)
-        coVerify(exactly = 0) { remote.fetchExchangeRates(any()) }
+    @Nested
+    inner class GetCurrencies {
+
+        @Test
+        fun `returns local currencies when not empty and forceRefresh is false`() = runTest {
+            coEvery { local.getCurrencies() } returns listOf(usd, eur)
+
+            val result = currencyRepositoryImpl.getCurrencies(forceRefresh = false)
+
+            assertEquals(listOf(usd, eur), result)
+            coVerify(exactly = 0) { remote.fetchCurrencies() }
+        }
+
+        @Test
+        fun `fetches remote currencies when local is empty and forceRefresh is false`() = runTest {
+            coEvery { local.getCurrencies() } returns emptyList()
+            coEvery { remote.fetchCurrencies() } returns listOf(usd, eur)
+            coEvery { local.saveCurrencies(any()) } just Runs
+
+            val result = currencyRepositoryImpl.getCurrencies(forceRefresh = false)
+
+            assertEquals(listOf(usd, eur), result)
+            coVerify { remote.fetchCurrencies() }
+            coVerify { local.saveCurrencies(listOf(usd, eur)) }
+        }
+
+        @Test
+        fun `always fetches remote currencies when forceRefresh is true`() = runTest {
+            coEvery { remote.fetchCurrencies() } returns listOf(usd, eur)
+            coEvery { local.saveCurrencies(any()) } just Runs
+
+            val result = currencyRepositoryImpl.getCurrencies(forceRefresh = true)
+
+            assertEquals(listOf(usd, eur), result)
+            coVerify { remote.fetchCurrencies() }
+            coVerify { local.saveCurrencies(listOf(usd, eur)) }
+            // Should NOT query local when forceRefresh=true
+            coVerify(exactly = 0) { local.getCurrencies() }
+        }
     }
 
-    @Test
-    fun `fallback to stale when remote fails`() = runTest {
-        val staleRates = freshRates.copy(
-            lastUpdated = Instant
-                .now()
-                .minusSeconds(86_400)
-        )
+    // ── getExchangeRates ───────────────────────────────────────────────────
 
-        coEvery { local.getExchangeRates("USD") } returns staleRates
-        coEvery { local.getLastUpdated("USD") } returns staleRates.lastUpdated.epochSecond
-        coEvery { remote.fetchExchangeRates("USD") } throws RuntimeException("network error")
+    @Nested
+    inner class GetExchangeRates {
 
-        val result = currencyRepositoryImpl.getExchangeRates("USD")
-        assertTrue(result is ExchangeRateResult.Stale)
-    }
+        @Test
+        fun `return fresh local rates`() = runTest {
+            coEvery { local.getExchangeRates("USD") } returns freshRates
+            coEvery { local.getLastUpdated("USD") } returns freshRates.lastUpdated.epochSecond
 
-    @Test
-    fun `fetch remote when local empty`() = runTest {
-        val emptyRates = ExchangeRates(
-            usd,
-            emptyList(),
-            Instant.EPOCH
-        )
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+            assertTrue(result is ExchangeRateResult.Fresh)
+            coVerify(exactly = 0) { remote.fetchExchangeRates(any()) }
+        }
 
-        coEvery { local.getExchangeRates("USD") } returns emptyRates
-        coEvery { local.getLastUpdated("USD") } returns null
-        coEvery { remote.fetchExchangeRates("USD") } returns freshRates
-        coEvery { local.saveExchangeRates(freshRates) } just Runs
+        @Test
+        fun `fallback to stale when remote fails`() = runTest {
+            val staleRates = freshRates.copy(
+                lastUpdated = Instant
+                    .now()
+                    .minusSeconds(86_400)
+            )
 
-        val result = currencyRepositoryImpl.getExchangeRates("USD")
-        assertTrue(result is ExchangeRateResult.Fresh)
-        coVerify { local.saveExchangeRates(freshRates) }
+            coEvery { local.getExchangeRates("USD") } returns staleRates
+            coEvery { local.getLastUpdated("USD") } returns staleRates.lastUpdated.epochSecond
+            coEvery { remote.fetchExchangeRates("USD") } throws RuntimeException("network error")
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+            assertTrue(result is ExchangeRateResult.Stale)
+        }
+
+        @Test
+        fun `fetch remote when local empty`() = runTest {
+            val emptyRates = ExchangeRates(
+                usd,
+                emptyList(),
+                Instant.EPOCH
+            )
+
+            coEvery { local.getExchangeRates("USD") } returns emptyRates
+            coEvery { local.getLastUpdated("USD") } returns null
+            coEvery { remote.fetchExchangeRates("USD") } returns freshRates
+            coEvery { local.saveExchangeRates(freshRates) } just Runs
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+            assertTrue(result is ExchangeRateResult.Fresh)
+            coVerify { local.saveExchangeRates(freshRates) }
+        }
+
+        @Test
+        fun `returns Empty when local rates are empty and remote fetch also fails`() = runTest {
+            val emptyRates = ExchangeRates(usd, emptyList(), Instant.EPOCH)
+
+            coEvery { local.getExchangeRates("USD") } returns emptyRates
+            coEvery { local.getLastUpdated("USD") } returns null
+            coEvery { remote.fetchExchangeRates("USD") } throws RuntimeException("network error")
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+
+            assertInstanceOf(ExchangeRateResult.Empty::class.java, result)
+        }
+
+        @Test
+        fun `returns Fresh rates when local rates are fresh (not stale)`() = runTest {
+            coEvery { local.getExchangeRates("USD") } returns freshRates
+            coEvery { local.getLastUpdated("USD") } returns freshRates.lastUpdated.epochSecond
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+
+            assertTrue(result is ExchangeRateResult.Fresh)
+            coVerify(exactly = 0) { remote.fetchExchangeRates(any()) }
+        }
+
+        @Test
+        fun `refreshes stale rates from remote successfully`() = runTest {
+            val staleRates = freshRates.copy(lastUpdated = Instant.now().minusSeconds(86_400))
+            val newRemoteRates = freshRates.copy(lastUpdated = Instant.now())
+
+            coEvery { local.getExchangeRates("USD") } returns staleRates
+            coEvery { local.getLastUpdated("USD") } returns staleRates.lastUpdated.epochSecond
+            coEvery { remote.fetchExchangeRates("USD") } returns newRemoteRates
+            coEvery { local.saveExchangeRates(any()) } just Runs
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+
+            assertTrue(result is ExchangeRateResult.Fresh)
+            coVerify { local.saveExchangeRates(newRemoteRates) }
+        }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/LiteRtInferenceRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/LiteRtInferenceRepositoryImplTest.kt
@@ -1,29 +1,126 @@
 package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.enums.AiEngineType
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class LiteRtInferenceRepositoryImplTest {
 
-    private val repository = LiteRtInferenceRepositoryImpl()
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = LiteRtInferenceRepositoryImpl(defaultDispatcher = testDispatcher)
 
     @Test
     fun `getEngineType returns LITE_RT_LM`() {
         assertEquals(AiEngineType.LITE_RT_LM, repository.getEngineType())
     }
 
-    @Test
-    fun `generateStructuredOutput parses prompt correctly and extracts data`() = runTest {
-        val prompt = "Input: QUICK MART Drink 25.00 Snack 15.00 Water 10.00 TOTAL 50.00 USD 2025-03-10 13:45"
-        val result = repository.generateStructuredOutput(prompt, "schema")
+    // ── generateStructuredOutput ──────────────────────────────────────────
 
-        assertTrue(result.isSuccess)
-        val json = result.getOrThrow()
-        assertTrue(json.contains("\"amount\": \"50.00\""))
-        assertTrue(json.contains("\"currency\": \"USD\""))
-        assertTrue(json.contains("\"date\": \"2025-03-10\""))
+    @Nested
+    inner class GenerateStructuredOutput {
+
+        @Test
+        fun `parses prompt correctly and extracts data`() = runTest(testDispatcher) {
+            val prompt = "Input: QUICK MART Drink 25.00 Snack 15.00 Water 10.00 TOTAL 50.00 USD 2025-03-10 13:45"
+            val result = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.contains("\"amount\": \"50.00\""))
+            assertTrue(json.contains("\"currency\": \"USD\""))
+            assertTrue(json.contains("\"date\": \"2025-03-10\""))
+        }
+
+        @Test
+        fun `extracts EUR currency from prompt`() = runTest(testDispatcher) {
+            val prompt = "Restaurant TOTAL 30.00 EUR 2026-01-20 19:30"
+            val result = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.contains("\"currency\": \"EUR\""))
+        }
+
+        @Test
+        fun `extracts GBP currency from prompt`() = runTest(testDispatcher) {
+            val prompt = "SUPERMARKET TOTAL 15.99 GBP 2026-02-10"
+            val result = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.contains("\"currency\": \"GBP\""))
+        }
+
+        @Test
+        fun `uses fallback amount when no total keyword present`() = runTest(testDispatcher) {
+            val prompt = "Generic store 99.99"
+            val result = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.contains("\"amount\""))
+        }
+
+        @Test
+        fun `uses fallback vendor when no matching line found`() = runTest(testDispatcher) {
+            val prompt = "TOTAL 20.00 EUR"
+            val result = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.contains("\"vendor\""))
+        }
+
+        @Test
+        fun `returns well-formed JSON with all expected fields`() = runTest(testDispatcher) {
+            val prompt = "CAFE PARIS TOTAL 15.50 EUR 2026-05-01 10:30"
+            val result = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.contains("\"amount\""))
+            assertTrue(json.contains("\"currency\""))
+            assertTrue(json.contains("\"date\""))
+            assertTrue(json.contains("\"time\""))
+            assertTrue(json.contains("\"vendor\""))
+            assertTrue(json.contains("\"title\""))
+            assertTrue(json.contains("\"category\""))
+            assertTrue(json.contains("\"paymentMethod\""))
+        }
+    }
+
+    // ── generateContent ───────────────────────────────────────────────────
+
+    @Nested
+    inner class GenerateContent {
+
+        @Test
+        fun `returns success with JSON content`() = runTest(testDispatcher) {
+            val prompt = "QUICK MART TOTAL 50.00 USD 2025-03-10 13:45"
+            val result = repository.generateContent(prompt)
+
+            assertTrue(result.isSuccess)
+            val json = result.getOrThrow()
+            assertTrue(json.isNotBlank())
+            assertTrue(json.contains("\"amount\""))
+        }
+
+        @Test
+        fun `returns same extraction logic as generateStructuredOutput`() = runTest(testDispatcher) {
+            val prompt = "STORE TOTAL PAGAR 100.00 USD 2026-01-01 09:00"
+
+            val contentResult = repository.generateContent(prompt)
+            val structuredResult = repository.generateStructuredOutput(prompt, "schema")
+
+            assertTrue(contentResult.isSuccess)
+            assertTrue(structuredResult.isSuccess)
+            // Both should succeed with same currency extraction
+            assertTrue(contentResult.getOrThrow().contains("\"currency\": \"USD\""))
+            assertTrue(structuredResult.getOrThrow().contains("\"currency\": \"USD\""))
+        }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/service/ReceiptExtractionServiceImplTest.kt
@@ -7,7 +7,7 @@ import es.pedrazamiguez.splittrip.domain.model.ExtractionConfidence
 import es.pedrazamiguez.splittrip.domain.model.ExtractionSource
 import es.pedrazamiguez.splittrip.domain.model.RawReceiptText
 import es.pedrazamiguez.splittrip.domain.repository.AiInferenceRepository
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.every
@@ -39,7 +39,7 @@ class ReceiptExtractionServiceImplTest {
     private lateinit var aiCoreCapabilityProvider: AICoreCapabilityProvider
     private lateinit var aiCoreInferenceRepository: AiInferenceRepository
     private lateinit var liteRtInferenceRepository: AiInferenceRepository
-    private lateinit var aiModelResolver: AiModelResolver
+    private lateinit var aiModelResolver: AiModelResolverService
     private lateinit var service: ReceiptExtractionServiceImpl
     private val activeEngineFlow = MutableStateFlow(AiEngineType.AI_CORE_GEMMA_4)
 

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/BalancesDomainModule.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/BalancesDomainModule.kt
@@ -8,6 +8,7 @@ import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.DeleteCashWithdrawalUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.balance.DeleteContributionUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetGroupContributionsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetGroupPocketBalanceFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetMemberBalancesFlowUseCase
@@ -52,6 +53,13 @@ val balancesDomainModule = module {
     factory {
         DeleteCashWithdrawalUseCase(
             cashWithdrawalRepository = get<CashWithdrawalRepository>(),
+            groupMembershipService = get<GroupMembershipService>()
+        )
+    }
+
+    factory {
+        GetContributionByExpenseIdUseCase(
+            contributionRepository = get<ContributionRepository>(),
             groupMembershipService = get<GroupMembershipService>()
         )
     }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/ExpensesDomainModule.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/ExpensesDomainModule.kt
@@ -30,9 +30,9 @@ import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCa
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpenseConfigUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpensesFlowUseCase
-import es.pedrazamiguez.splittrip.domain.usecase.expense.PersistExpenseStrategyFactory
 import es.pedrazamiguez.splittrip.domain.usecase.expense.PreviewCashExchangeRateUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.factory.PersistExpenseStrategyFactory
 import org.koin.dsl.module
 
 val expensesDomainModule = module {

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/ExpensesDomainModule.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/ExpensesDomainModule.kt
@@ -30,12 +30,14 @@ import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCa
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpenseConfigUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpensesFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.PersistExpenseStrategyFactory
 import es.pedrazamiguez.splittrip.domain.usecase.expense.PreviewCashExchangeRateUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
 import org.koin.dsl.module
 
 val expensesDomainModule = module {
-    factory<AddExpenseUseCase> {
-        AddExpenseUseCase(
+    factory {
+        PersistExpenseStrategyFactory(
             expenseRepository = get<ExpenseRepository>(),
             cashWithdrawalRepository = get<CashWithdrawalRepository>(),
             expenseCalculatorService = get<ExpenseCalculatorService>(),
@@ -45,6 +47,12 @@ val expensesDomainModule = module {
             authenticationService = get<AuthenticationService>(),
             addOnCalculationService = get<AddOnCalculationService>()
         )
+    }
+    factory<AddExpenseUseCase> {
+        AddExpenseUseCase(strategyFactory = get<PersistExpenseStrategyFactory>())
+    }
+    factory<UpdateExpenseUseCase> {
+        UpdateExpenseUseCase(strategyFactory = get<PersistExpenseStrategyFactory>())
     }
     factory<DeleteExpenseUseCase> {
         DeleteExpenseUseCase(

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/CashWithdrawalRepository.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/CashWithdrawalRepository.kt
@@ -84,4 +84,9 @@ interface CashWithdrawalRepository {
     suspend fun refundTranche(withdrawalId: String, amountToRefund: Long)
 
     suspend fun deleteWithdrawal(groupId: String, withdrawalId: String)
+
+    /**
+     * Fetches a single cash withdrawal by its ID.
+     */
+    suspend fun getWithdrawalById(withdrawalId: String): CashWithdrawal?
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/AiModelResolverService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/AiModelResolverService.kt
@@ -3,7 +3,7 @@ package es.pedrazamiguez.splittrip.domain.service
 import es.pedrazamiguez.splittrip.domain.enums.AiEngineType
 import kotlinx.coroutines.flow.Flow
 
-interface AiModelResolver {
+interface AiModelResolverService {
     /**
      * Returns the active model that should be used for receipt extraction.
      * This flow emits the resolved engine type based on capabilities, active

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetContributionByExpenseIdUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetContributionByExpenseIdUseCase.kt
@@ -1,0 +1,22 @@
+package es.pedrazamiguez.splittrip.domain.usecase.balance
+
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+
+/**
+ * Retrieves the contribution linked to a specific expense ID.
+ *
+ * Verifies group membership before querying the repository. Paired contributions
+ * are managed automatically as side-effects of out-of-pocket expenses; this use case
+ * allows loading a linked contribution's details during expense modification.
+ */
+class GetContributionByExpenseIdUseCase(
+    private val contributionRepository: ContributionRepository,
+    private val groupMembershipService: GroupMembershipService
+) {
+    suspend operator fun invoke(groupId: String, expenseId: String): Contribution? {
+        groupMembershipService.requireMembership(groupId)
+        return contributionRepository.findByLinkedExpenseId(groupId, expenseId)
+    }
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpensePersistStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpensePersistStrategy.kt
@@ -1,0 +1,98 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
+import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
+import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import java.util.UUID
+
+class AddExpensePersistStrategy(
+    expenseRepository: ExpenseRepository,
+    cashWithdrawalRepository: CashWithdrawalRepository,
+    expenseCalculatorService: ExpenseCalculatorService,
+    exchangeRateCalculationService: ExchangeRateCalculationService,
+    groupMembershipService: GroupMembershipService,
+    contributionRepository: ContributionRepository,
+    authenticationService: AuthenticationService,
+    addOnCalculationService: AddOnCalculationService
+) : BasePersistExpenseStrategy(
+    expenseRepository,
+    cashWithdrawalRepository,
+    expenseCalculatorService,
+    exchangeRateCalculationService,
+    groupMembershipService,
+    contributionRepository,
+    authenticationService,
+    addOnCalculationService
+) {
+
+    override suspend fun persist(
+        groupId: String,
+        expense: Expense,
+        pairedContributionScope: PayerType,
+        pairedSubunitId: String?,
+        preferredWithdrawalScope: PayerType?,
+        preferredWithdrawalOwnerId: String?
+    ): Result<Unit> = runCatching {
+        require(expense.sourceAmount > 0) { "Expense amount must be greater than zero" }
+        require(expense.title.isNotBlank()) { "Expense title cannot be empty" }
+
+        groupMembershipService.requireMembership(groupId)
+
+        val expenseWithId = if (expense.id.isBlank()) {
+            expense.copy(id = UUID.randomUUID().toString())
+        } else {
+            expense
+        }
+
+        val expenseToSave: Expense
+        if (expenseWithId.paymentMethod == PaymentMethod.CASH) {
+            val fifoResult = computeCashFifoResult(
+                groupId,
+                expenseWithId,
+                preferredWithdrawalScope,
+                preferredWithdrawalOwnerId
+            )
+
+            val transactionCommitted = expenseRepository.addCashExpense(
+                groupId,
+                fifoResult.expense,
+                fifoResult.expectedRemainingAmounts
+            )
+
+            if (transactionCommitted) {
+                cashWithdrawalRepository.updateRemainingAmounts(groupId, fifoResult.updatedWithdrawals)
+            }
+
+            expenseToSave = fifoResult.expense
+        } else {
+            expenseRepository.addExpense(groupId, expenseWithId)
+            expenseToSave = expenseWithId
+        }
+
+        if (expenseToSave.payerType == PayerType.USER) {
+            try {
+                createPairedContribution(
+                    groupId,
+                    expenseToSave,
+                    pairedContributionScope,
+                    pairedSubunitId
+                )
+            } catch (exception: Exception) {
+                runCatching {
+                    expenseRepository.deleteExpense(groupId, expenseToSave.id)
+                }.exceptionOrNull()?.let { rollbackException ->
+                    exception.addSuppressed(rollbackException)
+                }
+                throw exception
+            }
+        }
+    }
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpenseUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpenseUseCase.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.domain.usecase.expense
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.usecase.expense.factory.PersistExpenseStrategyFactory
 
 class AddExpenseUseCase(
     private val strategyFactory: PersistExpenseStrategyFactory

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategy.kt
@@ -1,0 +1,148 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.exception.InsufficientCashException
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
+import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
+import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import java.util.UUID
+
+interface PersistExpenseStrategy {
+    suspend fun persist(
+        groupId: String,
+        expense: Expense,
+        pairedContributionScope: PayerType,
+        pairedSubunitId: String?,
+        preferredWithdrawalScope: PayerType?,
+        preferredWithdrawalOwnerId: String?
+    ): Result<Unit>
+}
+
+abstract class BasePersistExpenseStrategy(
+    protected val expenseRepository: ExpenseRepository,
+    protected val cashWithdrawalRepository: CashWithdrawalRepository,
+    protected val expenseCalculatorService: ExpenseCalculatorService,
+    protected val exchangeRateCalculationService: ExchangeRateCalculationService,
+    protected val groupMembershipService: GroupMembershipService,
+    protected val contributionRepository: ContributionRepository,
+    protected val authenticationService: AuthenticationService,
+    protected val addOnCalculationService: AddOnCalculationService
+) : PersistExpenseStrategy {
+
+    protected suspend fun computeCashFifoResult(
+        groupId: String,
+        expense: Expense,
+        preferredScope: PayerType? = null,
+        preferredScopeOwnerId: String? = null
+    ): CashFifoResult {
+        val availableWithdrawals = if (preferredScope != null) {
+            cashWithdrawalRepository.getAvailableWithdrawalsByExactScope(
+                groupId = groupId,
+                currency = expense.sourceCurrency,
+                scope = preferredScope,
+                scopeOwnerId = preferredScopeOwnerId
+            )
+        } else {
+            cashWithdrawalRepository.getAvailableWithdrawals(
+                groupId,
+                expense.sourceCurrency,
+                expense.payerType,
+                expense.payerId
+            )
+        }
+
+        if (expenseCalculatorService.hasInsufficientCash(expense.sourceAmount, availableWithdrawals)) {
+            val availableCents = availableWithdrawals.sumOf { it.remainingAmount }
+            throw InsufficientCashException(
+                requiredCents = expense.sourceAmount,
+                availableCents = availableCents
+            )
+        }
+
+        val fifoResult = expenseCalculatorService.calculateFifoCashAmount(
+            amountToCover = expense.sourceAmount,
+            availableWithdrawals = availableWithdrawals
+        )
+
+        val withdrawalById = availableWithdrawals.associateBy { it.id }
+        val consumedWithdrawalIds = fifoResult.tranches.map { it.withdrawalId }.toSet()
+        val expectedRemainingAmounts = availableWithdrawals
+            .filter { it.id in consumedWithdrawalIds }
+            .associate { it.id to it.remainingAmount }
+
+        val updatedWithdrawals = fifoResult.tranches.map { tranche ->
+            val withdrawal = withdrawalById.getValue(tranche.withdrawalId)
+            withdrawal.copy(remainingAmount = withdrawal.remainingAmount - tranche.amountConsumed)
+        }
+
+        val updatedExpense = expense.copy(
+            cashTranches = fifoResult.tranches,
+            groupAmount = fifoResult.groupAmountCents,
+            exchangeRate = exchangeRateCalculationService.calculateBlendedRate(
+                sourceAmountCents = expense.sourceAmount,
+                groupAmountCents = fifoResult.groupAmountCents
+            )
+        )
+
+        return CashFifoResult(
+            expense = updatedExpense,
+            updatedWithdrawals = updatedWithdrawals,
+            expectedRemainingAmounts = expectedRemainingAmounts
+        )
+    }
+
+    protected suspend fun createPairedContribution(
+        groupId: String,
+        expense: Expense,
+        contributionScope: PayerType,
+        subunitId: String?
+    ) {
+        val sanitizedSubunitId = sanitizeSubunitId(contributionScope, subunitId)
+
+        val effectiveAmount = addOnCalculationService.calculateEffectiveGroupAmount(
+            expense.groupAmount,
+            expense.addOns
+        )
+        val createdBy = authenticationService.requireUserId()
+        val userId = expense.payerId ?: createdBy
+        val pairedContribution = Contribution(
+            id = UUID.randomUUID().toString(),
+            groupId = groupId,
+            userId = userId,
+            createdBy = createdBy,
+            contributionScope = contributionScope,
+            subunitId = sanitizedSubunitId,
+            amount = effectiveAmount,
+            currency = expense.groupCurrency,
+            linkedExpenseId = expense.id
+        )
+        contributionRepository.addContribution(groupId, pairedContribution)
+    }
+
+    private fun sanitizeSubunitId(
+        contributionScope: PayerType,
+        subunitId: String?
+    ): String? = when (contributionScope) {
+        PayerType.SUBUNIT -> {
+            require(!subunitId.isNullOrBlank()) {
+                "SUBUNIT scope requires a non-blank subunitId"
+            }
+            subunitId
+        }
+        else -> null
+    }
+
+    protected data class CashFifoResult(
+        val expense: Expense,
+        val updatedWithdrawals: List<CashWithdrawal>,
+        val expectedRemainingAmounts: Map<String, Long>
+    )
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategyFactory.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategyFactory.kt
@@ -1,0 +1,47 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
+import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
+import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+
+class PersistExpenseStrategyFactory(
+    private val expenseRepository: ExpenseRepository,
+    private val cashWithdrawalRepository: CashWithdrawalRepository,
+    private val expenseCalculatorService: ExpenseCalculatorService,
+    private val exchangeRateCalculationService: ExchangeRateCalculationService,
+    private val groupMembershipService: GroupMembershipService,
+    private val contributionRepository: ContributionRepository,
+    private val authenticationService: AuthenticationService,
+    private val addOnCalculationService: AddOnCalculationService
+) {
+    fun create(isUpdate: Boolean): PersistExpenseStrategy {
+        return if (isUpdate) {
+            UpdateExpensePersistStrategy(
+                expenseRepository,
+                cashWithdrawalRepository,
+                expenseCalculatorService,
+                exchangeRateCalculationService,
+                groupMembershipService,
+                contributionRepository,
+                authenticationService,
+                addOnCalculationService
+            )
+        } else {
+            AddExpensePersistStrategy(
+                expenseRepository,
+                cashWithdrawalRepository,
+                expenseCalculatorService,
+                exchangeRateCalculationService,
+                groupMembershipService,
+                contributionRepository,
+                authenticationService,
+                addOnCalculationService
+            )
+        }
+    }
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpensePersistStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpensePersistStrategy.kt
@@ -1,0 +1,183 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
+import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
+import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+
+class UpdateExpensePersistStrategy(
+    expenseRepository: ExpenseRepository,
+    cashWithdrawalRepository: CashWithdrawalRepository,
+    expenseCalculatorService: ExpenseCalculatorService,
+    exchangeRateCalculationService: ExchangeRateCalculationService,
+    groupMembershipService: GroupMembershipService,
+    contributionRepository: ContributionRepository,
+    authenticationService: AuthenticationService,
+    addOnCalculationService: AddOnCalculationService
+) : BasePersistExpenseStrategy(
+    expenseRepository,
+    cashWithdrawalRepository,
+    expenseCalculatorService,
+    exchangeRateCalculationService,
+    groupMembershipService,
+    contributionRepository,
+    authenticationService,
+    addOnCalculationService
+) {
+
+    override suspend fun persist(
+        groupId: String,
+        expense: Expense,
+        pairedContributionScope: PayerType,
+        pairedSubunitId: String?,
+        preferredWithdrawalScope: PayerType?,
+        preferredWithdrawalOwnerId: String?
+    ): Result<Unit> = runCatching {
+        validateInputs(expense)
+        groupMembershipService.requireMembership(groupId)
+
+        val originalState = getOriginalState(groupId, expense.id)
+
+        // Refund original tranches locally (updates Room DB)
+        originalState.expense.cashTranches.forEach { tranche ->
+            cashWithdrawalRepository.refundTranche(tranche.withdrawalId, tranche.amountConsumed)
+        }
+
+        var withdrawalRollbackNeeded = true
+        try {
+            val persistenceResult = performPersistence(
+                groupId = groupId,
+                expense = expense,
+                originalWithdrawals = originalState.withdrawals,
+                preferredWithdrawalScope = preferredWithdrawalScope,
+                preferredWithdrawalOwnerId = preferredWithdrawalOwnerId
+            )
+            withdrawalRollbackNeeded = persistenceResult.withdrawalRollbackNeeded
+
+            // Update paired contribution
+            contributionRepository.deleteByLinkedExpenseId(groupId, expense.id)
+            if (persistenceResult.expenseToSave.payerType == PayerType.USER) {
+                createPairedContribution(
+                    groupId,
+                    persistenceResult.expenseToSave,
+                    pairedContributionScope,
+                    pairedSubunitId
+                )
+            }
+        } catch (exception: Exception) {
+            rollback(
+                groupId = groupId,
+                originalState = originalState,
+                withdrawalRollbackNeeded = withdrawalRollbackNeeded,
+                exception = exception
+            )
+            throw exception
+        }
+    }
+
+    private fun validateInputs(expense: Expense) {
+        require(expense.id.isNotBlank()) { "Expense ID cannot be blank for update strategy" }
+        require(expense.sourceAmount > 0) { "Expense amount must be greater than zero" }
+        require(expense.title.isNotBlank()) { "Expense title cannot be empty" }
+    }
+
+    private suspend fun getOriginalState(groupId: String, expenseId: String): OriginalExpenseState {
+        val originalExpense = expenseRepository.getExpenseById(expenseId)
+            ?: throw IllegalArgumentException("Expense not found with ID: $expenseId")
+
+        val originalContribution = contributionRepository.findByLinkedExpenseId(groupId, expenseId)
+
+        val originalTranches = originalExpense.cashTranches
+        val originalWithdrawals = originalTranches.mapNotNull { tranche ->
+            cashWithdrawalRepository.getWithdrawalById(tranche.withdrawalId)
+        }
+
+        return OriginalExpenseState(originalExpense, originalContribution, originalWithdrawals)
+    }
+
+    private suspend fun performPersistence(
+        groupId: String,
+        expense: Expense,
+        originalWithdrawals: List<CashWithdrawal>,
+        preferredWithdrawalScope: PayerType?,
+        preferredWithdrawalOwnerId: String?
+    ): PersistenceResult {
+        return if (expense.paymentMethod == PaymentMethod.CASH) {
+            val fifoResult = computeCashFifoResult(
+                groupId,
+                expense,
+                preferredWithdrawalScope,
+                preferredWithdrawalOwnerId
+            )
+
+            val transactionCommitted = expenseRepository.addCashExpense(
+                groupId,
+                fifoResult.expense,
+                fifoResult.expectedRemainingAmounts
+            )
+
+            if (transactionCommitted) {
+                cashWithdrawalRepository.updateRemainingAmounts(groupId, fifoResult.updatedWithdrawals)
+            } else {
+                // Offline fallback: do not apply new deductions, and restore original withdrawals
+                if (originalWithdrawals.isNotEmpty()) {
+                    cashWithdrawalRepository.updateRemainingAmounts(groupId, originalWithdrawals)
+                }
+            }
+
+            PersistenceResult(
+                expenseToSave = fifoResult.expense,
+                withdrawalRollbackNeeded = false
+            )
+        } else {
+            expenseRepository.addExpense(groupId, expense)
+            PersistenceResult(
+                expenseToSave = expense,
+                withdrawalRollbackNeeded = false // Refund is kept since new expense is not cash
+            )
+        }
+    }
+
+    private suspend fun rollback(
+        groupId: String,
+        originalState: OriginalExpenseState,
+        withdrawalRollbackNeeded: Boolean,
+        exception: Exception
+    ) {
+        if (withdrawalRollbackNeeded && originalState.withdrawals.isNotEmpty()) {
+            runCatching {
+                cashWithdrawalRepository.updateRemainingAmounts(groupId, originalState.withdrawals)
+            }.exceptionOrNull()?.let { exception.addSuppressed(it) }
+        }
+
+        runCatching {
+            expenseRepository.addExpense(groupId, originalState.expense)
+        }.exceptionOrNull()?.let { exception.addSuppressed(it) }
+
+        if (originalState.contribution != null) {
+            runCatching {
+                contributionRepository.addContribution(groupId, originalState.contribution)
+            }.exceptionOrNull()?.let { exception.addSuppressed(it) }
+        }
+    }
+
+    private data class OriginalExpenseState(
+        val expense: Expense,
+        val contribution: Contribution?,
+        val withdrawals: List<CashWithdrawal>
+    )
+
+    private data class PersistenceResult(
+        val expenseToSave: Expense,
+        val withdrawalRollbackNeeded: Boolean
+    )
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCase.kt
@@ -3,10 +3,9 @@ package es.pedrazamiguez.splittrip.domain.usecase.expense
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.Expense
 
-class AddExpenseUseCase(
+class UpdateExpenseUseCase(
     private val strategyFactory: PersistExpenseStrategyFactory
 ) {
-
     suspend operator fun invoke(
         groupId: String?,
         expense: Expense,
@@ -18,7 +17,7 @@ class AddExpenseUseCase(
         if (groupId.isNullOrBlank()) {
             return Result.failure(IllegalArgumentException("Group ID cannot be null or blank"))
         }
-        val strategy = strategyFactory.create(isUpdate = false)
+        val strategy = strategyFactory.create(isUpdate = true)
         return strategy.persist(
             groupId = groupId,
             expense = expense,

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCase.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.domain.usecase.expense
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.usecase.expense.factory.PersistExpenseStrategyFactory
 
 class UpdateExpenseUseCase(
     private val strategyFactory: PersistExpenseStrategyFactory

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/factory/PersistExpenseStrategyFactory.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/factory/PersistExpenseStrategyFactory.kt
@@ -1,4 +1,4 @@
-package es.pedrazamiguez.splittrip.domain.usecase.expense
+package es.pedrazamiguez.splittrip.domain.usecase.expense.factory
 
 import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
 import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
@@ -8,6 +8,9 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import es.pedrazamiguez.splittrip.domain.usecase.expense.strategy.AddExpensePersistStrategy
+import es.pedrazamiguez.splittrip.domain.usecase.expense.strategy.PersistExpenseStrategy
+import es.pedrazamiguez.splittrip.domain.usecase.expense.strategy.UpdateExpensePersistStrategy
 
 class PersistExpenseStrategyFactory(
     private val expenseRepository: ExpenseRepository,

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/AddExpensePersistStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/AddExpensePersistStrategy.kt
@@ -1,4 +1,4 @@
-package es.pedrazamiguez.splittrip.domain.usecase.expense
+package es.pedrazamiguez.splittrip.domain.usecase.expense.strategy
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/PersistExpenseStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/PersistExpenseStrategy.kt
@@ -1,4 +1,4 @@
-package es.pedrazamiguez.splittrip.domain.usecase.expense
+package es.pedrazamiguez.splittrip.domain.usecase.expense.strategy
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.exception.InsufficientCashException

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/UpdateExpensePersistStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/UpdateExpensePersistStrategy.kt
@@ -1,4 +1,4 @@
-package es.pedrazamiguez.splittrip.domain.usecase.expense
+package es.pedrazamiguez.splittrip.domain.usecase.expense.strategy
 
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/UpdateExpensePersistStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/UpdateExpensePersistStrategy.kt
@@ -52,23 +52,21 @@ class UpdateExpensePersistStrategy(
             cashWithdrawalRepository.refundTranche(tranche.withdrawalId, tranche.amountConsumed)
         }
 
-        var withdrawalRollbackNeeded = true
         try {
-            val persistenceResult = performPersistence(
+            val savedExpense = performPersistence(
                 groupId = groupId,
                 expense = expense,
                 originalWithdrawals = originalState.withdrawals,
                 preferredWithdrawalScope = preferredWithdrawalScope,
                 preferredWithdrawalOwnerId = preferredWithdrawalOwnerId
             )
-            withdrawalRollbackNeeded = persistenceResult.withdrawalRollbackNeeded
 
             // Update paired contribution
             contributionRepository.deleteByLinkedExpenseId(groupId, expense.id)
-            if (persistenceResult.expenseToSave.payerType == PayerType.USER) {
+            if (savedExpense.payerType == PayerType.USER) {
                 createPairedContribution(
                     groupId,
-                    persistenceResult.expenseToSave,
+                    savedExpense,
                     pairedContributionScope,
                     pairedSubunitId
                 )
@@ -77,7 +75,6 @@ class UpdateExpensePersistStrategy(
             rollback(
                 groupId = groupId,
                 originalState = originalState,
-                withdrawalRollbackNeeded = withdrawalRollbackNeeded,
                 exception = exception
             )
             throw exception
@@ -110,7 +107,7 @@ class UpdateExpensePersistStrategy(
         originalWithdrawals: List<CashWithdrawal>,
         preferredWithdrawalScope: PayerType?,
         preferredWithdrawalOwnerId: String?
-    ): PersistenceResult {
+    ): Expense {
         return if (expense.paymentMethod == PaymentMethod.CASH) {
             val fifoResult = computeCashFifoResult(
                 groupId,
@@ -134,26 +131,19 @@ class UpdateExpensePersistStrategy(
                 }
             }
 
-            PersistenceResult(
-                expenseToSave = fifoResult.expense,
-                withdrawalRollbackNeeded = false
-            )
+            fifoResult.expense
         } else {
             expenseRepository.addExpense(groupId, expense)
-            PersistenceResult(
-                expenseToSave = expense,
-                withdrawalRollbackNeeded = false // Refund is kept since new expense is not cash
-            )
+            expense
         }
     }
 
     private suspend fun rollback(
         groupId: String,
         originalState: OriginalExpenseState,
-        withdrawalRollbackNeeded: Boolean,
         exception: Exception
     ) {
-        if (withdrawalRollbackNeeded && originalState.withdrawals.isNotEmpty()) {
+        if (originalState.withdrawals.isNotEmpty()) {
             runCatching {
                 cashWithdrawalRepository.updateRemainingAmounts(groupId, originalState.withdrawals)
             }.exceptionOrNull()?.let { exception.addSuppressed(it) }
@@ -174,10 +164,5 @@ class UpdateExpensePersistStrategy(
         val expense: Expense,
         val contribution: Contribution?,
         val withdrawals: List<CashWithdrawal>
-    )
-
-    private data class PersistenceResult(
-        val expenseToSave: Expense,
-        val withdrawalRollbackNeeded: Boolean
     )
 }

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/enums/GroupRoleTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/enums/GroupRoleTest.kt
@@ -1,0 +1,44 @@
+package es.pedrazamiguez.splittrip.domain.enums
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class GroupRoleTest {
+
+    @Nested
+    inner class FromString {
+
+        @ParameterizedTest
+        @CsvSource(
+            "ADMIN, ADMIN",
+            "MEMBER, MEMBER",
+            "GUEST, GUEST",
+            "admin, ADMIN",
+            "member, MEMBER",
+            "Guest, GUEST",
+            "ADMIN, ADMIN"
+        )
+        fun `parses known roles case-insensitively`(input: String, expected: GroupRole) {
+            assertEquals(expected, GroupRole.fromString(input))
+        }
+
+        @Test
+        fun `throws IllegalArgumentException for unknown role string`() {
+            assertThrows(IllegalArgumentException::class.java) {
+                GroupRole.fromString("SUPERUSER")
+            }
+        }
+
+        @Test
+        fun `throws with descriptive message containing the unknown role`() {
+            val ex = assertThrows(IllegalArgumentException::class.java) {
+                GroupRole.fromString("OWNER")
+            }
+            assertEquals("Unknown role: OWNER", ex.message)
+        }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetContributionByExpenseIdUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetContributionByExpenseIdUseCaseTest.kt
@@ -1,0 +1,109 @@
+package es.pedrazamiguez.splittrip.domain.usecase.balance
+
+import es.pedrazamiguez.splittrip.domain.exception.NotGroupMemberException
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class GetContributionByExpenseIdUseCaseTest {
+
+    private lateinit var contributionRepository: ContributionRepository
+    private lateinit var groupMembershipService: GroupMembershipService
+    private lateinit var useCase: GetContributionByExpenseIdUseCase
+
+    private val groupId = "group-123"
+    private val expenseId = "expense-456"
+
+    @BeforeEach
+    fun setUp() {
+        contributionRepository = mockk()
+        groupMembershipService = mockk()
+        coEvery { groupMembershipService.requireMembership(any()) } just Runs
+        useCase = GetContributionByExpenseIdUseCase(contributionRepository, groupMembershipService)
+    }
+
+    @Nested
+    inner class MembershipValidation {
+
+        @Test
+        fun `throws NotGroupMemberException when user is not a member`() = runTest {
+            // Given
+            coEvery {
+                groupMembershipService.requireMembership(groupId)
+            } throws NotGroupMemberException(groupId, "user-999")
+
+            // When / Then
+            try {
+                useCase(groupId, expenseId)
+                fail("Expected NotGroupMemberException")
+            } catch (e: NotGroupMemberException) {
+                assertEquals(groupId, e.groupId)
+            }
+        }
+
+        @Test
+        fun `verifies membership before querying repository`() = runTest {
+            // Given
+            coEvery { contributionRepository.findByLinkedExpenseId(groupId, expenseId) } returns null
+
+            // When
+            useCase(groupId, expenseId)
+
+            // Then — membership check happened before repository call
+            coVerify { groupMembershipService.requireMembership(groupId) }
+        }
+    }
+
+    @Nested
+    inner class Invocation {
+
+        @Test
+        fun `returns contribution when linked expense exists`() = runTest {
+            // Given
+            val contribution = mockk<Contribution>()
+            coEvery { contributionRepository.findByLinkedExpenseId(groupId, expenseId) } returns contribution
+
+            // When
+            val result = useCase(groupId, expenseId)
+
+            // Then
+            assertEquals(contribution, result)
+        }
+
+        @Test
+        fun `returns null when no contribution is linked to the expense`() = runTest {
+            // Given
+            coEvery { contributionRepository.findByLinkedExpenseId(groupId, expenseId) } returns null
+
+            // When
+            val result = useCase(groupId, expenseId)
+
+            // Then
+            assertNull(result)
+        }
+
+        @Test
+        fun `delegates to repository with correct groupId and expenseId`() = runTest {
+            // Given
+            coEvery { contributionRepository.findByLinkedExpenseId(any(), any()) } returns null
+
+            // When
+            useCase(groupId, expenseId)
+
+            // Then
+            coVerify(exactly = 1) { contributionRepository.findByLinkedExpenseId(groupId, expenseId) }
+        }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpenseUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpenseUseCaseTest.kt
@@ -79,15 +79,19 @@ class AddExpenseUseCaseTest {
             firstArg()
         }
 
+        val strategyFactory = PersistExpenseStrategyFactory(
+            expenseRepository = expenseRepository,
+            cashWithdrawalRepository = cashWithdrawalRepository,
+            expenseCalculatorService = expenseCalculatorService,
+            exchangeRateCalculationService = exchangeRateCalculationService,
+            groupMembershipService = groupMembershipService,
+            contributionRepository = contributionRepository,
+            authenticationService = authenticationService,
+            addOnCalculationService = addOnCalculationService
+        )
+
         useCase = AddExpenseUseCase(
-            expenseRepository,
-            cashWithdrawalRepository,
-            expenseCalculatorService,
-            exchangeRateCalculationService,
-            groupMembershipService,
-            contributionRepository,
-            authenticationService,
-            addOnCalculationService
+            strategyFactory = strategyFactory
         )
     }
 

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpenseUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/AddExpenseUseCaseTest.kt
@@ -21,6 +21,7 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import es.pedrazamiguez.splittrip.domain.usecase.expense.factory.PersistExpenseStrategyFactory
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategyFactoryTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategyFactoryTest.kt
@@ -1,0 +1,65 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
+import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
+import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PersistExpenseStrategyFactoryTest {
+
+    private lateinit var factory: PersistExpenseStrategyFactory
+
+    @BeforeEach
+    fun setUp() {
+        factory = PersistExpenseStrategyFactory(
+            expenseRepository = mockk<ExpenseRepository>(relaxed = true),
+            cashWithdrawalRepository = mockk<CashWithdrawalRepository>(relaxed = true),
+            expenseCalculatorService = mockk<ExpenseCalculatorService>(relaxed = true),
+            exchangeRateCalculationService = mockk<ExchangeRateCalculationService>(relaxed = true),
+            groupMembershipService = mockk<GroupMembershipService>(relaxed = true),
+            contributionRepository = mockk<ContributionRepository>(relaxed = true),
+            authenticationService = mockk<AuthenticationService>(relaxed = true),
+            addOnCalculationService = mockk<AddOnCalculationService>(relaxed = true)
+        )
+    }
+
+    @Test
+    fun `create with isUpdate=true returns UpdateExpensePersistStrategy`() {
+        val strategy = factory.create(isUpdate = true)
+
+        assertTrue(
+            strategy is UpdateExpensePersistStrategy,
+            "Expected UpdateExpensePersistStrategy but got ${strategy::class.simpleName}"
+        )
+    }
+
+    @Test
+    fun `create with isUpdate=false returns AddExpensePersistStrategy`() {
+        val strategy = factory.create(isUpdate = false)
+
+        assertTrue(
+            strategy is AddExpensePersistStrategy,
+            "Expected AddExpensePersistStrategy but got ${strategy::class.simpleName}"
+        )
+    }
+
+    @Test
+    fun `create returns a new instance on each invocation`() {
+        val firstUpdate = factory.create(isUpdate = true)
+        val secondUpdate = factory.create(isUpdate = true)
+        val firstAdd = factory.create(isUpdate = false)
+        val secondAdd = factory.create(isUpdate = false)
+
+        assertNotSame(firstUpdate, secondUpdate)
+        assertNotSame(firstAdd, secondAdd)
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategyFactoryTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/PersistExpenseStrategyFactoryTest.kt
@@ -8,6 +8,9 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import es.pedrazamiguez.splittrip.domain.usecase.expense.factory.PersistExpenseStrategyFactory
+import es.pedrazamiguez.splittrip.domain.usecase.expense.strategy.AddExpensePersistStrategy
+import es.pedrazamiguez.splittrip.domain.usecase.expense.strategy.UpdateExpensePersistStrategy
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCaseTest.kt
@@ -15,6 +15,7 @@ import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import es.pedrazamiguez.splittrip.domain.usecase.expense.factory.PersistExpenseStrategyFactory
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -421,7 +422,7 @@ class UpdateExpenseUseCaseTest {
             } returns originalContribution
             coEvery {
                 contributionRepository.addContribution(any(), any())
-            } throws RuntimeException("Contribution failed")
+            } throws IllegalStateException("Contribution failed")
 
             val result = useCase(groupId, oopUpdated)
 
@@ -448,14 +449,14 @@ class UpdateExpenseUseCaseTest {
             } returns originalContribution
             coEvery {
                 contributionRepository.addContribution(any(), any())
-            } throws RuntimeException("Primary failure")
+            } throws IllegalStateException("Primary failure")
 
             // First call to addExpense (new persist) succeeds; second call (restore in rollback) throws.
             var addExpenseCallCount = 0
             coEvery { expenseRepository.addExpense(any(), any()) } answers {
                 addExpenseCallCount++
                 if (addExpenseCallCount > 1) {
-                    throw RuntimeException("Restore expense failed")
+                    error("Restore expense failed")
                 }
             }
 

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/UpdateExpenseUseCaseTest.kt
@@ -1,0 +1,471 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.exception.NotGroupMemberException
+import es.pedrazamiguez.splittrip.domain.model.CashTranche
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
+import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
+import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
+import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
+import es.pedrazamiguez.splittrip.domain.service.GroupMembershipService
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UpdateExpenseUseCaseTest {
+
+    private lateinit var expenseRepository: ExpenseRepository
+    private lateinit var cashWithdrawalRepository: CashWithdrawalRepository
+    private lateinit var expenseCalculatorService: ExpenseCalculatorService
+    private lateinit var exchangeRateCalculationService: ExchangeRateCalculationService
+    private lateinit var groupMembershipService: GroupMembershipService
+    private lateinit var contributionRepository: ContributionRepository
+    private lateinit var authenticationService: AuthenticationService
+    private lateinit var addOnCalculationService: AddOnCalculationService
+    private lateinit var useCase: UpdateExpenseUseCase
+
+    private val groupId = "group-123"
+    private val currentUserId = "current-user-456"
+    private val expenseId = "expense-1"
+
+    private val originalExpense = Expense(
+        id = expenseId,
+        title = "Dinner",
+        sourceAmount = 5000L,
+        sourceCurrency = "EUR",
+        groupAmount = 5000L,
+        groupCurrency = "EUR",
+        paymentMethod = PaymentMethod.CREDIT_CARD
+    )
+
+    private val updatedExpense = originalExpense.copy(
+        title = "Updated Dinner",
+        sourceAmount = 7500L,
+        groupAmount = 7500L
+    )
+
+    @BeforeEach
+    fun setUp() {
+        expenseRepository = mockk(relaxed = true)
+        cashWithdrawalRepository = mockk(relaxed = true)
+        expenseCalculatorService = mockk()
+        exchangeRateCalculationService = mockk(relaxed = true)
+        groupMembershipService = mockk()
+        contributionRepository = mockk(relaxed = true)
+        authenticationService = mockk()
+        addOnCalculationService = mockk()
+
+        coEvery { groupMembershipService.requireMembership(any()) } just Runs
+        every { authenticationService.requireUserId() } returns currentUserId
+        every { addOnCalculationService.calculateEffectiveGroupAmount(any(), any()) } answers {
+            firstArg()
+        }
+        coEvery { expenseRepository.getExpenseById(expenseId) } returns originalExpense
+        coEvery { contributionRepository.findByLinkedExpenseId(groupId, expenseId) } returns null
+
+        val strategyFactory = PersistExpenseStrategyFactory(
+            expenseRepository = expenseRepository,
+            cashWithdrawalRepository = cashWithdrawalRepository,
+            expenseCalculatorService = expenseCalculatorService,
+            exchangeRateCalculationService = exchangeRateCalculationService,
+            groupMembershipService = groupMembershipService,
+            contributionRepository = contributionRepository,
+            authenticationService = authenticationService,
+            addOnCalculationService = addOnCalculationService
+        )
+
+        useCase = UpdateExpenseUseCase(strategyFactory = strategyFactory)
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class Validation {
+
+        @Test
+        fun `fails when groupId is null`() = runTest {
+            val result = useCase(null, updatedExpense)
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+            assertTrue(result.exceptionOrNull()?.message?.contains("Group ID") == true)
+        }
+
+        @Test
+        fun `fails when groupId is blank`() = runTest {
+            val result = useCase("   ", updatedExpense)
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("Group ID") == true)
+        }
+
+        @Test
+        fun `fails when expense id is blank`() = runTest {
+            val result = useCase(groupId, updatedExpense.copy(id = ""))
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("ID") == true)
+        }
+
+        @Test
+        fun `fails when sourceAmount is zero`() = runTest {
+            val result = useCase(groupId, updatedExpense.copy(sourceAmount = 0L))
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("amount") == true)
+        }
+
+        @Test
+        fun `fails when title is blank`() = runTest {
+            val result = useCase(groupId, updatedExpense.copy(title = "  "))
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("title") == true)
+        }
+
+        @Test
+        fun `fails when original expense is not found`() = runTest {
+            coEvery { expenseRepository.getExpenseById(expenseId) } returns null
+
+            val result = useCase(groupId, updatedExpense)
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+            assertTrue(result.exceptionOrNull()?.message?.contains(expenseId) == true)
+        }
+    }
+
+    // ── Membership ────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class MembershipValidation {
+
+        @Test
+        fun `fails with NotGroupMemberException when user is not a member`() = runTest {
+            coEvery {
+                groupMembershipService.requireMembership(groupId)
+            } throws NotGroupMemberException(groupId = groupId, userId = currentUserId)
+
+            val result = useCase(groupId, updatedExpense)
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is NotGroupMemberException)
+            coVerify(exactly = 0) { expenseRepository.addExpense(any(), any()) }
+            coVerify(exactly = 0) { expenseRepository.addCashExpense(any(), any(), any()) }
+        }
+    }
+
+    // ── Non-cash update ───────────────────────────────────────────────────────
+
+    @Nested
+    inner class NonCashUpdate {
+
+        @Test
+        fun `saves expense directly without touching withdrawal repository for GROUP non-cash`() = runTest {
+            coEvery { expenseRepository.addExpense(any(), any()) } just Runs
+
+            val result = useCase(groupId, updatedExpense)
+
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 1) { expenseRepository.addExpense(groupId, updatedExpense) }
+            coVerify(exactly = 0) { cashWithdrawalRepository.getAvailableWithdrawals(any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `does not create paired contribution for GROUP non-cash update`() = runTest {
+            useCase(groupId, updatedExpense)
+
+            coVerify(exactly = 0) { contributionRepository.addContribution(any(), any()) }
+        }
+
+        @Test
+        fun `deletes existing paired contribution before processing`() = runTest {
+            useCase(groupId, updatedExpense)
+
+            coVerify(exactly = 1) { contributionRepository.deleteByLinkedExpenseId(groupId, expenseId) }
+        }
+    }
+
+    // ── Out-of-pocket update (USER, non-cash) ─────────────────────────────────
+
+    @Nested
+    inner class OutOfPocketUpdate {
+
+        private val oopUpdated = updatedExpense.copy(
+            payerType = PayerType.USER,
+            payerId = currentUserId
+        )
+
+        @Test
+        fun `creates new paired contribution for USER expense after deleting old one`() = runTest {
+            val contributionSlot = slot<Contribution>()
+            coEvery {
+                contributionRepository.addContribution(any(), capture(contributionSlot))
+            } just Runs
+
+            val result = useCase(groupId, oopUpdated)
+
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 1) { contributionRepository.deleteByLinkedExpenseId(groupId, expenseId) }
+            assertEquals(oopUpdated.id, contributionSlot.captured.linkedExpenseId)
+            assertEquals(PayerType.USER, contributionSlot.captured.contributionScope)
+            assertEquals(currentUserId, contributionSlot.captured.userId)
+        }
+
+        @Test
+        fun `paired contribution uses SUBUNIT scope when specified`() = runTest {
+            val contributionSlot = slot<Contribution>()
+            coEvery {
+                contributionRepository.addContribution(any(), capture(contributionSlot))
+            } just Runs
+
+            useCase(
+                groupId,
+                oopUpdated,
+                pairedContributionScope = PayerType.SUBUNIT,
+                pairedSubunitId = "subunit-9"
+            )
+
+            assertEquals(PayerType.SUBUNIT, contributionSlot.captured.contributionScope)
+            assertEquals("subunit-9", contributionSlot.captured.subunitId)
+        }
+
+        @Test
+        fun `fails when SUBUNIT scope has blank subunitId`() = runTest {
+            val result = useCase(
+                groupId,
+                oopUpdated,
+                pairedContributionScope = PayerType.SUBUNIT,
+                pairedSubunitId = ""
+            )
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("SUBUNIT") == true)
+        }
+    }
+
+    // ── Cash update: refunds original tranches and applies new FIFO ───────────
+
+    @Nested
+    inner class CashUpdate {
+
+        private val originalTranches = listOf(
+            CashTranche(withdrawalId = "w-1", amountConsumed = 5000L),
+            CashTranche(withdrawalId = "w-2", amountConsumed = 3000L)
+        )
+
+        private val originalCashExpense = originalExpense.copy(
+            paymentMethod = PaymentMethod.CASH,
+            sourceCurrency = "THB",
+            sourceAmount = 8000L,
+            cashTranches = originalTranches
+        )
+
+        private val updatedCashExpense = originalCashExpense.copy(
+            title = "Updated Dinner",
+            sourceAmount = 10000L
+        )
+
+        private val withdrawal1 = CashWithdrawal(
+            id = "w-1",
+            groupId = groupId,
+            amountWithdrawn = 100000L,
+            remainingAmount = 50000L,
+            currency = "THB",
+            deductedBaseAmount = 2700L,
+            createdAt = LocalDateTime.of(2026, 1, 10, 12, 0)
+        )
+
+        private val withdrawal2 = CashWithdrawal(
+            id = "w-2",
+            groupId = groupId,
+            amountWithdrawn = 100000L,
+            remainingAmount = 80000L,
+            currency = "THB",
+            deductedBaseAmount = 2700L,
+            createdAt = LocalDateTime.of(2026, 1, 12, 12, 0)
+        )
+
+        private val fifoResult = ExpenseCalculatorService.FifoCashResult(
+            groupAmountCents = 270L,
+            tranches = listOf(CashTranche(withdrawalId = "w-1", amountConsumed = 10000L))
+        )
+
+        @BeforeEach
+        fun setUpCash() {
+            coEvery { expenseRepository.getExpenseById(expenseId) } returns originalCashExpense
+            coEvery {
+                cashWithdrawalRepository.getWithdrawalById("w-1")
+            } returns withdrawal1
+            coEvery {
+                cashWithdrawalRepository.getWithdrawalById("w-2")
+            } returns withdrawal2
+
+            coEvery {
+                cashWithdrawalRepository.getAvailableWithdrawals(groupId, "THB", PayerType.GROUP, null)
+            } returns listOf(withdrawal1, withdrawal2)
+
+            every { expenseCalculatorService.hasInsufficientCash(any(), any()) } returns false
+
+            coEvery {
+                expenseCalculatorService.calculateFifoCashAmount(any(), any())
+            } returns fifoResult
+
+            every { exchangeRateCalculationService.calculateBlendedRate(any(), any()) } returns BigDecimal("0.027000")
+
+            coEvery { expenseRepository.addCashExpense(any(), any(), any()) } returns true
+            coEvery { cashWithdrawalRepository.updateRemainingAmounts(any(), any()) } just Runs
+            coEvery { cashWithdrawalRepository.refundTranche(any(), any()) } just Runs
+        }
+
+        @Test
+        fun `refunds each original tranche locally before applying new FIFO`() = runTest {
+            useCase(groupId, updatedCashExpense)
+
+            coVerify(exactly = 1) { cashWithdrawalRepository.refundTranche("w-1", 5000L) }
+            coVerify(exactly = 1) { cashWithdrawalRepository.refundTranche("w-2", 3000L) }
+        }
+
+        @Test
+        fun `applies new FIFO and updates remaining amounts when transaction commits`() = runTest {
+            useCase(groupId, updatedCashExpense)
+
+            coVerify(exactly = 1) { expenseRepository.addCashExpense(groupId, any(), any()) }
+            coVerify(exactly = 1) { cashWithdrawalRepository.updateRemainingAmounts(groupId, any()) }
+        }
+
+        @Test
+        fun `attaches new tranches and blended group amount to saved expense`() = runTest {
+            val savedSlot = slot<Expense>()
+            coEvery {
+                expenseRepository.addCashExpense(any(), capture(savedSlot), any())
+            } returns true
+
+            useCase(groupId, updatedCashExpense)
+
+            assertEquals(fifoResult.tranches, savedSlot.captured.cashTranches)
+            assertEquals(fifoResult.groupAmountCents, savedSlot.captured.groupAmount)
+            assertEquals(BigDecimal("0.027000"), savedSlot.captured.exchangeRate)
+        }
+
+        @Test
+        fun `offline fallback restores original withdrawals when transaction does not commit`() = runTest {
+            coEvery { expenseRepository.addCashExpense(any(), any(), any()) } returns false
+
+            useCase(groupId, updatedCashExpense)
+
+            val capturedSlot = slot<List<CashWithdrawal>>()
+            coVerify(exactly = 1) {
+                cashWithdrawalRepository.updateRemainingAmounts(eq(groupId), capture(capturedSlot))
+            }
+            val ids = capturedSlot.captured.map { it.id }.toSet()
+            assertTrue(ids.contains("w-1"))
+            assertTrue(ids.contains("w-2"))
+        }
+
+        @Test
+        fun `does not update withdrawals on offline fallback when there are no original withdrawals`() = runTest {
+            val expenseWithoutTranches = originalCashExpense.copy(cashTranches = emptyList())
+            coEvery { expenseRepository.getExpenseById(expenseId) } returns expenseWithoutTranches
+            coEvery { expenseRepository.addCashExpense(any(), any(), any()) } returns false
+
+            useCase(groupId, updatedCashExpense)
+
+            coVerify(exactly = 0) { cashWithdrawalRepository.updateRemainingAmounts(any(), any()) }
+        }
+    }
+
+    // ── Rollback on persistence failure ───────────────────────────────────────
+
+    @Nested
+    inner class Rollback {
+
+        private val originalContribution = Contribution(
+            id = "c-1",
+            groupId = groupId,
+            userId = currentUserId,
+            createdBy = currentUserId,
+            contributionScope = PayerType.USER,
+            amount = 5000L,
+            currency = "EUR",
+            linkedExpenseId = expenseId
+        )
+
+        @Test
+        fun `rolls back to original state when paired contribution creation fails`() = runTest {
+            val oopUpdated = updatedExpense.copy(
+                payerType = PayerType.USER,
+                payerId = currentUserId
+            )
+
+            coEvery {
+                expenseRepository.getExpenseById(expenseId)
+            } returns originalExpense.copy(payerType = PayerType.USER, payerId = currentUserId)
+            coEvery {
+                contributionRepository.findByLinkedExpenseId(groupId, expenseId)
+            } returns originalContribution
+            coEvery {
+                contributionRepository.addContribution(any(), any())
+            } throws RuntimeException("Contribution failed")
+
+            val result = useCase(groupId, oopUpdated)
+
+            assertTrue(result.isFailure)
+            assertEquals("Contribution failed", result.exceptionOrNull()?.message)
+
+            // Original expense and contribution restored
+            coVerify(atLeast = 1) { expenseRepository.addExpense(groupId, any()) }
+            coVerify(exactly = 1) { contributionRepository.addContribution(groupId, originalContribution) }
+        }
+
+        @Test
+        fun `rollback suppresses secondary exceptions on restore failure`() = runTest {
+            val oopUpdated = updatedExpense.copy(
+                payerType = PayerType.USER,
+                payerId = currentUserId
+            )
+
+            coEvery {
+                expenseRepository.getExpenseById(expenseId)
+            } returns originalExpense.copy(payerType = PayerType.USER, payerId = currentUserId)
+            coEvery {
+                contributionRepository.findByLinkedExpenseId(groupId, expenseId)
+            } returns originalContribution
+            coEvery {
+                contributionRepository.addContribution(any(), any())
+            } throws RuntimeException("Primary failure")
+
+            // First call to addExpense (new persist) succeeds; second call (restore in rollback) throws.
+            var addExpenseCallCount = 0
+            coEvery { expenseRepository.addExpense(any(), any()) } answers {
+                addExpenseCallCount++
+                if (addExpenseCallCount > 1) {
+                    throw RuntimeException("Restore expense failed")
+                }
+            }
+
+            val result = useCase(groupId, oopUpdated)
+
+            assertTrue(result.isFailure)
+            val ex = result.exceptionOrNull()
+            assertNotNull(ex)
+            assertEquals("Primary failure", ex?.message)
+            assertTrue(ex!!.suppressed.any { it.message == "Restore expense failed" })
+        }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/CreateGroupUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/CreateGroupUseCaseTest.kt
@@ -1,0 +1,69 @@
+package es.pedrazamiguez.splittrip.domain.usecase.group
+
+import es.pedrazamiguez.splittrip.domain.model.Group
+import es.pedrazamiguez.splittrip.domain.repository.GroupRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CreateGroupUseCaseTest {
+
+    private lateinit var groupRepository: GroupRepository
+    private lateinit var useCase: CreateGroupUseCase
+
+    private val testGroup = Group(id = "", name = "Trip to Japan", currency = "JPY")
+
+    @BeforeEach
+    fun setUp() {
+        groupRepository = mockk()
+        useCase = CreateGroupUseCase(groupRepository)
+    }
+
+    @Nested
+    inner class Invocation {
+
+        @Test
+        fun `returns Result success with group id on successful creation`() = runTest {
+            // Given
+            coEvery { groupRepository.createGroup(testGroup) } returns "generated-id-123"
+
+            // When
+            val result = useCase(testGroup)
+
+            // Then
+            assertTrue(result.isSuccess)
+            assertEquals("generated-id-123", result.getOrNull())
+        }
+
+        @Test
+        fun `wraps repository exception in Result failure`() = runTest {
+            // Given
+            coEvery { groupRepository.createGroup(testGroup) } throws RuntimeException("Network error")
+
+            // When
+            val result = useCase(testGroup)
+
+            // Then
+            assertTrue(result.isFailure)
+            assertEquals("Network error", result.exceptionOrNull()?.message)
+        }
+
+        @Test
+        fun `delegates to repository with the provided group`() = runTest {
+            // Given
+            coEvery { groupRepository.createGroup(any()) } returns "id-1"
+
+            // When
+            useCase(testGroup)
+
+            // Then
+            coVerify(exactly = 1) { groupRepository.createGroup(testGroup) }
+        }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/user/SearchUsersByEmailUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/user/SearchUsersByEmailUseCaseTest.kt
@@ -1,0 +1,85 @@
+package es.pedrazamiguez.splittrip.domain.usecase.user
+
+import es.pedrazamiguez.splittrip.domain.model.User
+import es.pedrazamiguez.splittrip.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SearchUsersByEmailUseCaseTest {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var useCase: SearchUsersByEmailUseCase
+
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        useCase = SearchUsersByEmailUseCase(userRepository)
+    }
+
+    @Nested
+    inner class Invocation {
+
+        @Test
+        fun `returns Result success with user list when found`() = runTest {
+            // Given
+            val email = "alice@example.com"
+            val users = listOf(mockk<User>())
+            coEvery { userRepository.searchUsersByEmail(email) } returns users
+
+            // When
+            val result = useCase(email)
+
+            // Then
+            assertTrue(result.isSuccess)
+            assertEquals(users, result.getOrNull())
+        }
+
+        @Test
+        fun `returns Result success with empty list when no users found`() = runTest {
+            // Given
+            val email = "unknown@example.com"
+            coEvery { userRepository.searchUsersByEmail(email) } returns emptyList()
+
+            // When
+            val result = useCase(email)
+
+            // Then
+            assertTrue(result.isSuccess)
+            assertTrue(result.getOrNull()!!.isEmpty())
+        }
+
+        @Test
+        fun `wraps repository exception in Result failure`() = runTest {
+            // Given
+            val email = "bad@example.com"
+            coEvery { userRepository.searchUsersByEmail(email) } throws RuntimeException("Network error")
+
+            // When
+            val result = useCase(email)
+
+            // Then
+            assertTrue(result.isFailure)
+            assertEquals("Network error", result.exceptionOrNull()?.message)
+        }
+
+        @Test
+        fun `delegates to repository with the provided email`() = runTest {
+            // Given
+            val email = "test@example.com"
+            coEvery { userRepository.searchUsersByEmail(any()) } returns emptyList()
+
+            // When
+            useCase(email)
+
+            // Then
+            coVerify(exactly = 1) { userRepository.searchUsersByEmail(email) }
+        }
+    }
+}

--- a/features/contributions/src/test/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/mapper/AddContributionUiMapperTest.kt
+++ b/features/contributions/src/test/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/mapper/AddContributionUiMapperTest.kt
@@ -226,5 +226,23 @@ class AddContributionUiMapperTest {
         fun `returns empty string for empty members list`() {
             assertEquals("", mapper.resolveDisplayName("user-1", persistentListOf()))
         }
+
+        @Test
+        fun `returns youLabel for the current user when youLabel is provided`() {
+            val result = mapper.resolveDisplayName("user-1", members, youLabel = "You")
+            assertEquals("You", result)
+        }
+
+        @Test
+        fun `returns display name of non-current user even when youLabel is provided`() {
+            val result = mapper.resolveDisplayName("user-2", members, youLabel = "You")
+            assertEquals("Ana", result)
+        }
+
+        @Test
+        fun `returns display name directly when youLabel is blank`() {
+            val result = mapper.resolveDisplayName("user-1", members, youLabel = "")
+            assertEquals("Andrés", result)
+        }
     }
 }

--- a/features/contributions/src/test/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/viewmodel/state/AddContributionUiStateTest.kt
+++ b/features/contributions/src/test/kotlin/es/pedrazamiguez/splittrip/features/contribution/presentation/viewmodel/state/AddContributionUiStateTest.kt
@@ -1,0 +1,160 @@
+package es.pedrazamiguez.splittrip.features.contribution.presentation.viewmodel.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class AddContributionUiStateTest {
+
+    // ── steps / currentStepIndex ──────────────────────────────────────────
+
+    @Nested
+    inner class StepsAndIndex {
+
+        @Test
+        fun `steps contains all AddContributionStep entries`() {
+            val state = AddContributionUiState()
+            assertEquals(AddContributionStep.entries, state.steps)
+        }
+
+        @Test
+        fun `currentStepIndex returns 0 for AMOUNT (default)`() {
+            val state = AddContributionUiState()
+            assertEquals(0, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns 1 for SCOPE`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.SCOPE)
+            assertEquals(1, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns 2 for REVIEW`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.REVIEW)
+            assertEquals(2, state.currentStepIndex)
+        }
+    }
+
+    // ── canGoNext ─────────────────────────────────────────────────────────
+
+    @Nested
+    inner class CanGoNext {
+
+        @Test
+        fun `canGoNext is true on AMOUNT step`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.AMOUNT)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is true on SCOPE step`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.SCOPE)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is false on REVIEW step (last)`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.REVIEW)
+            assertFalse(state.canGoNext)
+        }
+    }
+
+    // ── isOnReviewStep ────────────────────────────────────────────────────
+
+    @Nested
+    inner class IsOnReviewStep {
+
+        @Test
+        fun `isOnReviewStep is true when on REVIEW`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.REVIEW)
+            assertTrue(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on AMOUNT`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.AMOUNT)
+            assertFalse(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on SCOPE`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.SCOPE)
+            assertFalse(state.isOnReviewStep)
+        }
+    }
+
+    // ── isCurrentStepValid ────────────────────────────────────────────────
+
+    @Nested
+    inner class IsCurrentStepValid {
+
+        @Test
+        fun `AMOUNT step is valid when amountInput is not blank and no error`() {
+            val state = AddContributionUiState(
+                currentStep = AddContributionStep.AMOUNT,
+                amountInput = "50.00",
+                amountError = false
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `AMOUNT step is invalid when amountInput is blank`() {
+            val state = AddContributionUiState(
+                currentStep = AddContributionStep.AMOUNT,
+                amountInput = "",
+                amountError = false
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `AMOUNT step is invalid when amountError is true`() {
+            val state = AddContributionUiState(
+                currentStep = AddContributionStep.AMOUNT,
+                amountInput = "abc",
+                amountError = true
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `SCOPE step is always valid (has a default selection)`() {
+            val state = AddContributionUiState(currentStep = AddContributionStep.SCOPE)
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is valid when amountInput is not blank and no error`() {
+            val state = AddContributionUiState(
+                currentStep = AddContributionStep.REVIEW,
+                amountInput = "100.00",
+                amountError = false
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when amountInput is blank`() {
+            val state = AddContributionUiState(
+                currentStep = AddContributionStep.REVIEW,
+                amountInput = "",
+                amountError = false
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when amountError is true`() {
+            val state = AddContributionUiState(
+                currentStep = AddContributionStep.REVIEW,
+                amountInput = "-5",
+                amountError = true
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/di/ExpensesUiModule.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.features.expense.di
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.core.designsystem.navigation.NavigationProvider
+import es.pedrazamiguez.splittrip.core.designsystem.navigation.Routes
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.screen.ScreenUiProvider
 import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
@@ -16,6 +17,7 @@ import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFac
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
 import es.pedrazamiguez.splittrip.domain.service.split.SubunitAwareSplitService
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetCashWithdrawalsFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.balance.GetGroupContributionsFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
@@ -25,9 +27,11 @@ import es.pedrazamiguez.splittrip.domain.usecase.expense.DownloadReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.ExtractReceiptFieldsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetAvailableWithdrawalPoolsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdFlowUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpenseConfigUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpensesFlowUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.PreviewCashExchangeRateUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.group.GetGroupByIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCategoryUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCurrencyUseCase
@@ -71,7 +75,9 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handle
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubmitResultDelegate
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubunitSplitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.WithdrawalPoolSelectionDelegate
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategyFactory
 import org.koin.core.module.dsl.viewModel
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -147,7 +153,8 @@ val expensesUiModule = module {
     // are shared between the ViewModel and cross-handler references
     // (e.g., ConfigEventHandler calls CurrencyEventHandler.fetchRate()).
 
-    viewModel {
+    viewModel { params ->
+        val expenseId = params.getOrNull<String>()
         val addExpenseUiMapper = get<AddExpenseUiMapper>()
         val addExpenseOptionsUiMapper = get<AddExpenseOptionsUiMapper>()
         val addExpenseSplitUiMapper = get<AddExpenseSplitUiMapper>()
@@ -225,7 +232,6 @@ val expensesUiModule = module {
         )
 
         val submitHandler = SubmitEventHandler(
-            addExpenseUseCase = get<AddExpenseUseCase>(),
             expenseValidationService = get<ExpenseValidationService>(),
             addOnCalculationService = get<AddOnCalculationService>(),
             expenseCalculatorService = get<ExpenseCalculatorService>(),
@@ -271,7 +277,19 @@ val expensesUiModule = module {
             addExpenseUiMapper = addExpenseUiMapper
         )
 
+        val strategyFactory = ExpenseFlowStrategyFactory(
+            configEventHandler = configHandler,
+            addExpenseUseCase = get<AddExpenseUseCase>(),
+            updateExpenseUseCase = get<UpdateExpenseUseCase>(),
+            getExpenseByIdUseCase = get<GetExpenseByIdUseCase>(),
+            getContributionByExpenseIdUseCase = get<GetContributionByExpenseIdUseCase>(),
+            addExpenseUiMapper = addExpenseUiMapper,
+            getMemberProfilesUseCase = get<GetMemberProfilesUseCase>(),
+            getGroupSubunitsUseCase = get<GetGroupSubunitsUseCase>()
+        )
+
         AddExpenseViewModel(
+            expenseId = expenseId,
             configEventHandler = configHandler,
             currencyEventHandler = currencyHandler,
             splitEventHandler = splitHandler,
@@ -279,14 +297,18 @@ val expensesUiModule = module {
             addOnEventHandler = addOnHandler,
             submitEventHandler = submitHandler,
             formEventHandler = formHandler,
-            receiptAutoFillEventHandler = receiptAutoFillEventHandler
+            receiptAutoFillEventHandler = receiptAutoFillEventHandler,
+            strategyFactory = strategyFactory
         )
     }
 
     factory { ExpensesNavigationProviderImpl() } bind NavigationProvider::class
 
     single { ExpensesScreenUiProviderImpl() } bind ScreenUiProvider::class
-    single { AddExpenseScreenUiProviderImpl() } bind ScreenUiProvider::class
+    single(named("addExpenseProvider")) { AddExpenseScreenUiProviderImpl(Routes.ADD_EXPENSE) } bind
+        ScreenUiProvider::class
+    single(named("editExpenseProvider")) { AddExpenseScreenUiProviderImpl(Routes.EDIT_EXPENSE) } bind
+        ScreenUiProvider::class
     single { ExpenseDetailScreenUiProviderImpl() } bind ScreenUiProvider::class
     single { ReceiptViewerScreenUiProviderImpl() } bind ScreenUiProvider::class
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/navigation/ExpensesNavigation.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/navigation/ExpensesNavigation.kt
@@ -26,6 +26,20 @@ fun NavGraphBuilder.expensesGraph() {
     }
 
     sharedComposable(
+        route = Routes.EDIT_EXPENSE,
+        arguments = listOf(navArgument("expenseId") { type = NavType.StringType })
+    ) { backStackEntry ->
+        val expenseId = backStackEntry.arguments?.getString("expenseId") ?: return@sharedComposable
+        val navController = LocalTabNavController.current
+        AddExpenseFeature(
+            expenseId = expenseId,
+            onAddExpenseSuccess = {
+                navController.popBackStack()
+            }
+        )
+    }
+
+    sharedComposable(
         route = Routes.EXPENSE_DETAIL,
         arguments = listOf(navArgument("expenseId") { type = NavType.StringType })
     ) { backStackEntry ->

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/TitleStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/TitleStep.kt
@@ -41,7 +41,7 @@ fun TitleStep(
         Column(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Large)
         ) {
-            if (uiState.isAiCapable && !uiState.isAiModeActive) {
+            if (uiState.isAiCapable && !uiState.isAiModeActive && !uiState.isEditMode) {
                 FlatCard(
                     modifier = Modifier.fillMaxWidth()
                 ) {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/AddExpenseFeature.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/AddExpenseFeature.kt
@@ -38,7 +38,10 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun AddExpenseFeature(
-    addExpenseViewModel: AddExpenseViewModel = koinViewModel<AddExpenseViewModel>(),
+    expenseId: String? = null,
+    addExpenseViewModel: AddExpenseViewModel = koinViewModel<AddExpenseViewModel> {
+        org.koin.core.parameter.parametersOf(expenseId)
+    },
     sharedViewModel: SharedViewModel = koinViewModel(
         viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner
     ),

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ExpensesFeature.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ExpensesFeature.kt
@@ -75,6 +75,9 @@ fun ExpensesFeature(
         onAddExpenseClick = {
             navController.navigate(Routes.ADD_EXPENSE)
         },
+        onEditExpenseClick = { expenseId ->
+            navController.navigate(Routes.editExpenseRoute(expenseId))
+        },
         onScrollPositionChanged = { index, offset ->
             expensesViewModel.onEvent(ExpensesUiEvent.ScrollPositionChanged(index, offset))
         },

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseSplitUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseSplitUiMapper.kt
@@ -5,8 +5,10 @@ import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
 import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
+import es.pedrazamiguez.splittrip.domain.model.Subunit
 import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitTypeUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.EntitySplitFlattenDelegate
 import java.math.BigDecimal
@@ -100,6 +102,128 @@ class AddExpenseSplitUiMapper(
     ): List<ExpenseSplit> {
         val result = entitySplitFlattenDelegate.flattenEntities(entitySplits, splitType)
         return entitySplitFlattenDelegate.redistributePercentagesIfNeeded(result, splitType)
+    }
+
+    /**
+     * Maps domain splits back into SplitUiModels for edit mode support.
+     */
+    fun mapDomainToSplits(
+        memberIds: List<String>,
+        shares: List<ExpenseSplit>,
+        memberProfiles: Map<String, User> = emptyMap()
+    ): ImmutableList<SplitUiModel> =
+        memberIds.map { userId ->
+            val share = shares.find { it.userId == userId }
+            val isExcluded = share == null
+            val amountCents = share?.amountCents ?: 0L
+            SplitUiModel(
+                userId = userId,
+                displayName = resolveDisplayName(userId, memberProfiles),
+                amountCents = amountCents,
+                formattedAmount = formattingHelper.formatCentsValue(amountCents),
+                amountInput = formattingHelper.formatCentsValue(amountCents),
+                percentageInput = share?.percentage?.toPlainString() ?: "",
+                isExcluded = isExcluded
+            )
+        }.sortedWith(
+            localeAwareComparator(localeProvider.getCurrentLocale()) { it.displayName }
+        ).toImmutableList()
+
+    /**
+     * Maps domain splits back into entity-level SplitUiModels for edit mode support.
+     */
+    fun buildEntitySplitsFromDomain(
+        memberIds: List<String>,
+        subunits: List<Subunit>,
+        shares: List<ExpenseSplit>,
+        availableSplitTypes: List<SplitTypeUiModel>,
+        memberProfiles: Map<String, User> = emptyMap()
+    ): ImmutableList<SplitUiModel> {
+        val subunitMemberIds = subunits.flatMap { it.memberIds }.toSet()
+        val soloMemberIds = memberIds.filter { it !in subunitMemberIds }
+        val defaultSplitType = availableSplitTypes.find { it.id == SplitType.EQUAL.name }
+
+        val entityRows = mutableListOf<SplitUiModel>()
+
+        entityRows.addAll(buildSoloMemberRows(soloMemberIds, shares, memberProfiles))
+        entityRows.addAll(buildSubunitRows(subunits, shares, availableSplitTypes, defaultSplitType, memberProfiles))
+
+        val localeComparator =
+            localeAwareComparator(localeProvider.getCurrentLocale()) { model: SplitUiModel -> model.displayName }
+        return entityRows.sortedWith { a, b ->
+            val firstCompare = a.entityMembers.isNotEmpty().compareTo(b.entityMembers.isNotEmpty())
+            if (firstCompare != 0) firstCompare else localeComparator.compare(a, b)
+        }.toImmutableList()
+    }
+
+    private fun buildSoloMemberRows(
+        soloMemberIds: List<String>,
+        shares: List<ExpenseSplit>,
+        memberProfiles: Map<String, User>
+    ): List<SplitUiModel> {
+        return soloMemberIds.map { userId ->
+            val share = shares.find { it.userId == userId && it.subunitId == null }
+            val isExcluded = share == null
+            val amountCents = share?.amountCents ?: 0L
+            SplitUiModel(
+                userId = userId,
+                displayName = resolveDisplayName(userId, memberProfiles),
+                isEntityRow = true,
+                amountCents = amountCents,
+                formattedAmount = formattingHelper.formatCentsValue(amountCents),
+                amountInput = formattingHelper.formatCentsValue(amountCents),
+                percentageInput = share?.percentage?.toPlainString() ?: "",
+                isExcluded = isExcluded
+            )
+        }
+    }
+
+    private fun buildSubunitRows(
+        subunits: List<Subunit>,
+        shares: List<ExpenseSplit>,
+        availableSplitTypes: List<SplitTypeUiModel>,
+        defaultSplitType: SplitTypeUiModel?,
+        memberProfiles: Map<String, User>
+    ): List<SplitUiModel> {
+        return subunits.map { subunit ->
+            val subunitShares = shares.filter { it.subunitId == subunit.id }
+            val isSubunitExcluded = subunitShares.isEmpty()
+            val subunitTotalCents = subunitShares.sumOf { it.amountCents }
+
+            val subunitSplitTypeDomain = subunitShares.firstOrNull()?.splitType ?: SplitType.EQUAL
+            val subunitSplitType = availableSplitTypes.find { it.id == subunitSplitTypeDomain.name } ?: defaultSplitType
+
+            val memberRows = subunit.memberIds.map { memberId ->
+                val share = subunitShares.find { it.userId == memberId }
+                val isMemberExcluded = share == null
+                val amountCents = share?.amountCents ?: 0L
+                SplitUiModel(
+                    userId = memberId,
+                    displayName = resolveDisplayName(memberId, memberProfiles),
+                    subunitId = subunit.id,
+                    amountCents = amountCents,
+                    formattedAmount = formattingHelper.formatCentsValue(amountCents),
+                    amountInput = formattingHelper.formatCentsValue(amountCents),
+                    percentageInput = share?.percentage?.toPlainString() ?: "",
+                    isExcluded = isMemberExcluded
+                )
+            }.sortedWith(
+                localeAwareComparator(localeProvider.getCurrentLocale()) { model -> model.displayName }
+            ).toImmutableList()
+
+            SplitUiModel(
+                userId = subunit.id,
+                displayName = subunit.name,
+                isEntityRow = true,
+                amountCents = subunitTotalCents,
+                formattedAmount = formattingHelper.formatCentsValue(subunitTotalCents),
+                amountInput = formattingHelper.formatCentsValue(subunitTotalCents),
+                percentageInput = "",
+                isExcluded = isSubunitExcluded,
+                entityMembers = memberRows,
+                entitySplitType = subunitSplitType
+            )
+        }
     }
 
     // ── Private helpers ──────────────────────────────────────────────────

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
@@ -267,7 +267,7 @@ class AddExpenseUiMapper(
             dueDateMillis = dueDateMillis,
             formattedDueDate = formattedDueDate,
             showDueDateSection = expense.paymentStatus == PaymentStatus.SCHEDULED,
-            receiptUri = expense.receiptAttachment?.let { it.localUri.ifBlank { it.remoteUrl } },
+            receiptUri = expense.receiptAttachment?.let { it.localUri.takeIf { it.isNotBlank() } ?: it.remoteUrl },
             receiptAttachment = expense.receiptAttachment,
             addOns = addOnsMapped.toImmutableList(),
             isSubunitMode = expense.splits.any { it.subunitId != null },

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
@@ -190,17 +190,18 @@ class AddExpenseUiMapper(
         memberProfiles: Map<String, User>,
         subunits: List<Subunit>
     ): AddExpenseUiState {
-        val groupDecimalDigits = expense.groupCurrency.let { code ->
+        val groupDecimalDigits = expense.groupCurrency.let { _ ->
             currentState.groupCurrency?.decimalDigits ?: 2
         }
 
         val sourceDecimalDigits = expense.sourceCurrency.let { code ->
             currentState.availableCurrencies.find { it.code == code }?.decimalDigits ?: 2
         }
-        val sourceAmountString = BigDecimal(expense.sourceAmount).movePointLeft(sourceDecimalDigits).toPlainString()
+        val sourceAmountString = BigDecimal(expense.sourceAmount).movePointLeft(sourceDecimalDigits)
+            .stripTrailingZeros().toPlainString()
         val calculatedGroupAmountString = BigDecimal(
             expense.groupAmount
-        ).movePointLeft(groupDecimalDigits).toPlainString()
+        ).movePointLeft(groupDecimalDigits).stripTrailingZeros().toPlainString()
 
         val selectedCurrency = currentState.availableCurrencies.find { it.code == expense.sourceCurrency }
         val selectedPaymentMethod = currentState.paymentMethods.find { it.id == expense.paymentMethod.name }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
@@ -2,20 +2,33 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
 
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
 import es.pedrazamiguez.splittrip.domain.converter.CurrencyConverter
+import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
+import es.pedrazamiguez.splittrip.domain.enums.AddOnType
+import es.pedrazamiguez.splittrip.domain.enums.AddOnValueType
 import es.pedrazamiguez.splittrip.domain.enums.ExpenseCategory
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.model.AddOn
+import es.pedrazamiguez.splittrip.domain.model.Contribution
 import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.model.Subunit
+import es.pedrazamiguez.splittrip.domain.model.User
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentMethodUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * Core Add Expense mapper: handles date formatting, display formatting,
@@ -164,5 +177,206 @@ class AddExpenseUiMapper(
         Result.success(expense)
     } catch (e: Exception) {
         Result.failure(e)
+    }
+
+    /**
+     * Maps an existing domain [Expense] and its paired [Contribution] back into UI state for modification.
+     */
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
+    fun mapExpenseToState(
+        expense: Expense,
+        contribution: Contribution?,
+        currentState: AddExpenseUiState,
+        memberProfiles: Map<String, User>,
+        subunits: List<Subunit>
+    ): AddExpenseUiState {
+        val groupDecimalDigits = expense.groupCurrency.let { code ->
+            currentState.groupCurrency?.decimalDigits ?: 2
+        }
+
+        val sourceDecimalDigits = expense.sourceCurrency.let { code ->
+            currentState.availableCurrencies.find { it.code == code }?.decimalDigits ?: 2
+        }
+        val sourceAmountString = BigDecimal(expense.sourceAmount).movePointLeft(sourceDecimalDigits).toPlainString()
+        val calculatedGroupAmountString = BigDecimal(
+            expense.groupAmount
+        ).movePointLeft(groupDecimalDigits).toPlainString()
+
+        val selectedCurrency = currentState.availableCurrencies.find { it.code == expense.sourceCurrency }
+        val selectedPaymentMethod = currentState.paymentMethods.find { it.id == expense.paymentMethod.name }
+        val selectedFundingSource = currentState.fundingSources.find { it.id == expense.payerType.name }
+        val selectedCategory = currentState.availableCategories.find { it.id == expense.category.name }
+        val selectedPaymentStatus = currentState.availablePaymentStatuses.find { it.id == expense.paymentStatus.name }
+
+        val isForeign = expense.sourceCurrency != expense.groupCurrency
+        val displayRate = if (expense.exchangeRate.compareTo(BigDecimal.ZERO) != 0) {
+            BigDecimal.ONE.divide(expense.exchangeRate, RATE_PRECISION, RoundingMode.HALF_UP)
+                .stripTrailingZeros().toPlainString()
+        } else {
+            "1.0"
+        }
+
+        val formattedDueDate = expense.dueDate?.let {
+            val millis = it.toInstant(ZoneOffset.UTC).toEpochMilli()
+            formatDueDateForDisplay(millis)
+        } ?: ""
+
+        val dueDateMillis = expense.dueDate?.toInstant(ZoneOffset.UTC)?.toEpochMilli()
+
+        val addOnsMapped = mapAddOnsToState(
+            addOns = expense.addOns,
+            availableCurrencies = currentState.availableCurrencies,
+            paymentMethods = currentState.paymentMethods,
+            groupCurrency = expense.groupCurrency,
+            groupDecimalDigits = groupDecimalDigits,
+            sourceAmount = expense.sourceAmount
+        )
+
+        val (mappedSplits, mappedEntitySplits) = mapSplitsToState(
+            expense = expense,
+            currentState = currentState,
+            memberProfiles = memberProfiles,
+            subunits = subunits
+        )
+
+        val expenseDateMillis =
+            expense.createdAt?.toInstant(ZoneOffset.UTC)?.toEpochMilli() ?: currentState.expenseDateMillis
+        val formattedExpenseDate =
+            expenseDateMillis?.let { formatExpenseDateForDisplay(it) } ?: currentState.formattedExpenseDate
+
+        val selectedSplitType = currentState.availableSplitTypes.find { it.id == expense.splitType.name }
+
+        val contributionScope = contribution?.contributionScope ?: PayerType.USER
+        val selectedContributionSubunitId = contribution?.subunitId
+
+        return currentState.copy(
+            expenseTitle = expense.title,
+            sourceAmount = sourceAmountString,
+            vendor = expense.vendor ?: "",
+            notes = expense.notes ?: "",
+            selectedCurrency = selectedCurrency,
+            selectedPaymentMethod = selectedPaymentMethod,
+            selectedFundingSource = selectedFundingSource,
+            selectedCategory = selectedCategory,
+            selectedPaymentStatus = selectedPaymentStatus,
+            displayExchangeRate = displayRate,
+            calculatedGroupAmount = calculatedGroupAmountString,
+            showExchangeRateSection = isForeign,
+            isExchangeRateLocked = expense.paymentMethod == PaymentMethod.CASH && isForeign,
+            dueDateMillis = dueDateMillis,
+            formattedDueDate = formattedDueDate,
+            showDueDateSection = expense.paymentStatus == PaymentStatus.SCHEDULED,
+            receiptUri = expense.receiptAttachment?.let { it.localUri.ifBlank { it.remoteUrl } },
+            receiptAttachment = expense.receiptAttachment,
+            addOns = addOnsMapped.toImmutableList(),
+            isSubunitMode = expense.splits.any { it.subunitId != null },
+            splits = mappedSplits,
+            entitySplits = mappedEntitySplits,
+            contributionScope = contributionScope,
+            selectedContributionSubunitId = selectedContributionSubunitId,
+            expenseDateMillis = expenseDateMillis,
+            formattedExpenseDate = formattedExpenseDate,
+            selectedSplitType = selectedSplitType,
+            isAiModeActive = false
+        )
+    }
+
+    private fun mapAddOnsToState(
+        addOns: List<AddOn>,
+        availableCurrencies: List<CurrencyUiModel>,
+        paymentMethods: List<PaymentMethodUiModel>,
+        groupCurrency: String?,
+        groupDecimalDigits: Int,
+        sourceAmount: Long
+    ): List<AddOnUiModel> {
+        return addOns.map { addOn ->
+            val currencyUiModel = availableCurrencies.find { it.code == addOn.currency }
+            val paymentMethodUiModel = paymentMethods.find { it.id == addOn.paymentMethod.name }
+            val isAddOnForeign = addOn.currency != groupCurrency
+
+            val addOnDisplayRate = getAddOnDisplayRate(addOn.exchangeRate)
+            val addOnDecimalDigits = currencyUiModel?.decimalDigits ?: 2
+            val amountInput = getAddOnAmountInput(addOn, sourceAmount, addOnDecimalDigits)
+
+            AddOnUiModel(
+                id = addOn.id,
+                type = addOn.type,
+                mode = addOn.mode,
+                valueType = addOn.valueType,
+                amountInput = amountInput,
+                resolvedAmountCents = addOn.amountCents,
+                currency = currencyUiModel,
+                displayExchangeRate = addOnDisplayRate,
+                showExchangeRateSection = isAddOnForeign,
+                isExchangeRateLocked = addOn.paymentMethod == PaymentMethod.CASH && isAddOnForeign,
+                calculatedGroupAmount = BigDecimal(
+                    addOn.groupAmountCents
+                ).movePointLeft(groupDecimalDigits).toPlainString(),
+                groupAmountCents = addOn.groupAmountCents,
+                paymentMethod = paymentMethodUiModel,
+                description = addOn.description ?: ""
+            )
+        }
+    }
+
+    private fun getAddOnDisplayRate(exchangeRate: BigDecimal): String {
+        return if (exchangeRate.compareTo(BigDecimal.ZERO) != 0) {
+            BigDecimal.ONE.divide(exchangeRate, RATE_PRECISION, RoundingMode.HALF_UP)
+                .stripTrailingZeros().toPlainString()
+        } else {
+            "1.0"
+        }
+    }
+
+    private fun getAddOnAmountInput(addOn: AddOn, sourceAmount: Long, decimalDigits: Int): String {
+        if (addOn.valueType != AddOnValueType.PERCENTAGE) {
+            return BigDecimal(addOn.amountCents).movePointLeft(decimalDigits).stripTrailingZeros().toPlainString()
+        }
+
+        val baseCents = if (addOn.mode == AddOnMode.INCLUDED && addOn.type == AddOnType.DISCOUNT) {
+            sourceAmount + addOn.amountCents
+        } else {
+            sourceAmount
+        }
+
+        return if (baseCents > 0) {
+            val pct = BigDecimal(addOn.amountCents * 100).divide(BigDecimal(baseCents), 2, RoundingMode.HALF_UP)
+            pct.stripTrailingZeros().toPlainString()
+        } else {
+            ""
+        }
+    }
+
+    private fun mapSplitsToState(
+        expense: Expense,
+        currentState: AddExpenseUiState,
+        memberProfiles: Map<String, User>,
+        subunits: List<Subunit>
+    ): Pair<ImmutableList<SplitUiModel>, ImmutableList<SplitUiModel>> {
+        val hasSubunitSplits = expense.splits.any { it.subunitId != null }
+
+        val mappedSplits = if (hasSubunitSplits) {
+            currentState.splits
+        } else {
+            splitMapper.mapDomainToSplits(
+                memberIds = currentState.memberIds,
+                shares = expense.splits,
+                memberProfiles = memberProfiles
+            )
+        }
+
+        val mappedEntitySplits = if (hasSubunitSplits) {
+            splitMapper.buildEntitySplitsFromDomain(
+                memberIds = currentState.memberIds,
+                subunits = subunits,
+                shares = expense.splits,
+                availableSplitTypes = currentState.availableSplitTypes,
+                memberProfiles = memberProfiles
+            )
+        } else {
+            currentState.entitySplits
+        }
+
+        return mappedSplits to mappedEntitySplits
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
@@ -68,6 +68,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.component.step.e
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.event.AddExpenseUiEvent
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import timber.log.Timber
 
 /**
  * Shared element transition key for the Add Expense FAB -> Screen transition.
@@ -122,6 +123,8 @@ private fun ExpenseWizard(
 
     val bottomPadding = LocalBottomPadding.current
 
+    LogReviewStepState(uiState)
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -146,10 +149,38 @@ private fun ExpenseWizard(
             ),
             onBack = { onEvent(AddExpenseUiEvent.PreviousStep) },
             onNext = { onEvent(AddExpenseUiEvent.NextStep) },
-            onSubmit = { onEvent(AddExpenseUiEvent.SubmitAddExpense(groupId)) },
+            onSubmit = {
+                Timber.d(
+                    "AddExpenseScreen: submit tapped groupId=%s isEditMode=%s isCurrentStepValid=%s isLoading=%s",
+                    groupId,
+                    uiState.isEditMode,
+                    uiState.isCurrentStepValid,
+                    uiState.isLoading
+                )
+                onEvent(AddExpenseUiEvent.SubmitAddExpense(groupId))
+            },
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = bottomPadding)
+        )
+    }
+}
+
+@Composable
+private fun LogReviewStepState(uiState: AddExpenseUiState) {
+    LaunchedEffect(uiState.isOnReviewStep, uiState.isFormValid, uiState.isLoading) {
+        if (!uiState.isOnReviewStep) return@LaunchedEffect
+        Timber.d(
+            "AddExpenseScreen REVIEW: formValid=%s titleValid=%s amountValid=%s dueValid=%s " +
+                "addOnsValid=%s title='%s' amount='%s' loading=%s",
+            uiState.isFormValid,
+            uiState.isTitleValid,
+            uiState.isAmountValid,
+            uiState.isDueDateValid,
+            uiState.addOns.all { it.isAmountValid },
+            uiState.expenseTitle,
+            uiState.sourceAmount,
+            uiState.isLoading
         )
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
@@ -117,7 +117,7 @@ private fun ExpenseWizard(
 
     val backLabel = stringResource(R.string.expense_wizard_back)
     val nextLabel = stringResource(R.string.expense_wizard_next)
-    val submitLabel = stringResource(R.string.add_expense_submit_button)
+    val submitLabel = stringResource(uiState.submitLabelRes)
     val skipToReviewLabel = stringResource(R.string.expense_wizard_skip_to_review)
 
     val bottomPadding = LocalBottomPadding.current
@@ -173,6 +173,7 @@ private fun ExpenseWizardBody(
             } else {
                 null
             },
+            allowForwardJumps = uiState.isEditMode,
             onStepClicked = { onEvent(AddExpenseUiEvent.JumpToStep(it)) }
         )
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ExpensesScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ExpensesScreen.kt
@@ -62,6 +62,7 @@ fun ExpensesScreen(
     uiState: ExpensesUiState = ExpensesUiState(),
     onExpenseClicked: (String) -> Unit = { _ -> },
     onAddExpenseClick: () -> Unit = {},
+    onEditExpenseClick: (String) -> Unit = {},
     onScrollPositionChanged: (Int, Int) -> Unit = { _, _ -> },
     onDeleteExpense: (expenseId: String) -> Unit = {}
 ) {
@@ -100,7 +101,8 @@ fun ExpensesScreen(
             expenseToDelete = expense
             selectedExpenseForMenu = null
         },
-        onDeleteDismiss = { expenseToDelete = null }
+        onDeleteDismiss = { expenseToDelete = null },
+        onEditExpenseClick = onEditExpenseClick
     )
 }
 
@@ -182,7 +184,8 @@ private fun ExpensesScreenOverlays(
     onDeleteExpense: (String) -> Unit,
     onMenuDismiss: () -> Unit,
     onDeleteRequested: (ExpenseUiModel) -> Unit,
-    onDeleteDismiss: () -> Unit
+    onDeleteDismiss: () -> Unit,
+    onEditExpenseClick: (String) -> Unit
 ) {
     selectedExpense?.let { expense ->
         ActionBottomSheet(
@@ -192,7 +195,10 @@ private fun ExpensesScreenOverlays(
                 SheetAction(
                     text = stringResource(R.string.action_edit_expense),
                     icon = TablerIcons.Outline.Edit,
-                    onClick = { onMenuDismiss() }
+                    onClick = {
+                        onEditExpenseClick(expense.id)
+                        onMenuDismiss()
+                    }
                 ),
                 SheetAction(
                     text = stringResource(R.string.action_delete_expense),

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/AddExpenseScreenUiProviderImpl.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/AddExpenseScreenUiProviderImpl.kt
@@ -13,6 +13,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.screen.ScreenUi
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.topbar.DynamicTopAppBar
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.viewmodel.SharedViewModel
 import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.AddExpenseViewModel
 import org.koin.androidx.compose.koinViewModel
 
 class AddExpenseScreenUiProviderImpl(override val route: String = Routes.ADD_EXPENSE) : ScreenUiProvider {
@@ -25,8 +26,17 @@ class AddExpenseScreenUiProviderImpl(override val route: String = Routes.ADD_EXP
         )
         val groupName by sharedViewModel.selectedGroupName.collectAsStateWithLifecycle()
 
+        val backStackEntry = navController.currentBackStackEntry
+        val title = if (backStackEntry != null) {
+            val vm: AddExpenseViewModel = koinViewModel(viewModelStoreOwner = backStackEntry)
+            val uiState by vm.uiState.collectAsStateWithLifecycle()
+            stringResource(uiState.screenTitleRes)
+        } else {
+            stringResource(R.string.expenses_add)
+        }
+
         DynamicTopAppBar(
-            title = stringResource(R.string.expenses_add),
+            title = title,
             subtitle = groupName,
             onBack = { navController.popBackStack() },
             pinned = true

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/AddExpenseScreenUiProviderImpl.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/AddExpenseScreenUiProviderImpl.kt
@@ -15,6 +15,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.viewmodel.Share
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.AddExpenseViewModel
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 class AddExpenseScreenUiProviderImpl(override val route: String = Routes.ADD_EXPENSE) : ScreenUiProvider {
 
@@ -28,7 +29,11 @@ class AddExpenseScreenUiProviderImpl(override val route: String = Routes.ADD_EXP
 
         val backStackEntry = navController.currentBackStackEntry
         val title = if (backStackEntry != null) {
-            val vm: AddExpenseViewModel = koinViewModel(viewModelStoreOwner = backStackEntry)
+            val expenseId = backStackEntry.arguments?.getString("expenseId")
+            val vm: AddExpenseViewModel = koinViewModel(
+                viewModelStoreOwner = backStackEntry,
+                parameters = { parametersOf(expenseId) }
+            )
             val uiState by vm.uiState.collectAsStateWithLifecycle()
             stringResource(uiState.screenTitleRes)
         } else {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/ExpenseDetailScreenUiProviderImpl.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/impl/ExpenseDetailScreenUiProviderImpl.kt
@@ -37,13 +37,20 @@ class ExpenseDetailScreenUiProviderImpl(
             val uiState by vm.uiState.collectAsStateWithLifecycle()
             var showDeleteDialog by remember { mutableStateOf(false) }
 
+            val expenseId = backStackEntry.arguments?.getString("expenseId")
+
             DynamicTopAppBar(
                 title = uiState.expense?.title ?: "",
                 subtitle = uiState.expense?.categoryText?.takeIf { it.isNotEmpty() },
                 onBack = { navController.popBackStack() },
                 actions = {
-                    // Edit — placeholder until the edit screen is implemented
-                    IconButton(onClick = { /* Navigate to edit screen once implemented */ }) {
+                    IconButton(
+                        onClick = {
+                            if (expenseId != null) {
+                                navController.navigate(Routes.editExpenseRoute(expenseId))
+                            }
+                        }
+                    ) {
                         Icon(
                             imageVector = TablerIcons.Outline.Edit,
                             contentDescription = stringResource(R.string.action_edit_expense)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
@@ -17,6 +17,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handle
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubmitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubunitSplitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategyFactory
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AddExpenseViewModel(
+    private val expenseId: String? = null,
     private val configEventHandler: ConfigEventHandler,
     private val currencyEventHandler: CurrencyEventHandler,
     private val splitEventHandler: SplitEventHandler,
@@ -34,10 +36,19 @@ class AddExpenseViewModel(
     private val addOnEventHandler: AddOnEventHandler,
     private val submitEventHandler: SubmitEventHandler,
     private val formEventHandler: FormEventHandler,
-    private val receiptAutoFillEventHandler: ReceiptAutoFillEventHandler
+    private val receiptAutoFillEventHandler: ReceiptAutoFillEventHandler,
+    private val strategyFactory: ExpenseFlowStrategyFactory
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(AddExpenseUiState())
+    private val strategy = strategyFactory.create(expenseId)
+
+    private val _uiState = MutableStateFlow(
+        AddExpenseUiState(
+            screenTitleRes = strategy.screenTitleRes,
+            submitLabelRes = strategy.submitLabelRes,
+            isEditMode = strategy.isEditMode
+        )
+    )
     val uiState: StateFlow<AddExpenseUiState> = _uiState.asStateFlow()
 
     private val _actions = MutableSharedFlow<AddExpenseUiAction>()
@@ -55,6 +66,8 @@ class AddExpenseViewModel(
         submitEventHandler.bind(_uiState, _actions, viewModelScope)
         formEventHandler.bind(_uiState, _actions, viewModelScope)
         receiptAutoFillEventHandler.bind(_uiState, _actions, viewModelScope)
+
+        submitEventHandler.setStrategy(strategy)
 
         receiptAutoFillEventHandler.setOnCurrencySelected { currencyCode ->
             onEvent(AddExpenseUiEvent.CurrencySelected(currencyCode))
@@ -136,11 +149,23 @@ class AddExpenseViewModel(
         when (event) {
             // ── Config ──────────────────────────────────────────────────
             is AddExpenseUiEvent.LoadGroupConfig ->
-                configEventHandler.loadGroupConfig(event.groupId)
+                strategy.loadInitialData(
+                    groupId = event.groupId,
+                    uiState = _uiState,
+                    actions = _actions,
+                    scope = viewModelScope,
+                    forceRefresh = false
+                ) {}
 
             is AddExpenseUiEvent.RetryLoadConfig -> {
                 _uiState.update { it.copy(configLoadFailed = false, error = null) }
-                configEventHandler.loadGroupConfig(event.groupId, forceRefresh = true)
+                strategy.loadInitialData(
+                    groupId = event.groupId,
+                    uiState = _uiState,
+                    actions = _actions,
+                    scope = viewModelScope,
+                    forceRefresh = true
+                ) {}
             }
 
             // ── Currency & Exchange Rate ────────────────────────────────
@@ -412,7 +437,11 @@ class AddExpenseViewModel(
      */
     private fun navigateToStep(stepIndex: Int) {
         val state = _uiState.value
-        val target = wizardNavigator.jumpToStep(state.currentStep, stepIndex, state.applicableSteps) ?: return
+        val target = if (state.isEditMode) {
+            state.applicableSteps.getOrNull(stepIndex)
+        } else {
+            wizardNavigator.jumpToStep(state.currentStep, stepIndex, state.applicableSteps)
+        } ?: return
         _uiState.update { it.copy(currentStep = target, jumpedFromStep = null) }
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class AddExpenseViewModel(
     private val expenseId: String? = null,
@@ -256,8 +257,13 @@ class AddExpenseViewModel(
                 subunitSplitEventHandler.handleIntraSubunitShareLockToggled(event.subunitId, event.userId)
 
             // ── Submission ──────────────────────────────────────────────
-            is AddExpenseUiEvent.SubmitAddExpense ->
+            is AddExpenseUiEvent.SubmitAddExpense -> {
+                Timber.d(
+                    "AddExpenseViewModel: SubmitAddExpense received groupId=%s",
+                    event.groupId
+                )
                 submitEventHandler.submitExpense(event.groupId, onAddExpenseSuccess)
+            }
 
             // ── Simple form field updates (delegated to FormEventHandler) ──
             is AddExpenseUiEvent.TitleChanged ->

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
@@ -169,7 +169,7 @@ class ConfigEventHandler(
 
         _uiState.update {
             it.copy(
-                isLoading = false,
+                isLoading = if (it.isEditMode) it.isLoading else false,
                 isConfigLoaded = true,
                 configLoadFailed = false,
                 loadedGroupId = groupId,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
@@ -90,9 +90,7 @@ class ConfigEventHandler(
         postConfigCallback = callback
     }
 
-    fun loadGroupConfig(groupId: String?, forceRefresh: Boolean = false) {
-        if (groupId == null) return
-
+    suspend fun suspendLoadGroupConfig(groupId: String, forceRefresh: Boolean = false) {
         val currentState = _uiState.value
         val isGroupChanged = currentState.loadedGroupId != groupId
 
@@ -101,29 +99,34 @@ class ConfigEventHandler(
         // Always reload if the groupId has changed
         if (!forceRefresh && !isGroupChanged && currentState.isConfigLoaded) return
 
-        scope.launch {
-            // Reset form state when loading a different group's config
-            if (isGroupChanged) {
-                _uiState.update {
-                    AddExpenseUiState(isLoading = true, configLoadFailed = false)
-                }
-            } else {
-                _uiState.update { it.copy(isLoading = true, configLoadFailed = false) }
+        // Reset form state when loading a different group's config
+        if (isGroupChanged) {
+            _uiState.update {
+                AddExpenseUiState(isLoading = true, configLoadFailed = false)
             }
+        } else {
+            _uiState.update { it.copy(isLoading = true, configLoadFailed = false) }
+        }
 
-            val config = getGroupExpenseConfigUseCase(groupId, forceRefresh).getOrElse { e ->
-                Timber.e(e, "Failed to load group configuration for groupId: $groupId")
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isConfigLoaded = false,
-                        configLoadFailed = true,
-                        error = UiText.StringResource(R.string.expense_error_load_group_config)
-                    )
-                }
-                return@launch
+        val config = getGroupExpenseConfigUseCase(groupId, forceRefresh).getOrElse { e ->
+            Timber.e(e, "Failed to load group configuration for groupId: $groupId")
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isConfigLoaded = false,
+                    configLoadFailed = true,
+                    error = UiText.StringResource(R.string.expense_error_load_group_config)
+                )
             }
-            applyConfig(groupId, config)
+            return
+        }
+        applyConfig(groupId, config)
+    }
+
+    fun loadGroupConfig(groupId: String?, forceRefresh: Boolean = false) {
+        if (groupId == null) return
+        scope.launch {
+            suspendLoadGroupConfig(groupId, forceRefresh)
         }
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
@@ -169,7 +169,7 @@ class ConfigEventHandler(
 
         _uiState.update {
             it.copy(
-                isLoading = if (it.isEditMode) it.isLoading else false,
+                isLoading = it.isEditMode && it.isLoading,
                 isConfigLoaded = true,
                 configLoadFailed = false,
                 loadedGroupId = groupId,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandler.kt
@@ -99,10 +99,19 @@ class ConfigEventHandler(
         // Always reload if the groupId has changed
         if (!forceRefresh && !isGroupChanged && currentState.isConfigLoaded) return
 
-        // Reset form state when loading a different group's config
+        // Reset form state when loading a different group's config, but preserve the
+        // edit-mode bootstrap fields set by the ViewModel constructor from the strategy.
+        // Wiping these would cause the screen to revert to "add expense" titles/labels,
+        // re-enable the AI receipt-scan step, and disable forward step jumps.
         if (isGroupChanged) {
-            _uiState.update {
-                AddExpenseUiState(isLoading = true, configLoadFailed = false)
+            _uiState.update { current ->
+                AddExpenseUiState(
+                    isLoading = true,
+                    configLoadFailed = false,
+                    isEditMode = current.isEditMode,
+                    screenTitleRes = current.screenTitleRes,
+                    submitLabelRes = current.submitLabelRes
+                )
             }
         } else {
             _uiState.update { it.copy(isLoading = true, configLoadFailed = false) }
@@ -134,6 +143,9 @@ class ConfigEventHandler(
      * Maps the loaded [GroupExpenseConfig] into UI state, resolves user preferences
      * (last-used currency, payment method, category), and emits post-config actions.
      */
+    // Single sequential state-assembly function: each `copy(...)` field is a distinct
+    // mapping from the loaded config; splitting would obscure the data-flow with no benefit.
+    @Suppress("LongMethod")
     internal suspend fun applyConfig(
         groupId: String,
         config: GroupExpenseConfig
@@ -151,6 +163,7 @@ class ConfigEventHandler(
         val userSubunitOptions = filterSubunitsForCurrentUser(currentUserId, config)
 
         val isAiCapable = receiptExtractionService.capability() == ExtractionCapability.ON_DEVICE_AI
+        val effectiveAiMode = resolveEffectiveAiMode(isAiCapable)
         val currentMillis = System.currentTimeMillis()
         val formattedDate = addExpenseUiMapper.formatExpenseDateForDisplay(currentMillis)
 
@@ -161,8 +174,8 @@ class ConfigEventHandler(
                 configLoadFailed = false,
                 loadedGroupId = groupId,
                 isAiCapable = isAiCapable,
-                isAiModeActive = isAiCapable,
-                currentStep = if (isAiCapable) AddExpenseStep.RECEIPT else AddExpenseStep.TITLE,
+                isAiModeActive = effectiveAiMode,
+                currentStep = if (effectiveAiMode) AddExpenseStep.RECEIPT else AddExpenseStep.TITLE,
                 groupName = config.group.name,
                 currentUserId = currentUserId,
                 expenseDateMillis = currentMillis,
@@ -200,6 +213,17 @@ class ConfigEventHandler(
             memberProfiles
         )
     }
+
+    /**
+     * Resolves whether AI auto-fill mode should be active.
+     *
+     * AI mode is suppressed in edit mode because the expense already exists, so
+     * re-uploading a receipt to extract fields would be nonsensical and would
+     * cause a FOUC where the wizard briefly opens on the RECEIPT step before
+     * the mapper restores TITLE as the current step.
+     */
+    private fun resolveEffectiveAiMode(isAiCapable: Boolean): Boolean =
+        isAiCapable && !_uiState.value.isEditMode
 
     private suspend fun resolveDefaults(
         groupId: String,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * Handles expense form submission.
@@ -67,7 +68,10 @@ class SubmitEventHandler(
     // each branch is a distinct validation/error case
     @Suppress("CognitiveComplexMethod", "LongMethod", "ReturnCount")
     fun submitExpense(groupId: String?, onSuccess: () -> Unit) {
-        if (groupId == null) return
+        if (groupId == null) {
+            Timber.w("submitExpense: groupId is null, aborting submission")
+            return
+        }
 
         val currentState = _uiState.value
 
@@ -154,6 +158,7 @@ class SubmitEventHandler(
                 }
             }
         }.onFailure { e ->
+            Timber.e(e, "Failed to map expense to domain")
             _uiState.update {
                 it.copy(
                     isLoading = false,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -86,11 +86,15 @@ class SubmitEventHandler(
         val titleValidation = expenseValidationService.validateTitle(currentState.expenseTitle)
         if (titleValidation is ValidationResult.Invalid) {
             Timber.w("submitExpense: title validation failed — title='%s'", currentState.expenseTitle)
+            val errorText = UiText.StringResource(R.string.expense_error_title_empty)
             _uiState.update {
                 it.copy(
                     isTitleValid = false,
-                    error = UiText.StringResource(R.string.expense_error_title_empty)
+                    error = errorText
                 )
+            }
+            scope.launch {
+                _actions.emit(AddExpenseUiAction.ShowError(errorText))
             }
             return
         }
@@ -103,11 +107,15 @@ class SubmitEventHandler(
                 currentState.sourceAmount,
                 amountValidation.message
             )
+            val errorText = UiText.DynamicString(amountValidation.message)
             _uiState.update {
                 it.copy(
                     isAmountValid = false,
-                    error = UiText.DynamicString(amountValidation.message)
+                    error = errorText
                 )
+            }
+            scope.launch {
+                _actions.emit(AddExpenseUiAction.ShowError(errorText))
             }
             return
         }
@@ -120,11 +128,15 @@ class SubmitEventHandler(
                 "submitExpense: due-date required but null — paymentStatus=%s",
                 currentState.selectedPaymentStatus?.id
             )
+            val errorText = UiText.StringResource(R.string.expense_error_due_date_required)
             _uiState.update {
                 it.copy(
                     isDueDateValid = false,
-                    error = UiText.StringResource(R.string.expense_error_due_date_required)
+                    error = errorText
                 )
+            }
+            scope.launch {
+                _actions.emit(AddExpenseUiAction.ShowError(errorText))
             }
             return
         }
@@ -140,11 +152,15 @@ class SubmitEventHandler(
                     currentState.expenseDateMillis,
                     dateValidation.message
                 )
+                val errorText = UiText.StringResource(R.string.expense_error_date_future)
                 _uiState.update {
                     it.copy(
                         isExpenseDateValid = false,
-                        error = UiText.StringResource(R.string.expense_error_date_future)
+                        error = errorText
                     )
+                }
+                scope.launch {
+                    _actions.emit(AddExpenseUiAction.ShowError(errorText))
                 }
                 return
             }
@@ -157,12 +173,16 @@ class SubmitEventHandler(
                 "submitExpense: add-on validation failed — invalidAddOns=%d",
                 addOnsWithInput.count { it.resolvedAmountCents <= 0 }
             )
+            val errorText = UiText.StringResource(
+                R.string.add_expense_add_on_error_amount
+            )
             _uiState.update {
                 it.copy(
-                    addOnError = UiText.StringResource(
-                        R.string.add_expense_add_on_error_amount
-                    )
+                    addOnError = errorText
                 )
+            }
+            scope.launch {
+                _actions.emit(AddExpenseUiAction.ShowError(errorText))
             }
             return
         }
@@ -189,11 +209,15 @@ class SubmitEventHandler(
             }
         }.onFailure { e ->
             Timber.e(e, "submitExpense: failed to map expense to domain")
+            val errorText = UiText.DynamicString(e.message ?: "Unknown error")
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    error = UiText.DynamicString(e.message ?: "Unknown error")
+                    error = errorText
                 )
+            }
+            scope.launch {
+                _actions.emit(AddExpenseUiAction.ShowError(errorText))
             }
         }
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -68,6 +68,12 @@ class SubmitEventHandler(
     // each branch is a distinct validation/error case
     @Suppress("CognitiveComplexMethod", "LongMethod", "ReturnCount")
     fun submitExpense(groupId: String?, onSuccess: () -> Unit) {
+        Timber.d(
+            "submitExpense: entry groupId=%s isEditMode=%s currentStep=%s",
+            groupId,
+            _uiState.value.isEditMode,
+            _uiState.value.currentStep
+        )
         if (groupId == null) {
             Timber.w("submitExpense: groupId is null, aborting submission")
             return
@@ -78,6 +84,7 @@ class SubmitEventHandler(
         // Validate title using domain service
         val titleValidation = expenseValidationService.validateTitle(currentState.expenseTitle)
         if (titleValidation is ValidationResult.Invalid) {
+            Timber.w("submitExpense: title validation failed — title='%s'", currentState.expenseTitle)
             _uiState.update {
                 it.copy(
                     isTitleValid = false,
@@ -90,6 +97,11 @@ class SubmitEventHandler(
         // Validate amount using domain service
         val amountValidation = expenseValidationService.validateAmount(currentState.sourceAmount)
         if (amountValidation is ValidationResult.Invalid) {
+            Timber.w(
+                "submitExpense: amount validation failed — sourceAmount='%s' reason=%s",
+                currentState.sourceAmount,
+                amountValidation.message
+            )
             _uiState.update {
                 it.copy(
                     isAmountValid = false,
@@ -103,6 +115,10 @@ class SubmitEventHandler(
         if (currentState.selectedPaymentStatus?.id == PaymentStatus.SCHEDULED.name &&
             currentState.dueDateMillis == null
         ) {
+            Timber.w(
+                "submitExpense: due-date required but null — paymentStatus=%s",
+                currentState.selectedPaymentStatus?.id
+            )
             _uiState.update {
                 it.copy(
                     isDueDateValid = false,
@@ -118,6 +134,11 @@ class SubmitEventHandler(
                 currentState.expenseDateMillis ?: System.currentTimeMillis()
             )
             if (dateValidation is ValidationResult.Invalid) {
+                Timber.w(
+                    "submitExpense: expense-date validation failed — expenseDateMillis=%d reason=%s",
+                    currentState.expenseDateMillis,
+                    dateValidation.message
+                )
                 _uiState.update {
                     it.copy(
                         isExpenseDateValid = false,
@@ -131,6 +152,10 @@ class SubmitEventHandler(
         // Validate add-ons (only those with non-empty input)
         val addOnsWithInput = currentState.addOns.filter { it.amountInput.isNotBlank() }
         if (addOnsWithInput.any { it.resolvedAmountCents <= 0 }) {
+            Timber.w(
+                "submitExpense: add-on validation failed — invalidAddOns=%d",
+                addOnsWithInput.count { it.resolvedAmountCents <= 0 }
+            )
             _uiState.update {
                 it.copy(
                     addOnError = UiText.StringResource(
@@ -141,24 +166,28 @@ class SubmitEventHandler(
             return
         }
 
+        Timber.d("submitExpense: validations passed, mapping to domain")
         _uiState.update { it.copy(isLoading = true, error = null) }
 
         addExpenseUiMapper.mapToDomain(_uiState.value, groupId).onSuccess { expense ->
             val withIncludedAdj = adjustForIncludedAddOns(expense, _uiState.value.addOns)
             val adjustedExpense = adjustForOnTopDiscounts(withIncludedAdj)
+            Timber.d("submitExpense: domain mapping ok, delegating to strategy.saveExpense")
             scope.launch {
                 strategy.saveExpense(
                     groupId = groupId,
                     expense = adjustedExpense,
                     uiState = currentState
                 ).onSuccess {
+                    Timber.d("submitExpense: strategy.saveExpense succeeded")
                     submitResultDelegate.handleSuccess(_uiState, groupId, onSuccess)
                 }.onFailure { e ->
+                    Timber.e(e, "submitExpense: strategy.saveExpense failed")
                     submitResultDelegate.handleFailure(e, _uiState, _actions, currentState)
                 }
             }
         }.onFailure { e ->
-            Timber.e(e, "Failed to map expense to domain")
+            Timber.e(e, "submitExpense: failed to map expense to domain")
             _uiState.update {
                 it.copy(
                     isLoading = false,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -85,7 +85,7 @@ class SubmitEventHandler(
         // Validate title using domain service
         val titleValidation = expenseValidationService.validateTitle(currentState.expenseTitle)
         if (titleValidation is ValidationResult.Invalid) {
-            Timber.w("submitExpense: title validation failed — title='%s'", currentState.expenseTitle)
+            Timber.w("submitExpense: title validation failed — length=%d", currentState.expenseTitle.length)
             val errorText = UiText.StringResource(R.string.expense_error_title_empty)
             _uiState.update {
                 it.copy(
@@ -103,8 +103,7 @@ class SubmitEventHandler(
         val amountValidation = expenseValidationService.validateAmount(currentState.sourceAmount)
         if (amountValidation is ValidationResult.Invalid) {
             Timber.w(
-                "submitExpense: amount validation failed — sourceAmount='%s' reason=%s",
-                currentState.sourceAmount,
+                "submitExpense: amount validation failed — reason=%s",
                 amountValidation.message
             )
             val errorText = UiText.DynamicString(amountValidation.message)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -74,8 +74,9 @@ class SubmitEventHandler(
             _uiState.value.isEditMode,
             _uiState.value.currentStep
         )
-        if (groupId == null) {
-            Timber.w("submitExpense: groupId is null, aborting submission")
+        val effectiveGroupId = groupId ?: _uiState.value.loadedGroupId
+        if (effectiveGroupId == null) {
+            Timber.w("submitExpense: both groupId parameter and loadedGroupId are null, aborting submission")
             return
         }
 
@@ -169,18 +170,18 @@ class SubmitEventHandler(
         Timber.d("submitExpense: validations passed, mapping to domain")
         _uiState.update { it.copy(isLoading = true, error = null) }
 
-        addExpenseUiMapper.mapToDomain(_uiState.value, groupId).onSuccess { expense ->
+        addExpenseUiMapper.mapToDomain(_uiState.value, effectiveGroupId).onSuccess { expense ->
             val withIncludedAdj = adjustForIncludedAddOns(expense, _uiState.value.addOns)
             val adjustedExpense = adjustForOnTopDiscounts(withIncludedAdj)
             Timber.d("submitExpense: domain mapping ok, delegating to strategy.saveExpense")
             scope.launch {
                 strategy.saveExpense(
-                    groupId = groupId,
+                    groupId = effectiveGroupId,
                     expense = adjustedExpense,
                     uiState = currentState
                 ).onSuccess {
                     Timber.d("submitExpense: strategy.saveExpense succeeded")
-                    submitResultDelegate.handleSuccess(_uiState, groupId, onSuccess)
+                    submitResultDelegate.handleSuccess(_uiState, effectiveGroupId, onSuccess)
                 }.onFailure { e ->
                     Timber.e(e, "submitExpense: strategy.saveExpense failed")
                     submitResultDelegate.handleFailure(e, _uiState, _actions, currentState)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -14,12 +14,12 @@ import es.pedrazamiguez.splittrip.domain.service.AddOnCalculationService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseValidationService
 import es.pedrazamiguez.splittrip.domain.service.RemainderDistributionService
-import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategy
 import java.math.BigDecimal
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
@@ -35,7 +35,6 @@ import kotlinx.coroutines.launch
  * decomposition via [ExpenseCalculatorService], and delegates to the use case.
  */
 class SubmitEventHandler(
-    private val addExpenseUseCase: AddExpenseUseCase,
     private val expenseValidationService: ExpenseValidationService,
     private val addOnCalculationService: AddOnCalculationService,
     private val expenseCalculatorService: ExpenseCalculatorService,
@@ -43,6 +42,12 @@ class SubmitEventHandler(
     private val addExpenseUiMapper: AddExpenseUiMapper,
     private val submitResultDelegate: SubmitResultDelegate
 ) : AddExpenseEventHandler {
+
+    private lateinit var strategy: ExpenseFlowStrategy
+
+    fun setStrategy(strategy: ExpenseFlowStrategy) {
+        this.strategy = strategy
+    }
 
     private lateinit var _uiState: MutableStateFlow<AddExpenseUiState>
     private lateinit var _actions: MutableSharedFlow<AddExpenseUiAction>
@@ -137,18 +142,11 @@ class SubmitEventHandler(
         addExpenseUiMapper.mapToDomain(_uiState.value, groupId).onSuccess { expense ->
             val withIncludedAdj = adjustForIncludedAddOns(expense, _uiState.value.addOns)
             val adjustedExpense = adjustForOnTopDiscounts(withIncludedAdj)
-            val pairedContributionScope = currentState.contributionScope
-            val pairedSubunitId = currentState.selectedContributionSubunitId
-            val preferredWithdrawalScope = currentState.selectedWithdrawalPool?.scope
-            val preferredWithdrawalOwnerId = currentState.selectedWithdrawalPool?.ownerId
             scope.launch {
-                addExpenseUseCase(
-                    groupId,
-                    adjustedExpense,
-                    pairedContributionScope,
-                    pairedSubunitId,
-                    preferredWithdrawalScope = preferredWithdrawalScope,
-                    preferredWithdrawalOwnerId = preferredWithdrawalOwnerId
+                strategy.saveExpense(
+                    groupId = groupId,
+                    expense = adjustedExpense,
+                    uiState = currentState
                 ).onSuccess {
                     submitResultDelegate.handleSuccess(_uiState, groupId, onSuccess)
                 }.onFailure { e ->

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitResultDelegate.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitResultDelegate.kt
@@ -10,6 +10,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import timber.log.Timber
 
 /**
  * Stateless delegate that handles the post-submit result processing for expenses.
@@ -70,6 +71,7 @@ class SubmitResultDelegate(
         actionsFlow: MutableSharedFlow<AddExpenseUiAction>,
         currentState: AddExpenseUiState
     ) {
+        Timber.e(error, "Failed to submit expense")
         uiState.update { it.copy(isLoading = false, error = null) }
 
         when (error) {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -26,6 +26,9 @@ data class AddExpenseUiState(
     val loadedGroupId: String? = null,
     val groupName: String? = null,
     val currentUserId: String? = null,
+    val screenTitleRes: Int = es.pedrazamiguez.splittrip.features.expense.R.string.add_expense_title,
+    val submitLabelRes: Int = es.pedrazamiguez.splittrip.features.expense.R.string.add_expense_submit_button,
+    val isEditMode: Boolean = false,
 
     // Inputs
     val expenseTitle: String = "",

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/AddExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/AddExpenseFlowStrategy.kt
@@ -1,0 +1,66 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy
+
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
+import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.ConfigEventHandler
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Strategy implementation for creating a new expense.
+ *
+ * Configures the screen with creation-related titles and submit labels,
+ * initiates config loading, and delegates save calls to the AddExpenseUseCase.
+ */
+class AddExpenseFlowStrategy(
+    private val configEventHandler: ConfigEventHandler,
+    private val addExpenseUseCase: AddExpenseUseCase
+) : ExpenseFlowStrategy {
+
+    override val screenTitleRes: Int = R.string.add_expense_title
+    override val submitLabelRes: Int = R.string.add_expense_submit_button
+    override val isEditMode: Boolean = false
+    override val startStep: AddExpenseStep = AddExpenseStep.TITLE
+
+    override fun loadInitialData(
+        groupId: String?,
+        uiState: MutableStateFlow<AddExpenseUiState>,
+        actions: MutableSharedFlow<AddExpenseUiAction>,
+        scope: CoroutineScope,
+        forceRefresh: Boolean,
+        onConfigLoaded: suspend () -> Unit
+    ) {
+        scope.launch {
+            configEventHandler.loadGroupConfig(groupId, forceRefresh)
+            onConfigLoaded()
+        }
+    }
+
+    override suspend fun saveExpense(
+        groupId: String?,
+        expense: Expense,
+        uiState: AddExpenseUiState
+    ): Result<Unit> {
+        val pairedSubunitId = if (uiState.contributionScope ==
+            es.pedrazamiguez.splittrip.domain.enums.PayerType.SUBUNIT
+        ) {
+            uiState.selectedContributionSubunitId
+        } else {
+            null
+        }
+        return addExpenseUseCase(
+            groupId = groupId,
+            expense = expense,
+            pairedContributionScope = uiState.contributionScope,
+            pairedSubunitId = pairedSubunitId,
+            preferredWithdrawalScope = uiState.selectedWithdrawalPool?.scope,
+            preferredWithdrawalOwnerId = uiState.selectedWithdrawalPool?.ownerId
+        )
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/AddExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/AddExpenseFlowStrategy.kt
@@ -36,8 +36,9 @@ class AddExpenseFlowStrategy(
         forceRefresh: Boolean,
         onConfigLoaded: suspend () -> Unit
     ) {
+        if (groupId == null) return
         scope.launch {
-            configEventHandler.loadGroupConfig(groupId, forceRefresh)
+            configEventHandler.suspendLoadGroupConfig(groupId, forceRefresh)
             onConfigLoaded()
         }
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
@@ -88,11 +88,18 @@ class EditExpenseFlowStrategy(
                         memberProfiles = memberProfiles,
                         subunits = subunits
                     )
-                    // Skip AI scan step completely: force start step to TITLE
+                    // Belt-and-suspenders: reaffirm the edit-mode contract after the mapper.
+                    // The mapper inherits `currentState`; if any intermediate step lost the
+                    // edit-mode flags, this restores them so the top bar title, submit label,
+                    // forward-jump enablement, and AI prompt suppression all behave correctly.
                     mappedState.copy(
                         currentStep = AddExpenseStep.TITLE,
                         isConfigLoaded = true,
-                        isLoading = false
+                        isLoading = false,
+                        isEditMode = true,
+                        screenTitleRes = R.string.edit_expense_title,
+                        submitLabelRes = R.string.edit_expense_submit_button,
+                        isAiModeActive = false
                     )
                 }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
@@ -57,7 +57,7 @@ class EditExpenseFlowStrategy(
                 uiState.update { it.copy(isLoading = true, configLoadFailed = false) }
 
                 // 1. Load group config via ConfigEventHandler
-                configEventHandler.loadGroupConfig(groupId, forceRefresh)
+                configEventHandler.suspendLoadGroupConfig(groupId, forceRefresh)
 
                 // 2. Fetch the target expense
                 val expense = getExpenseByIdUseCase(expenseId)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
@@ -76,7 +76,7 @@ class EditExpenseFlowStrategy(
                 val contribution = getContributionByExpenseIdUseCase(groupId, expenseId)
 
                 // 4. Fetch additional details needed for mapper (member profiles and subunits)
-                val memberProfiles = getMemberProfilesUseCase(expense.splits.map { it.userId })
+                val memberProfiles = getMemberProfilesUseCase(uiState.value.memberIds)
                 val subunits = getGroupSubunitsUseCase(groupId)
 
                 // 5. Map everything back to UI State

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
@@ -89,9 +89,6 @@ class EditExpenseFlowStrategy(
                         subunits = subunits
                     )
                     // Belt-and-suspenders: reaffirm the edit-mode contract after the mapper.
-                    // The mapper inherits `currentState`; if any intermediate step lost the
-                    // edit-mode flags, this restores them so the top bar title, submit label,
-                    // forward-jump enablement, and AI prompt suppression all behave correctly.
                     mappedState.copy(
                         currentStep = AddExpenseStep.TITLE,
                         isConfigLoaded = true,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategy.kt
@@ -1,0 +1,133 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy
+
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
+import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.ConfigEventHandler
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Strategy implementation for editing an existing expense.
+ *
+ * Configures the screen with edit-related titles and submit labels,
+ * initiates config loading followed by fetching the target expense & contribution,
+ * and delegates save calls to the UpdateExpenseUseCase.
+ */
+class EditExpenseFlowStrategy(
+    private val expenseId: String,
+    private val configEventHandler: ConfigEventHandler,
+    private val getExpenseByIdUseCase: GetExpenseByIdUseCase,
+    private val getContributionByExpenseIdUseCase: GetContributionByExpenseIdUseCase,
+    private val updateExpenseUseCase: UpdateExpenseUseCase,
+    private val addExpenseUiMapper: AddExpenseUiMapper,
+    private val getMemberProfilesUseCase: GetMemberProfilesUseCase,
+    private val getGroupSubunitsUseCase: GetGroupSubunitsUseCase
+) : ExpenseFlowStrategy {
+
+    override val screenTitleRes: Int = R.string.edit_expense_title
+    override val submitLabelRes: Int = R.string.edit_expense_submit_button
+    override val isEditMode: Boolean = true
+    override val startStep: AddExpenseStep = AddExpenseStep.TITLE
+
+    override fun loadInitialData(
+        groupId: String?,
+        uiState: MutableStateFlow<AddExpenseUiState>,
+        actions: MutableSharedFlow<AddExpenseUiAction>,
+        scope: CoroutineScope,
+        forceRefresh: Boolean,
+        onConfigLoaded: suspend () -> Unit
+    ) {
+        if (groupId == null) return
+        scope.launch {
+            try {
+                uiState.update { it.copy(isLoading = true, configLoadFailed = false) }
+
+                // 1. Load group config via ConfigEventHandler
+                configEventHandler.loadGroupConfig(groupId, forceRefresh)
+
+                // 2. Fetch the target expense
+                val expense = getExpenseByIdUseCase(expenseId)
+                if (expense == null) {
+                    Timber.e("Expense with ID %s not found in group %s", expenseId, groupId)
+                    uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            configLoadFailed = true
+                        )
+                    }
+                    return@launch
+                }
+
+                // 3. Fetch paired contribution if it exists
+                val contribution = getContributionByExpenseIdUseCase(groupId, expenseId)
+
+                // 4. Fetch additional details needed for mapper (member profiles and subunits)
+                val memberProfiles = getMemberProfilesUseCase(expense.splits.map { it.userId })
+                val subunits = getGroupSubunitsUseCase(groupId)
+
+                // 5. Map everything back to UI State
+                uiState.update { state ->
+                    val mappedState = addExpenseUiMapper.mapExpenseToState(
+                        expense = expense,
+                        contribution = contribution,
+                        currentState = state,
+                        memberProfiles = memberProfiles,
+                        subunits = subunits
+                    )
+                    // Skip AI scan step completely: force start step to TITLE
+                    mappedState.copy(
+                        currentStep = AddExpenseStep.TITLE,
+                        isConfigLoaded = true,
+                        isLoading = false
+                    )
+                }
+
+                onConfigLoaded()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to load initial data for editing expense: $expenseId")
+                uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        configLoadFailed = true
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun saveExpense(
+        groupId: String?,
+        expense: Expense,
+        uiState: AddExpenseUiState
+    ): Result<Unit> {
+        val expenseWithId = expense.copy(id = expenseId)
+
+        val pairedSubunitId = if (uiState.contributionScope == PayerType.SUBUNIT) {
+            uiState.selectedContributionSubunitId
+        } else {
+            null
+        }
+        return updateExpenseUseCase(
+            groupId = groupId,
+            expense = expenseWithId,
+            pairedContributionScope = uiState.contributionScope,
+            pairedSubunitId = pairedSubunitId,
+            preferredWithdrawalScope = uiState.selectedWithdrawalPool?.scope,
+            preferredWithdrawalOwnerId = uiState.selectedWithdrawalPool?.ownerId
+        )
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/ExpenseFlowStrategy.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/ExpenseFlowStrategy.kt
@@ -1,0 +1,38 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy
+
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Strategy pattern interface for the expense wizard flow.
+ *
+ * Decouples creation vs. modification behaviors, exposing screen-level
+ * metadata, the initial entry step, configuration loading logic, and
+ * the target persistence call (add vs. update use case).
+ */
+interface ExpenseFlowStrategy {
+    val screenTitleRes: Int
+    val submitLabelRes: Int
+    val isEditMode: Boolean
+    val startStep: AddExpenseStep
+
+    fun loadInitialData(
+        groupId: String?,
+        uiState: MutableStateFlow<AddExpenseUiState>,
+        actions: MutableSharedFlow<AddExpenseUiAction>,
+        scope: CoroutineScope,
+        forceRefresh: Boolean = false,
+        onConfigLoaded: suspend () -> Unit
+    )
+
+    suspend fun saveExpense(
+        groupId: String?,
+        expense: Expense,
+        uiState: AddExpenseUiState
+    ): Result<Unit>
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/ExpenseFlowStrategyFactory.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/ExpenseFlowStrategyFactory.kt
@@ -1,0 +1,48 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy
+
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.ConfigEventHandler
+
+/**
+ * Factory class that creates the appropriate ExpenseFlowStrategy.
+ *
+ * Directs Koin dependencies into the strategy implementations, returning
+ * EditExpenseFlowStrategy when an expenseId is present, or AddExpenseFlowStrategy
+ * when creating a new expense.
+ */
+class ExpenseFlowStrategyFactory(
+    private val configEventHandler: ConfigEventHandler,
+    private val addExpenseUseCase: AddExpenseUseCase,
+    private val updateExpenseUseCase: UpdateExpenseUseCase,
+    private val getExpenseByIdUseCase: GetExpenseByIdUseCase,
+    private val getContributionByExpenseIdUseCase: GetContributionByExpenseIdUseCase,
+    private val addExpenseUiMapper: AddExpenseUiMapper,
+    private val getMemberProfilesUseCase: GetMemberProfilesUseCase,
+    private val getGroupSubunitsUseCase: GetGroupSubunitsUseCase
+) {
+    fun create(expenseId: String?): ExpenseFlowStrategy {
+        return if (!expenseId.isNullOrBlank()) {
+            EditExpenseFlowStrategy(
+                expenseId = expenseId,
+                configEventHandler = configEventHandler,
+                getExpenseByIdUseCase = getExpenseByIdUseCase,
+                getContributionByExpenseIdUseCase = getContributionByExpenseIdUseCase,
+                updateExpenseUseCase = updateExpenseUseCase,
+                addExpenseUiMapper = addExpenseUiMapper,
+                getMemberProfilesUseCase = getMemberProfilesUseCase,
+                getGroupSubunitsUseCase = getGroupSubunitsUseCase
+            )
+        } else {
+            AddExpenseFlowStrategy(
+                configEventHandler = configEventHandler,
+                addExpenseUseCase = addExpenseUseCase
+            )
+        }
+    }
+}

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -329,4 +329,6 @@
     <string name="expense_date_time_ok">OK</string>
     <string name="expense_date_time_cancel">Cancelar</string>
     <string name="expense_error_date_future">La fecha y hora del gasto no pueden ser futuras</string>
+    <string name="edit_expense_title">Editar gasto</string>
+    <string name="edit_expense_submit_button">Guardar cambios</string>
 </resources>

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -328,4 +328,6 @@
     <string name="expense_date_time_ok">OK</string>
     <string name="expense_date_time_cancel">Cancel</string>
     <string name="expense_error_date_future">Expense date and time cannot be in the future</string>
+    <string name="edit_expense_title">Edit expense</string>
+    <string name="edit_expense_submit_button">Save changes</string>
 </resources>

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/extensions/PaymentStatusExtensionsTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/extensions/PaymentStatusExtensionsTest.kt
@@ -1,0 +1,100 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.extensions
+
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Calendar
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.CircleCheck
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Clock
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.X
+import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
+import es.pedrazamiguez.splittrip.features.expense.R
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PaymentStatusExtensionsTest {
+
+    // ── toStringRes ───────────────────────────────────────────────────────
+
+    @Nested
+    inner class ToStringRes {
+
+        @Test
+        fun `RECEIVED maps to payment_status_received string resource`() {
+            assertEquals(R.string.payment_status_received, PaymentStatus.RECEIVED.toStringRes())
+        }
+
+        @Test
+        fun `PENDING maps to payment_status_pending string resource`() {
+            assertEquals(R.string.payment_status_pending, PaymentStatus.PENDING.toStringRes())
+        }
+
+        @Test
+        fun `FINISHED maps to payment_status_finished string resource`() {
+            assertEquals(R.string.payment_status_finished, PaymentStatus.FINISHED.toStringRes())
+        }
+
+        @Test
+        fun `SCHEDULED maps to payment_status_scheduled string resource`() {
+            assertEquals(R.string.payment_status_scheduled, PaymentStatus.SCHEDULED.toStringRes())
+        }
+
+        @Test
+        fun `CANCELLED maps to payment_status_cancelled string resource`() {
+            assertEquals(R.string.payment_status_cancelled, PaymentStatus.CANCELLED.toStringRes())
+        }
+
+        @Test
+        fun `all statuses map to distinct resource IDs`() {
+            val ids = PaymentStatus.entries.map { it.toStringRes() }
+            assertEquals(ids.size, ids.toSet().size)
+        }
+    }
+
+    // ── toIconVector ──────────────────────────────────────────────────────
+
+    @Nested
+    inner class ToIconVector {
+
+        @Test
+        fun `FINISHED maps to CircleCheck icon`() {
+            assertEquals(TablerIcons.Outline.CircleCheck, PaymentStatus.FINISHED.toIconVector())
+        }
+
+        @Test
+        fun `RECEIVED maps to CircleCheck icon`() {
+            assertEquals(TablerIcons.Outline.CircleCheck, PaymentStatus.RECEIVED.toIconVector())
+        }
+
+        @Test
+        fun `PENDING maps to Clock icon`() {
+            assertEquals(TablerIcons.Outline.Clock, PaymentStatus.PENDING.toIconVector())
+        }
+
+        @Test
+        fun `SCHEDULED maps to Calendar icon`() {
+            assertEquals(TablerIcons.Outline.Calendar, PaymentStatus.SCHEDULED.toIconVector())
+        }
+
+        @Test
+        fun `CANCELLED maps to X icon`() {
+            assertEquals(TablerIcons.Outline.X, PaymentStatus.CANCELLED.toIconVector())
+        }
+
+        @Test
+        fun `FINISHED and RECEIVED share the same icon`() {
+            assertEquals(PaymentStatus.FINISHED.toIconVector(), PaymentStatus.RECEIVED.toIconVector())
+        }
+
+        @Test
+        fun `PENDING SCHEDULED CANCELLED all have distinct icons`() {
+            val pendingIcon = PaymentStatus.PENDING.toIconVector()
+            val scheduledIcon = PaymentStatus.SCHEDULED.toIconVector()
+            val cancelledIcon = PaymentStatus.CANCELLED.toIconVector()
+
+            assertNotEquals(pendingIcon, scheduledIcon)
+            assertNotEquals(pendingIcon, cancelledIcon)
+            assertNotEquals(scheduledIcon, cancelledIcon)
+        }
+    }
+}

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseSplitUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseSplitUiMapperTest.kt
@@ -1,0 +1,431 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
+
+import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
+import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
+import es.pedrazamiguez.splittrip.domain.model.Subunit
+import es.pedrazamiguez.splittrip.domain.model.User
+import es.pedrazamiguez.splittrip.domain.service.RemainderDistributionService
+import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitTypeUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.EntitySplitFlattenDelegate
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.util.Locale
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class AddExpenseSplitUiMapperTest {
+
+    private lateinit var localeProvider: LocaleProvider
+    private lateinit var formattingHelper: FormattingHelper
+    private lateinit var splitPreviewService: SplitPreviewService
+    private lateinit var entitySplitFlattenDelegate: EntitySplitFlattenDelegate
+    private lateinit var mapper: AddExpenseSplitUiMapper
+
+    private val user1 = User(userId = "user-1", email = "a@test.com", displayName = "Andrés")
+    private val user2 = User(userId = "user-2", email = "b@test.com", displayName = "Ana")
+    private val user3 = User(userId = "user-3", email = "c@test.com", displayName = "")
+
+    @BeforeEach
+    fun setUp() {
+        localeProvider = mockk()
+        every { localeProvider.getCurrentLocale() } returns Locale.US
+
+        formattingHelper = FormattingHelper(localeProvider)
+        splitPreviewService = SplitPreviewService()
+        val remainderDistributionService = RemainderDistributionService()
+        entitySplitFlattenDelegate = EntitySplitFlattenDelegate(splitPreviewService, remainderDistributionService)
+
+        mapper = AddExpenseSplitUiMapper(
+            localeProvider,
+            formattingHelper,
+            splitPreviewService,
+            entitySplitFlattenDelegate
+        )
+    }
+
+    // ── resolveDisplayName ────────────────────────────────────────────────
+
+    @Nested
+    inner class ResolveDisplayName {
+
+        @Test
+        fun `returns displayName when set`() {
+            val profiles = mapOf("user-1" to user1)
+            assertEquals("Andrés", mapper.resolveDisplayName("user-1", profiles))
+        }
+
+        @Test
+        fun `returns email as fallback when displayName is blank`() {
+            val profiles = mapOf("user-3" to user3)
+            assertEquals("c@test.com", mapper.resolveDisplayName("user-3", profiles))
+        }
+
+        @Test
+        fun `returns userId as fallback when profile is not found`() {
+            assertEquals("user-99", mapper.resolveDisplayName("user-99", emptyMap()))
+        }
+
+        @Test
+        fun `returns userId when user has no displayName and no email`() {
+            val noNameNoEmail = User(userId = "user-x", email = "", displayName = "")
+            val profiles = mapOf("user-x" to noNameNoEmail)
+            assertEquals("user-x", mapper.resolveDisplayName("user-x", profiles))
+        }
+    }
+
+    // ── buildInitialSplits ────────────────────────────────────────────────
+
+    @Nested
+    inner class BuildInitialSplits {
+
+        @Test
+        fun `builds splits from member IDs with existing shares`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-1", amountCents = 5000L),
+                ExpenseSplit(userId = "user-2", amountCents = 5000L)
+            )
+
+            val result = mapper.buildInitialSplits(
+                memberIds = listOf("user-1", "user-2"),
+                shares = shares,
+                memberProfiles = mapOf("user-1" to user1, "user-2" to user2)
+            )
+
+            assertEquals(2, result.size)
+            // Results are sorted by display name (Ana < Andrés in locale sort)
+            val names = result.map { it.displayName }
+            assertTrue(names.contains("Andrés"))
+            assertTrue(names.contains("Ana"))
+        }
+
+        @Test
+        fun `uses zero amountCents when member has no share`() {
+            val result = mapper.buildInitialSplits(
+                memberIds = listOf("user-1"),
+                shares = emptyList(),
+                memberProfiles = mapOf("user-1" to user1)
+            )
+
+            assertEquals(1, result.size)
+            assertEquals(0L, result[0].amountCents)
+        }
+
+        @Test
+        fun `returns empty list for empty member IDs`() {
+            val result = mapper.buildInitialSplits(
+                memberIds = emptyList(),
+                shares = emptyList()
+            )
+
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        fun `sorts results by display name`() {
+            val result = mapper.buildInitialSplits(
+                memberIds = listOf("user-1", "user-2"),
+                shares = emptyList(),
+                memberProfiles = mapOf("user-1" to user1, "user-2" to user2)
+            )
+
+            // Ana < Andrés alphabetically
+            assertEquals("Ana", result[0].displayName)
+            assertEquals("Andrés", result[1].displayName)
+        }
+
+        @Test
+        fun `populates percentageInput from share percentage`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-1", amountCents = 5000L, percentage = BigDecimal("50.00"))
+            )
+
+            val result = mapper.buildInitialSplits(
+                memberIds = listOf("user-1"),
+                shares = shares
+            )
+
+            assertEquals("50.00", result[0].percentageInput)
+        }
+
+        @Test
+        fun `percentageInput is blank when share has no percentage`() {
+            val shares = listOf(ExpenseSplit(userId = "user-1", amountCents = 5000L, percentage = null))
+
+            val result = mapper.buildInitialSplits(
+                memberIds = listOf("user-1"),
+                shares = shares
+            )
+
+            assertEquals("", result[0].percentageInput)
+        }
+    }
+
+    // ── mapSplitsToDomain ─────────────────────────────────────────────────
+
+    @Nested
+    inner class MapSplitsToDomain {
+
+        @Test
+        fun `maps splits without percentages in EQUAL mode`() {
+            val splits = listOf(
+                SplitUiModel(userId = "user-1", displayName = "Andrés", amountCents = 5000L),
+                SplitUiModel(userId = "user-2", displayName = "Ana", amountCents = 5000L)
+            )
+
+            val result = mapper.mapSplitsToDomain(splits, SplitType.EQUAL)
+
+            assertEquals(2, result.size)
+            assertNull(result[0].percentage)
+            assertNull(result[1].percentage)
+        }
+
+        @Test
+        fun `maps splits with percentages in PERCENT mode`() {
+            val splits = listOf(
+                SplitUiModel(
+                    userId = "user-1",
+                    displayName = "Andrés",
+                    amountCents = 6000L,
+                    percentageInput = "60.00"
+                )
+            )
+
+            val result = mapper.mapSplitsToDomain(splits, SplitType.PERCENT)
+
+            assertEquals(1, result.size)
+            assertNotNull(result[0].percentage)
+        }
+
+        @Test
+        fun `excludes splits marked as excluded`() {
+            val splits = listOf(
+                SplitUiModel(userId = "user-1", displayName = "Andrés", amountCents = 10000L),
+                SplitUiModel(userId = "user-2", displayName = "Ana", amountCents = 0L, isExcluded = true)
+            )
+
+            val result = mapper.mapSplitsToDomain(splits, SplitType.EQUAL)
+
+            assertEquals(1, result.size)
+            assertEquals("user-1", result[0].userId)
+        }
+
+        @Test
+        fun `returns empty list when all splits are excluded`() {
+            val splits = listOf(
+                SplitUiModel(userId = "user-1", displayName = "Andrés", isExcluded = true)
+            )
+
+            val result = mapper.mapSplitsToDomain(splits, SplitType.EQUAL)
+
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        fun `preserves subunitId on each split`() {
+            val splits = listOf(
+                SplitUiModel(
+                    userId = "user-1",
+                    displayName = "Andrés",
+                    amountCents = 5000L,
+                    subunitId = "subunit-1"
+                )
+            )
+
+            val result = mapper.mapSplitsToDomain(splits, SplitType.EQUAL)
+
+            assertEquals("subunit-1", result[0].subunitId)
+        }
+    }
+
+    // ── mapDomainToSplits ─────────────────────────────────────────────────
+
+    @Nested
+    inner class MapDomainToSplits {
+
+        @Test
+        fun `maps domain splits back to UI models`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-1", amountCents = 5000L),
+                ExpenseSplit(userId = "user-2", amountCents = 5000L)
+            )
+
+            val result = mapper.mapDomainToSplits(
+                memberIds = listOf("user-1", "user-2"),
+                shares = shares,
+                memberProfiles = mapOf("user-1" to user1, "user-2" to user2)
+            )
+
+            assertEquals(2, result.size)
+            val ids = result.map { it.userId }
+            assertTrue(ids.contains("user-1"))
+            assertTrue(ids.contains("user-2"))
+        }
+
+        @Test
+        fun `marks member as excluded when not in domain splits`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-1", amountCents = 10000L)
+                // user-2 is NOT in shares → excluded
+            )
+
+            val result = mapper.mapDomainToSplits(
+                memberIds = listOf("user-1", "user-2"),
+                shares = shares
+            )
+
+            val user2Row = result.first { it.userId == "user-2" }
+            assertTrue(user2Row.isExcluded)
+        }
+
+        @Test
+        fun `marks member as not excluded when in domain splits`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-1", amountCents = 10000L)
+            )
+
+            val result = mapper.mapDomainToSplits(
+                memberIds = listOf("user-1"),
+                shares = shares
+            )
+
+            assertFalse(result[0].isExcluded)
+        }
+
+        @Test
+        fun `returns empty list for empty member IDs`() {
+            val result = mapper.mapDomainToSplits(
+                memberIds = emptyList(),
+                shares = emptyList()
+            )
+
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    // ── mapEntitySplitsToDomain ───────────────────────────────────────────
+
+    @Nested
+    inner class MapEntitySplitsToDomain {
+
+        @Test
+        fun `maps flat entity splits to domain splits in EQUAL mode`() {
+            val entitySplits = listOf(
+                SplitUiModel(
+                    userId = "user-1",
+                    displayName = "Andrés",
+                    amountCents = 5000L,
+                    isEntityRow = true
+                )
+            )
+
+            val result = mapper.mapEntitySplitsToDomain(entitySplits, SplitType.EQUAL)
+
+            assertTrue(result.isNotEmpty())
+        }
+
+        @Test
+        fun `returns empty list for empty entity splits`() {
+            val result = mapper.mapEntitySplitsToDomain(emptyList(), SplitType.EQUAL)
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    // ── buildEntitySplitsFromDomain ───────────────────────────────────────
+
+    @Nested
+    inner class BuildEntitySplitsFromDomain {
+
+        private val subunit = Subunit(
+            id = "sub-1",
+            groupId = "group-1",
+            name = "Couple",
+            memberIds = listOf("user-1", "user-2"),
+            memberShares = mapOf("user-1" to BigDecimal("50"), "user-2" to BigDecimal("50"))
+        )
+
+        private val availableSplitTypes = listOf(
+            SplitTypeUiModel(id = "EQUAL", displayText = "Equal"),
+            SplitTypeUiModel(id = "EXACT", displayText = "Exact"),
+            SplitTypeUiModel(id = "PERCENT", displayText = "Percent")
+        )
+
+        @Test
+        fun `builds entity rows for subunits`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-1", amountCents = 3000L, subunitId = "sub-1"),
+                ExpenseSplit(userId = "user-2", amountCents = 3000L, subunitId = "sub-1")
+            )
+
+            val result = mapper.buildEntitySplitsFromDomain(
+                memberIds = listOf("user-1", "user-2"),
+                subunits = listOf(subunit),
+                shares = shares,
+                availableSplitTypes = availableSplitTypes,
+                memberProfiles = mapOf("user-1" to user1, "user-2" to user2)
+            )
+
+            // Should have one entity row for the subunit
+            val subunitRow = result.firstOrNull { it.isEntityRow && it.userId == "sub-1" }
+            assertNotNull(subunitRow)
+            assertEquals("Couple", subunitRow!!.displayName)
+            assertEquals(2, subunitRow.entityMembers.size)
+        }
+
+        @Test
+        fun `marks subunit as excluded when no shares exist for it`() {
+            val result = mapper.buildEntitySplitsFromDomain(
+                memberIds = listOf("user-1", "user-2"),
+                subunits = listOf(subunit),
+                shares = emptyList(), // no shares → subunit excluded
+                availableSplitTypes = availableSplitTypes
+            )
+
+            val subunitRow = result.firstOrNull { it.isEntityRow && it.userId == "sub-1" }
+            assertNotNull(subunitRow)
+            assertTrue(subunitRow!!.isExcluded)
+        }
+
+        @Test
+        fun `builds solo member rows for members not in any subunit`() {
+            val shares = listOf(
+                ExpenseSplit(userId = "user-3", amountCents = 5000L)
+            )
+
+            val soloUser = User(userId = "user-3", email = "solo@test.com", displayName = "Solo")
+
+            val result = mapper.buildEntitySplitsFromDomain(
+                memberIds = listOf("user-1", "user-2", "user-3"),
+                subunits = listOf(subunit), // only user-1 and user-2 are in subunit
+                shares = shares,
+                availableSplitTypes = availableSplitTypes,
+                memberProfiles = mapOf("user-3" to soloUser)
+            )
+
+            val soloRow = result.firstOrNull { it.isEntityRow && it.userId == "user-3" }
+            assertNotNull(soloRow)
+        }
+
+        @Test
+        fun `returns empty list when no members and no subunits`() {
+            val result = mapper.buildEntitySplitsFromDomain(
+                memberIds = emptyList(),
+                subunits = emptyList(),
+                shares = emptyList(),
+                availableSplitTypes = availableSplitTypes
+            )
+
+            assertTrue(result.isEmpty())
+        }
+    }
+}

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapperTest.kt
@@ -10,6 +10,10 @@ import es.pedrazamiguez.splittrip.domain.enums.ExpenseCategory
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
+import es.pedrazamiguez.splittrip.domain.enums.SplitType
+import es.pedrazamiguez.splittrip.domain.model.AddOn
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.service.RemainderDistributionService
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnUiModel
@@ -17,13 +21,17 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.model.CategoryUi
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.FundingSourceUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentMethodUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentStatusUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.SplitTypeUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.EntitySplitFlattenDelegate
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
+import java.time.LocalDateTime
 import java.util.Locale
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -1011,6 +1019,291 @@ class AddExpenseUiMapperTest {
             val expense = result.getOrThrow()
             assertEquals(PayerType.GROUP, expense.payerType)
             assertNull(expense.payerId)
+        }
+    }
+
+    // ── Lookup state for mapExpenseToState tests ───────────────────────────
+
+    private val cashStatus = PaymentStatusUiModel(id = "FINISHED", displayText = "Paid")
+    private val scheduledStatus = PaymentStatusUiModel(id = "SCHEDULED", displayText = "Scheduled")
+    private val splitTypeEqual = SplitTypeUiModel(id = "EQUAL", displayText = "Equal")
+    private val groupFundingSource = FundingSourceUiModel(id = "GROUP", displayText = "Group Pocket")
+    private val travelCategory = CategoryUiModel(id = "TRANSPORT", displayText = "Transport")
+    private val foodCategory = CategoryUiModel(id = "FOOD", displayText = "Food")
+
+    /** Builds a state that contains all the look-up lists [mapExpenseToState] needs to resolve. */
+    private fun baseEditState() = AddExpenseUiState(
+        groupCurrency = eurUi,
+        availableCurrencies = persistentListOf(eurUi, usdUi),
+        paymentMethods = persistentListOf(cashPaymentMethod, creditCardPaymentMethod),
+        availablePaymentStatuses = persistentListOf(cashStatus, scheduledStatus),
+        availableSplitTypes = persistentListOf(splitTypeEqual),
+        availableCategories = persistentListOf(travelCategory, foodCategory),
+        fundingSources = persistentListOf(groupFundingSource)
+    )
+
+    @Nested
+    inner class MapExpenseToState {
+
+        @Test
+        fun `maps basic same-currency expense to UI state`() {
+            val expense = Expense(
+                id = "exp-1",
+                groupId = "group-1",
+                title = "Taxi",
+                sourceAmount = 1500L,
+                sourceCurrency = "EUR",
+                groupAmount = 1500L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                category = ExpenseCategory.TRANSPORT,
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals("Taxi", result.expenseTitle)
+            assertEquals("15", result.sourceAmount)
+            assertEquals("EUR", result.selectedCurrency?.code)
+            assertEquals(PaymentMethod.CASH.name, result.selectedPaymentMethod?.id)
+            assertEquals(PaymentStatus.FINISHED.name, result.selectedPaymentStatus?.id)
+            assertEquals(ExpenseCategory.TRANSPORT.name, result.selectedCategory?.id)
+            assertFalse(result.showExchangeRateSection)
+            assertNull(result.receiptAttachment)
+            assertFalse(result.isAiModeActive)
+        }
+
+        @Test
+        fun `maps cross-currency expense and sets exchange rate display`() {
+            val expense = Expense(
+                id = "exp-2",
+                groupId = "group-1",
+                title = "Hotel",
+                sourceAmount = 30000L,
+                sourceCurrency = "USD",
+                groupAmount = 27500L,
+                groupCurrency = "EUR",
+                // internalRate USD→EUR = 1/1.09 ≈ 0.9174; displayRate stored as inverse = 1.09
+                exchangeRate = BigDecimal("0.917431"),
+                paymentMethod = PaymentMethod.CREDIT_CARD,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals("Hotel", result.expenseTitle)
+            assertEquals("USD", result.selectedCurrency?.code)
+            assertTrue(result.showExchangeRateSection)
+            assertTrue(result.displayExchangeRate.isNotBlank())
+        }
+
+        @Test
+        fun `maps expense with SCHEDULED status and due date`() {
+            val dueDateTime = LocalDateTime.of(2026, 12, 31, 0, 0)
+            val expense = Expense(
+                id = "exp-3",
+                groupId = "group-1",
+                title = "Subscription",
+                sourceAmount = 999L,
+                sourceCurrency = "EUR",
+                groupAmount = 999L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                paymentMethod = PaymentMethod.CREDIT_CARD,
+                paymentStatus = PaymentStatus.SCHEDULED,
+                dueDate = dueDateTime,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals(PaymentStatus.SCHEDULED.name, result.selectedPaymentStatus?.id)
+            assertNotNull(result.dueDateMillis)
+            assertTrue(result.formattedDueDate.isNotBlank())
+            assertTrue(result.showDueDateSection)
+        }
+
+        @Test
+        fun `null due date for FINISHED expense leaves dueDate fields empty`() {
+            val expense = Expense(
+                id = "exp-4",
+                groupId = "group-1",
+                title = "Coffee",
+                sourceAmount = 350L,
+                sourceCurrency = "EUR",
+                groupAmount = 350L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertNull(result.dueDateMillis)
+            assertTrue(result.formattedDueDate.isEmpty())
+            assertFalse(result.showDueDateSection)
+        }
+
+        @Test
+        fun `contribution scope and subunitId are applied from contribution`() {
+            val expense = Expense(
+                id = "exp-5",
+                groupId = "group-1",
+                title = "Tour",
+                sourceAmount = 5000L,
+                sourceCurrency = "EUR",
+                groupAmount = 5000L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+            val contribution = Contribution(
+                contributionScope = PayerType.SUBUNIT,
+                subunitId = "subunit-42"
+            )
+
+            val result = mapper.mapExpenseToState(
+                expense,
+                contribution,
+                baseEditState(),
+                emptyMap(),
+                emptyList()
+            )
+
+            assertEquals(PayerType.SUBUNIT, result.contributionScope)
+            assertEquals("subunit-42", result.selectedContributionSubunitId)
+        }
+
+        @Test
+        fun `null contribution defaults scope to USER`() {
+            val expense = Expense(
+                id = "exp-6",
+                groupId = "group-1",
+                title = "Lunch",
+                sourceAmount = 1200L,
+                sourceCurrency = "EUR",
+                groupAmount = 1200L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals(PayerType.USER, result.contributionScope)
+            assertNull(result.selectedContributionSubunitId)
+        }
+
+        @Test
+        fun `maps add-ons from expense to state`() {
+            val addOn = AddOn(
+                id = "addon-1",
+                type = AddOnType.TIP,
+                mode = AddOnMode.ON_TOP,
+                valueType = AddOnValueType.EXACT,
+                amountCents = 500L,
+                currency = "EUR",
+                groupAmountCents = 500L,
+                paymentMethod = PaymentMethod.CASH
+            )
+            val expense = Expense(
+                id = "exp-7",
+                groupId = "group-1",
+                title = "Restaurant",
+                sourceAmount = 5000L,
+                sourceCurrency = "EUR",
+                groupAmount = 5500L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                addOns = listOf(addOn),
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals(1, result.addOns.size)
+            assertEquals("addon-1", result.addOns[0].id)
+            assertEquals(AddOnType.TIP, result.addOns[0].type)
+        }
+
+        @Test
+        fun `expense with zero exchange rate uses 1 dot 0 as display rate`() {
+            val expense = Expense(
+                id = "exp-8",
+                groupId = "group-1",
+                title = "Airport",
+                sourceAmount = 2000L,
+                sourceCurrency = "USD",
+                groupAmount = 2000L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ZERO,
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals("1.0", result.displayExchangeRate)
+        }
+
+        @Test
+        fun `maps vendor and notes when present`() {
+            val expense = Expense(
+                id = "exp-9",
+                groupId = "group-1",
+                title = "Supermarket",
+                sourceAmount = 3000L,
+                sourceCurrency = "EUR",
+                groupAmount = 3000L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                vendor = "Lidl",
+                notes = "Weekly groceries",
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals("Lidl", result.vendor)
+            assertEquals("Weekly groceries", result.notes)
+        }
+
+        @Test
+        fun `null vendor and notes map to empty strings`() {
+            val expense = Expense(
+                id = "exp-10",
+                groupId = "group-1",
+                title = "Bus",
+                sourceAmount = 200L,
+                sourceCurrency = "EUR",
+                groupAmount = 200L,
+                groupCurrency = "EUR",
+                exchangeRate = BigDecimal.ONE,
+                vendor = null,
+                notes = null,
+                paymentMethod = PaymentMethod.CASH,
+                paymentStatus = PaymentStatus.FINISHED,
+                splitType = SplitType.EQUAL
+            )
+
+            val result = mapper.mapExpenseToState(expense, null, baseEditState(), emptyMap(), emptyList())
+
+            assertEquals("", result.vendor)
+            assertEquals("", result.notes)
         }
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
+import es.pedrazamiguez.splittrip.domain.enums.AddOnType
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.enums.PaymentStatus
@@ -1614,6 +1615,216 @@ class AddExpenseViewModelTest {
 
             // Then — step unchanged
             assertEquals(stepBefore, viewModel.uiState.value.currentStep)
+        }
+    }
+
+    @Nested
+    inner class CurrencyInputEvents {
+
+        @Test
+        fun `ExchangeRateChanged delegates to currency handler and updates displayExchangeRate`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.ExchangeRateChanged("1.5"))
+            advanceUntilIdle()
+            assertEquals("1.5", viewModel.uiState.value.displayExchangeRate)
+        }
+
+        @Test
+        fun `GroupAmountChanged delegates to currency handler and updates calculatedGroupAmount`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.GroupAmountChanged("50"))
+            advanceUntilIdle()
+            assertEquals("50", viewModel.uiState.value.calculatedGroupAmount)
+        }
+    }
+
+    @Nested
+    inner class WithdrawalPoolSelectedEvents {
+
+        @Test
+        fun `WithdrawalPoolSelected with GROUP scope delegates and does not enable subunit mode`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.WithdrawalPoolSelected(PayerType.GROUP, null))
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isSubunitMode)
+        }
+
+        @Test
+        fun `WithdrawalPoolSelected with SUBUNIT scope applies subunit pool default`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.WithdrawalPoolSelected(PayerType.SUBUNIT, "sub-1"))
+            advanceUntilIdle()
+            // Routing verified — SUBUNIT branch was taken (no exception thrown)
+        }
+    }
+
+    @Nested
+    inner class SplitEvents {
+
+        @Test
+        fun `SplitTypeChanged delegates to split and subunit handlers`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SplitTypeChanged("EQUAL"))
+            advanceUntilIdle()
+            // Routing verified — no exception; selectedSplitType unaffected (no config loaded)
+        }
+
+        @Test
+        fun `SplitAmountChanged routes to split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SplitAmountChanged("user-1", "50"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `SplitPercentageChanged routes to split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SplitPercentageChanged("user-1", "30"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `SplitExcludedToggled routes to split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SplitExcludedToggled("user-1"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `SplitShareLockToggled routes to split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SplitShareLockToggled("user-1"))
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class EntitySplitAndIntraSubunitEvents {
+
+        @Test
+        fun `EntitySplitAmountChanged routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.EntitySplitAmountChanged("entity-1", "50"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `EntitySplitPercentageChanged routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.EntitySplitPercentageChanged("entity-1", "25"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `EntityShareLockToggled routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.EntityShareLockToggled("entity-1"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `IntraSubunitSplitTypeChanged routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.IntraSubunitSplitTypeChanged("sub-1", "EQUAL"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `IntraSubunitAmountChanged routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.IntraSubunitAmountChanged("sub-1", "user-1", "50"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `IntraSubunitPercentageChanged routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.IntraSubunitPercentageChanged("sub-1", "user-1", "25"))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `IntraSubunitShareLockToggled routes to subunit split handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.IntraSubunitShareLockToggled("sub-1", "user-1"))
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class AddOnEvents {
+
+        @Test
+        fun `AddOnAdded adds an add-on to the state`() = runTest {
+            val countBefore = viewModel.uiState.value.addOns.size
+
+            viewModel.onEvent(AddExpenseUiEvent.AddOnAdded(AddOnType.FEE))
+            advanceUntilIdle()
+
+            assertEquals(countBefore + 1, viewModel.uiState.value.addOns.size)
+        }
+
+        @Test
+        fun `AddOnRemoved routes to add-on handler`() = runTest {
+            // Add one first, then remove it
+            viewModel.onEvent(AddExpenseUiEvent.AddOnAdded(AddOnType.TIP))
+            advanceUntilIdle()
+            val addOnId = viewModel.uiState.value.addOns.first().id
+
+            viewModel.onEvent(AddExpenseUiEvent.AddOnRemoved(addOnId))
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.addOns.none { it.id == addOnId })
+        }
+
+        @Test
+        fun `AddOnTypeChanged routes to add-on handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.AddOnAdded(AddOnType.FEE))
+            advanceUntilIdle()
+            val addOnId = viewModel.uiState.value.addOns.first().id
+
+            viewModel.onEvent(AddExpenseUiEvent.AddOnTypeChanged(addOnId, AddOnType.TIP))
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `AddOnsSectionToggled routes to add-on handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.AddOnsSectionToggled)
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class ExpenseDateAndResolutionEvents {
+
+        @Test
+        fun `ExpenseDateSelected delegates to form handler and sets formatted date`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.ExpenseDateSelected(1716000000000L))
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.formattedExpenseDate.isNotBlank())
+        }
+
+        @Test
+        fun `ResolutionAmountSelected routes to form handler as source amount change`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.ResolutionAmountSelected("75"))
+            advanceUntilIdle()
+            assertEquals("75", viewModel.uiState.value.sourceAmount)
+        }
+    }
+
+    @Nested
+    inner class AiAutoFillEvents {
+
+        @Test
+        fun `SetAiModeActive true activates AI mode`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SetAiModeActive(true))
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.isAiModeActive)
+        }
+
+        @Test
+        fun `DismissAutoFillBanner delegates to receipt auto-fill handler`() = runTest {
+            viewModel.onEvent(AddExpenseUiEvent.SetAiModeActive(true))
+            advanceUntilIdle()
+
+            viewModel.onEvent(AddExpenseUiEvent.DismissAutoFillBanner)
+            advanceUntilIdle()
+            // Routing verified — no exception (handler deactivates AI mode or dismisses banner)
+        }
+    }
+
+    @Nested
+    inner class RefreshCashPreview {
+
+        @Test
+        fun `refreshCashPreview delegates to currency handler without throwing`() = runTest {
+            viewModel.refreshCashPreview()
+            advanceUntilIdle()
+            // Routing verified — previewCashExchangeRateUseCase is relaxed and won't throw
         }
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
@@ -24,18 +24,22 @@ import es.pedrazamiguez.splittrip.domain.service.RemainderDistributionService
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
 import es.pedrazamiguez.splittrip.domain.service.split.SplitPreviewService
 import es.pedrazamiguez.splittrip.domain.service.split.SubunitAwareSplitService
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.AttachReceiptUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.ExtractReceiptFieldsUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.GetGroupExpenseConfigUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.expense.PreviewCashExchangeRateUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCategoryUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedPaymentMethodUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedCategoryUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedPaymentMethodUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseAddOnUiMapper
@@ -61,6 +65,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handle
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubmitResultDelegate
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.SubunitSplitEventHandler
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategyFactory
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -269,7 +274,6 @@ class AddExpenseViewModelTest {
         )
 
         val submitHandler = SubmitEventHandler(
-            addExpenseUseCase = addExpenseUseCase,
             expenseValidationService = expenseValidationService,
             addOnCalculationService = AddOnCalculationService(),
             expenseCalculatorService = ExpenseCalculatorService(),
@@ -334,6 +338,22 @@ class AddExpenseViewModelTest {
             addExpenseUiMapper = addExpenseUiMapper
         )
 
+        val updateExpenseUseCase = mockk<UpdateExpenseUseCase>(relaxed = true)
+        val getExpenseByIdUseCase = mockk<GetExpenseByIdUseCase>(relaxed = true)
+        val getContributionByExpenseIdUseCase = mockk<GetContributionByExpenseIdUseCase>(relaxed = true)
+        val getGroupSubunitsUseCase = mockk<GetGroupSubunitsUseCase>(relaxed = true)
+
+        val strategyFactory = ExpenseFlowStrategyFactory(
+            configEventHandler = configHandler,
+            addExpenseUseCase = addExpenseUseCase,
+            updateExpenseUseCase = updateExpenseUseCase,
+            getExpenseByIdUseCase = getExpenseByIdUseCase,
+            getContributionByExpenseIdUseCase = getContributionByExpenseIdUseCase,
+            addExpenseUiMapper = addExpenseUiMapper,
+            getMemberProfilesUseCase = getMemberProfilesUseCase,
+            getGroupSubunitsUseCase = getGroupSubunitsUseCase
+        )
+
         viewModel = AddExpenseViewModel(
             configEventHandler = configHandler,
             currencyEventHandler = currencyHandler,
@@ -342,7 +362,8 @@ class AddExpenseViewModelTest {
             addOnEventHandler = addOnHandler,
             submitEventHandler = submitHandler,
             formEventHandler = formHandler,
-            receiptAutoFillEventHandler = receiptAutoFillEventHandler
+            receiptAutoFillEventHandler = receiptAutoFillEventHandler,
+            strategyFactory = strategyFactory
         )
     }
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandlerTest.kt
@@ -235,6 +235,19 @@ class ConfigEventHandlerTest {
         }
 
         @Test
+        fun `suspendLoadGroupConfig preserves isLoading as true on success when in edit mode`() = runTest {
+            uiState.value = AddExpenseUiState(isEditMode = true, isLoading = true)
+            handler.bind(uiState, actions, this)
+
+            handler.suspendLoadGroupConfig("group-1")
+
+            val state = uiState.value
+            assertTrue(state.isConfigLoaded)
+            assertTrue(state.isLoading)
+            assertFalse(state.configLoadFailed)
+        }
+
+        @Test
         fun `populates loadedGroupId and groupName`() = runTest {
             handler.bind(uiState, actions, this)
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ConfigEventHandlerTest.kt
@@ -223,6 +223,18 @@ class ConfigEventHandlerTest {
         }
 
         @Test
+        fun `suspendLoadGroupConfig sets isConfigLoaded true and clears isLoading on success`() = runTest {
+            handler.bind(uiState, actions, this)
+
+            handler.suspendLoadGroupConfig("group-1")
+
+            val state = uiState.value
+            assertTrue(state.isConfigLoaded)
+            assertFalse(state.isLoading)
+            assertFalse(state.configLoadFailed)
+        }
+
+        @Test
         fun `populates loadedGroupId and groupName`() = runTest {
             handler.bind(uiState, actions, this)
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
@@ -647,6 +647,26 @@ class SubmitEventHandlerTest {
         }
 
         @Test
+        fun `submit with null groupId parameter uses loadedGroupId from state`() = runTest(testDispatcher) {
+            handler.bind(stateFlow, actionsFlow, this)
+            stateFlow.value = AddExpenseUiState(
+                expenseTitle = "Dinner",
+                sourceAmount = "50",
+                loadedGroupId = "group-loaded"
+            )
+            val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
+            every { addExpenseUiMapper.mapToDomain(any(), "group-loaded") } returns Result.success(expense)
+            coEvery { strategy.saveExpense("group-loaded", any(), any()) } returns Result.success(Unit)
+
+            var successCalled = false
+            handler.submitExpense(null) { successCalled = true }
+            advanceUntilIdle()
+
+            assertTrue(successCalled)
+            assertFalse(stateFlow.value.isLoading)
+        }
+
+        @Test
         fun `use case failure clears loading without inline error`() = runTest(testDispatcher) {
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
@@ -30,7 +30,9 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -531,28 +533,48 @@ class SubmitEventHandlerTest {
 
         @Test
         fun `empty title sets isTitleValid false and error`() = runTest(testDispatcher) {
+            val actions = mutableListOf<AddExpenseUiAction>()
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                actionsFlow.collect { actions.add(it) }
+            }
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(expenseTitle = "", sourceAmount = "50")
 
             handler.submitExpense("group-1") {}
+            advanceUntilIdle()
 
             assertFalse(stateFlow.value.isTitleValid)
             assertNotNull(stateFlow.value.error)
+            assertEquals(1, actions.size)
+            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
+            collectJob.cancel()
         }
 
         @Test
         fun `invalid amount sets isAmountValid false and error`() = runTest(testDispatcher) {
+            val actions = mutableListOf<AddExpenseUiAction>()
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                actionsFlow.collect { actions.add(it) }
+            }
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(expenseTitle = "Dinner", sourceAmount = "")
 
             handler.submitExpense("group-1") {}
+            advanceUntilIdle()
 
             assertFalse(stateFlow.value.isAmountValid)
             assertNotNull(stateFlow.value.error)
+            assertEquals(1, actions.size)
+            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
+            collectJob.cancel()
         }
 
         @Test
         fun `SCHEDULED with no dueDate sets isDueDateValid false`() = runTest(testDispatcher) {
+            val actions = mutableListOf<AddExpenseUiAction>()
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                actionsFlow.collect { actions.add(it) }
+            }
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(
                 expenseTitle = "Dinner",
@@ -565,13 +587,21 @@ class SubmitEventHandlerTest {
             )
 
             handler.submitExpense("group-1") {}
+            advanceUntilIdle()
 
             assertFalse(stateFlow.value.isDueDateValid)
             assertNotNull(stateFlow.value.error)
+            assertEquals(1, actions.size)
+            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
+            collectJob.cancel()
         }
 
         @Test
         fun `future expense date sets isExpenseDateValid false and error`() = runTest(testDispatcher) {
+            val actions = mutableListOf<AddExpenseUiAction>()
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                actionsFlow.collect { actions.add(it) }
+            }
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(
                 expenseTitle = "Dinner",
@@ -580,13 +610,21 @@ class SubmitEventHandlerTest {
             )
 
             handler.submitExpense("group-1") {}
+            advanceUntilIdle()
 
             assertFalse(stateFlow.value.isExpenseDateValid)
             assertNotNull(stateFlow.value.error)
+            assertEquals(1, actions.size)
+            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
+            collectJob.cancel()
         }
 
         @Test
         fun `add-on with zero resolved amount sets addOnError`() = runTest(testDispatcher) {
+            val actions = mutableListOf<AddExpenseUiAction>()
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                actionsFlow.collect { actions.add(it) }
+            }
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(
                 expenseTitle = "Dinner",
@@ -605,12 +643,20 @@ class SubmitEventHandlerTest {
             )
 
             handler.submitExpense("group-1") {}
+            advanceUntilIdle()
 
             assertNotNull(stateFlow.value.addOnError)
+            assertEquals(1, actions.size)
+            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
+            collectJob.cancel()
         }
 
         @Test
         fun `mapper failure sets error and clears loading`() = runTest(testDispatcher) {
+            val actions = mutableListOf<AddExpenseUiAction>()
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                actionsFlow.collect { actions.add(it) }
+            }
             handler.bind(stateFlow, actionsFlow, this)
             stateFlow.value = AddExpenseUiState(
                 expenseTitle = "Dinner",
@@ -625,6 +671,9 @@ class SubmitEventHandlerTest {
 
             assertFalse(stateFlow.value.isLoading)
             assertNotNull(stateFlow.value.error)
+            assertEquals(1, actions.size)
+            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
+            collectJob.cancel()
         }
 
         @Test

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
@@ -15,7 +15,6 @@ import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseValidationService
 import es.pedrazamiguez.splittrip.domain.service.RemainderDistributionService
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
-import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentStatusUiModel
@@ -57,7 +56,8 @@ import org.junit.jupiter.api.Test
 class SubmitEventHandlerTest {
 
     private lateinit var handler: SubmitEventHandler
-    private lateinit var addExpenseUseCase: AddExpenseUseCase
+    private lateinit var strategy:
+        es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategy
     private lateinit var addExpenseUiMapper: AddExpenseUiMapper
 
     /** A minimal [Expense] stub — only the fields used by adjustForIncludedAddOns matter. */
@@ -83,7 +83,7 @@ class SubmitEventHandlerTest {
 
     @BeforeEach
     fun setUp() {
-        addExpenseUseCase = mockk(relaxed = true)
+        strategy = mockk(relaxed = true)
         addExpenseUiMapper = mockk(relaxed = true)
         val splitCalculatorFactory = ExpenseSplitCalculatorFactory(ExpenseCalculatorService())
         val saveLastUsedPreferences = SaveLastUsedPreferencesBundle(
@@ -94,7 +94,6 @@ class SubmitEventHandlerTest {
         val formattingHelper = mockk<FormattingHelper>(relaxed = true)
 
         handler = SubmitEventHandler(
-            addExpenseUseCase = addExpenseUseCase,
             expenseValidationService = ExpenseValidationService(splitCalculatorFactory),
             addOnCalculationService = AddOnCalculationService(),
             expenseCalculatorService = ExpenseCalculatorService(),
@@ -104,7 +103,9 @@ class SubmitEventHandlerTest {
                 saveLastUsedPreferences = saveLastUsedPreferences,
                 formattingHelper = formattingHelper
             )
-        )
+        ).apply {
+            setStrategy(strategy)
+        }
     }
 
     // ── No INCLUDED add-ons ──────────────────────────────────────────────────
@@ -635,7 +636,7 @@ class SubmitEventHandlerTest {
             )
             val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
             every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
-            coEvery { addExpenseUseCase(any(), any()) } returns Result.success(Unit)
+            coEvery { strategy.saveExpense(any(), any(), any()) } returns Result.success(Unit)
 
             var successCalled = false
             handler.submitExpense("group-1") { successCalled = true }
@@ -654,7 +655,7 @@ class SubmitEventHandlerTest {
             )
             val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
             every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
-            coEvery { addExpenseUseCase(any(), any()) } returns Result.failure(
+            coEvery { strategy.saveExpense(any(), any(), any()) } returns Result.failure(
                 RuntimeException("Network error")
             )
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategyTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/EditExpenseFlowStrategyTest.kt
@@ -1,0 +1,373 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy
+
+import es.pedrazamiguez.splittrip.domain.enums.PayerType
+import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.model.Subunit
+import es.pedrazamiguez.splittrip.domain.model.User
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.model.WithdrawalPoolOptionUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.ConfigEventHandler
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseStep
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditExpenseFlowStrategyTest {
+
+    private val expenseId = "expense-42"
+    private val groupId = "group-1"
+
+    private lateinit var configEventHandler: ConfigEventHandler
+    private lateinit var getExpenseByIdUseCase: GetExpenseByIdUseCase
+    private lateinit var getContributionByExpenseIdUseCase: GetContributionByExpenseIdUseCase
+    private lateinit var updateExpenseUseCase: UpdateExpenseUseCase
+    private lateinit var addExpenseUiMapper: AddExpenseUiMapper
+    private lateinit var getMemberProfilesUseCase: GetMemberProfilesUseCase
+    private lateinit var getGroupSubunitsUseCase: GetGroupSubunitsUseCase
+    private lateinit var strategy: EditExpenseFlowStrategy
+
+    private lateinit var uiState: MutableStateFlow<AddExpenseUiState>
+    private lateinit var actions: MutableSharedFlow<AddExpenseUiAction>
+
+    private val sampleExpense = Expense(
+        id = expenseId,
+        title = "Dinner",
+        sourceAmount = 5000L,
+        sourceCurrency = "EUR",
+        groupAmount = 5000L,
+        groupCurrency = "EUR",
+        paymentMethod = PaymentMethod.CREDIT_CARD
+    )
+
+    @BeforeEach
+    fun setUp() {
+        configEventHandler = mockk(relaxed = true)
+        getExpenseByIdUseCase = mockk()
+        getContributionByExpenseIdUseCase = mockk()
+        updateExpenseUseCase = mockk()
+        addExpenseUiMapper = mockk()
+        getMemberProfilesUseCase = mockk()
+        getGroupSubunitsUseCase = mockk()
+
+        strategy = EditExpenseFlowStrategy(
+            expenseId = expenseId,
+            configEventHandler = configEventHandler,
+            getExpenseByIdUseCase = getExpenseByIdUseCase,
+            getContributionByExpenseIdUseCase = getContributionByExpenseIdUseCase,
+            updateExpenseUseCase = updateExpenseUseCase,
+            addExpenseUiMapper = addExpenseUiMapper,
+            getMemberProfilesUseCase = getMemberProfilesUseCase,
+            getGroupSubunitsUseCase = getGroupSubunitsUseCase
+        )
+
+        uiState = MutableStateFlow(AddExpenseUiState())
+        actions = MutableSharedFlow(extraBufferCapacity = 8)
+    }
+
+    // ── Metadata contract ─────────────────────────────────────────────────────
+
+    @Test
+    fun `strategy exposes edit-mode metadata`() {
+        assertTrue(strategy.isEditMode)
+        assertEquals(AddExpenseStep.TITLE, strategy.startStep)
+        assertTrue(strategy.screenTitleRes != 0)
+        assertTrue(strategy.submitLabelRes != 0)
+    }
+
+    // ── loadInitialData ───────────────────────────────────────────────────────
+
+    @Nested
+    inner class LoadInitialData {
+
+        @Test
+        fun `does nothing when groupId is null`() = runTest {
+            var onLoadedCalled = false
+            strategy.loadInitialData(
+                groupId = null,
+                uiState = uiState,
+                actions = actions,
+                scope = this,
+                onConfigLoaded = { onLoadedCalled = true }
+            )
+            advanceUntilIdle()
+
+            assertFalse(onLoadedCalled)
+            coVerify(exactly = 0) { configEventHandler.suspendLoadGroupConfig(any(), any()) }
+            coVerify(exactly = 0) { getExpenseByIdUseCase(any()) }
+        }
+
+        @Test
+        fun `flags configLoadFailed when expense is not found`() = runTest {
+            coEvery { configEventHandler.suspendLoadGroupConfig(groupId, false) } just Runs
+            coEvery { getExpenseByIdUseCase(expenseId) } returns null
+
+            var onLoadedCalled = false
+            strategy.loadInitialData(
+                groupId = groupId,
+                uiState = uiState,
+                actions = actions,
+                scope = this,
+                onConfigLoaded = { onLoadedCalled = true }
+            )
+            advanceUntilIdle()
+
+            assertFalse(onLoadedCalled)
+            assertTrue(uiState.value.configLoadFailed)
+            assertFalse(uiState.value.isLoading)
+            // Should NOT invoke downstream mappers/use cases when expense missing
+            coVerify(exactly = 0) { getMemberProfilesUseCase(any()) }
+            coVerify(exactly = 0) { addExpenseUiMapper.mapExpenseToState(any(), any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `loads config, expense, contribution, members and subunits on success`() = runTest {
+            val contribution = mockk<Contribution>(relaxed = true)
+            val memberProfiles = emptyMap<String, User>()
+            val subunits = listOf<Subunit>()
+            val mappedState = AddExpenseUiState(currentStep = AddExpenseStep.REVIEW)
+
+            coEvery { configEventHandler.suspendLoadGroupConfig(groupId, false) } just Runs
+            coEvery { getExpenseByIdUseCase(expenseId) } returns sampleExpense
+            coEvery { getContributionByExpenseIdUseCase(groupId, expenseId) } returns contribution
+            coEvery { getMemberProfilesUseCase(any()) } returns memberProfiles
+            coEvery { getGroupSubunitsUseCase(groupId) } returns subunits
+            every {
+                addExpenseUiMapper.mapExpenseToState(
+                    expense = any(),
+                    contribution = any(),
+                    currentState = any(),
+                    memberProfiles = any(),
+                    subunits = any()
+                )
+            } returns mappedState
+
+            var onLoadedCalled = false
+            strategy.loadInitialData(
+                groupId = groupId,
+                uiState = uiState,
+                actions = actions,
+                scope = this,
+                onConfigLoaded = { onLoadedCalled = true }
+            )
+            advanceUntilIdle()
+
+            assertTrue(onLoadedCalled)
+            assertTrue(uiState.value.isConfigLoaded)
+            assertFalse(uiState.value.isLoading)
+            assertTrue(uiState.value.isEditMode)
+            assertFalse(uiState.value.configLoadFailed)
+            assertEquals(AddExpenseStep.TITLE, uiState.value.currentStep)
+            assertFalse(uiState.value.isAiModeActive)
+
+            coVerify(exactly = 1) { configEventHandler.suspendLoadGroupConfig(groupId, false) }
+            coVerify(exactly = 1) { getExpenseByIdUseCase(expenseId) }
+            coVerify(exactly = 1) { getContributionByExpenseIdUseCase(groupId, expenseId) }
+            coVerify(exactly = 1) { getMemberProfilesUseCase(any()) }
+            coVerify(exactly = 1) { getGroupSubunitsUseCase(groupId) }
+        }
+
+        @Test
+        fun `propagates forceRefresh to ConfigEventHandler`() = runTest {
+            coEvery { configEventHandler.suspendLoadGroupConfig(groupId, true) } just Runs
+            coEvery { getExpenseByIdUseCase(expenseId) } returns null
+
+            strategy.loadInitialData(
+                groupId = groupId,
+                uiState = uiState,
+                actions = actions,
+                scope = this,
+                forceRefresh = true,
+                onConfigLoaded = { }
+            )
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { configEventHandler.suspendLoadGroupConfig(groupId, true) }
+        }
+
+        @Test
+        fun `flags configLoadFailed when an exception is thrown`() = runTest {
+            coEvery {
+                configEventHandler.suspendLoadGroupConfig(any(), any())
+            } throws RuntimeException("boom")
+
+            var onLoadedCalled = false
+            strategy.loadInitialData(
+                groupId = groupId,
+                uiState = uiState,
+                actions = actions,
+                scope = this,
+                onConfigLoaded = { onLoadedCalled = true }
+            )
+            advanceUntilIdle()
+
+            assertFalse(onLoadedCalled)
+            assertTrue(uiState.value.configLoadFailed)
+            assertFalse(uiState.value.isLoading)
+        }
+    }
+
+    // ── saveExpense ───────────────────────────────────────────────────────────
+
+    @Nested
+    inner class SaveExpense {
+
+        @Test
+        fun `forwards expense with strategy expenseId to UpdateExpenseUseCase`() = runTest {
+            val expenseFromUi = sampleExpense.copy(id = "stale-id-from-ui")
+            val state = AddExpenseUiState(contributionScope = PayerType.USER)
+            val expenseSlot = slot<Expense>()
+            coEvery {
+                updateExpenseUseCase(
+                    groupId = any(),
+                    expense = capture(expenseSlot),
+                    pairedContributionScope = any(),
+                    pairedSubunitId = any(),
+                    preferredWithdrawalScope = any(),
+                    preferredWithdrawalOwnerId = any()
+                )
+            } returns Result.success(Unit)
+
+            val result = strategy.saveExpense(groupId, expenseFromUi, state)
+
+            assertTrue(result.isSuccess)
+            assertEquals(expenseId, expenseSlot.captured.id)
+        }
+
+        @Test
+        fun `forwards SUBUNIT contribution scope with selected subunit id`() = runTest {
+            val state = AddExpenseUiState(
+                contributionScope = PayerType.SUBUNIT,
+                selectedContributionSubunitId = "subunit-7"
+            )
+            coEvery {
+                updateExpenseUseCase(any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
+
+            strategy.saveExpense(groupId, sampleExpense, state)
+
+            coVerify(exactly = 1) {
+                updateExpenseUseCase(
+                    groupId = groupId,
+                    expense = any(),
+                    pairedContributionScope = PayerType.SUBUNIT,
+                    pairedSubunitId = "subunit-7",
+                    preferredWithdrawalScope = any(),
+                    preferredWithdrawalOwnerId = any()
+                )
+            }
+        }
+
+        @Test
+        fun `nullifies pairedSubunitId when scope is USER`() = runTest {
+            val state = AddExpenseUiState(
+                contributionScope = PayerType.USER,
+                selectedContributionSubunitId = "stale-subunit"
+            )
+            coEvery {
+                updateExpenseUseCase(any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
+
+            strategy.saveExpense(groupId, sampleExpense, state)
+
+            coVerify(exactly = 1) {
+                updateExpenseUseCase(
+                    groupId = groupId,
+                    expense = any(),
+                    pairedContributionScope = PayerType.USER,
+                    pairedSubunitId = null,
+                    preferredWithdrawalScope = any(),
+                    preferredWithdrawalOwnerId = any()
+                )
+            }
+        }
+
+        @Test
+        fun `forwards selected withdrawal pool scope and owner`() = runTest {
+            val pool = WithdrawalPoolOptionUiModel(
+                scope = PayerType.USER,
+                ownerId = "user-9",
+                displayLabel = "User pool"
+            )
+            val state = AddExpenseUiState(
+                contributionScope = PayerType.USER,
+                selectedWithdrawalPool = pool
+            )
+            coEvery {
+                updateExpenseUseCase(any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
+
+            strategy.saveExpense(groupId, sampleExpense, state)
+
+            coVerify(exactly = 1) {
+                updateExpenseUseCase(
+                    groupId = groupId,
+                    expense = any(),
+                    pairedContributionScope = any(),
+                    pairedSubunitId = any(),
+                    preferredWithdrawalScope = PayerType.USER,
+                    preferredWithdrawalOwnerId = "user-9"
+                )
+            }
+        }
+
+        @Test
+        fun `passes null withdrawal pool scope and owner when none selected`() = runTest {
+            val state = AddExpenseUiState(selectedWithdrawalPool = null)
+            coEvery {
+                updateExpenseUseCase(any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
+
+            strategy.saveExpense(groupId, sampleExpense, state)
+
+            coVerify(exactly = 1) {
+                updateExpenseUseCase(
+                    groupId = groupId,
+                    expense = any(),
+                    pairedContributionScope = any(),
+                    pairedSubunitId = any(),
+                    preferredWithdrawalScope = null,
+                    preferredWithdrawalOwnerId = null
+                )
+            }
+        }
+
+        @Test
+        fun `propagates failure result from UpdateExpenseUseCase`() = runTest {
+            val state = AddExpenseUiState()
+            val failure = Result.failure<Unit>(IllegalStateException("nope"))
+            coEvery {
+                updateExpenseUseCase(any(), any(), any(), any(), any(), any())
+            } returns failure
+
+            val result = strategy.saveExpense(groupId, sampleExpense, state)
+
+            assertTrue(result.isFailure)
+            assertEquals("nope", result.exceptionOrNull()?.message)
+        }
+    }
+}

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/ExpenseFlowStrategyFactoryTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/strategy/ExpenseFlowStrategyFactoryTest.kt
@@ -1,0 +1,59 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy
+
+import es.pedrazamiguez.splittrip.domain.usecase.balance.GetContributionByExpenseIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.AddExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.GetExpenseByIdUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.expense.UpdateExpenseUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.subunit.GetGroupSubunitsUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.user.GetMemberProfilesUseCase
+import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler.ConfigEventHandler
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ExpenseFlowStrategyFactoryTest {
+
+    private lateinit var factory: ExpenseFlowStrategyFactory
+
+    @BeforeEach
+    fun setUp() {
+        factory = ExpenseFlowStrategyFactory(
+            configEventHandler = mockk<ConfigEventHandler>(relaxed = true),
+            addExpenseUseCase = mockk<AddExpenseUseCase>(relaxed = true),
+            updateExpenseUseCase = mockk<UpdateExpenseUseCase>(relaxed = true),
+            getExpenseByIdUseCase = mockk<GetExpenseByIdUseCase>(relaxed = true),
+            getContributionByExpenseIdUseCase = mockk<GetContributionByExpenseIdUseCase>(relaxed = true),
+            addExpenseUiMapper = mockk<AddExpenseUiMapper>(relaxed = true),
+            getMemberProfilesUseCase = mockk<GetMemberProfilesUseCase>(relaxed = true),
+            getGroupSubunitsUseCase = mockk<GetGroupSubunitsUseCase>(relaxed = true)
+        )
+    }
+
+    @Test
+    fun `create with non-blank expenseId returns EditExpenseFlowStrategy`() {
+        val strategy = factory.create(expenseId = "expense-1")
+        assertTrue(strategy is EditExpenseFlowStrategy)
+        assertTrue(strategy.isEditMode)
+    }
+
+    @Test
+    fun `create with null expenseId returns AddExpenseFlowStrategy`() {
+        val strategy = factory.create(expenseId = null)
+        assertTrue(strategy is AddExpenseFlowStrategy)
+        assertTrue(!strategy.isEditMode)
+    }
+
+    @Test
+    fun `create with empty expenseId returns AddExpenseFlowStrategy`() {
+        val strategy = factory.create(expenseId = "")
+        assertTrue(strategy is AddExpenseFlowStrategy)
+    }
+
+    @Test
+    fun `create with blank expenseId returns AddExpenseFlowStrategy`() {
+        val strategy = factory.create(expenseId = "   ")
+        assertTrue(strategy is AddExpenseFlowStrategy)
+    }
+}

--- a/features/groups/src/test/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/viewmodel/state/CreateGroupUiStateTest.kt
+++ b/features/groups/src/test/kotlin/es/pedrazamiguez/splittrip/features/group/presentation/viewmodel/state/CreateGroupUiStateTest.kt
@@ -1,0 +1,211 @@
+package es.pedrazamiguez.splittrip.features.group.presentation.viewmodel.state
+
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CreateGroupUiStateTest {
+
+    private val eurCurrency = CurrencyUiModel(
+        code = "EUR",
+        displayText = "EUR (€)",
+        decimalDigits = 2
+    )
+
+    // ── steps / currentStepIndex ──────────────────────────────────────────
+
+    @Nested
+    inner class StepsAndIndex {
+
+        @Test
+        fun `steps contains all CreateGroupStep entries`() {
+            val state = CreateGroupUiState()
+            assertEquals(CreateGroupStep.entries, state.steps)
+        }
+
+        @Test
+        fun `currentStepIndex returns 0 for INFO (default)`() {
+            val state = CreateGroupUiState()
+            assertEquals(0, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns correct index for CURRENCY`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.CURRENCY)
+            assertEquals(1, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns correct index for MEMBERS`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.MEMBERS)
+            assertEquals(2, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns correct index for REVIEW`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.REVIEW)
+            assertEquals(3, state.currentStepIndex)
+        }
+    }
+
+    // ── canGoNext ─────────────────────────────────────────────────────────
+
+    @Nested
+    inner class CanGoNext {
+
+        @Test
+        fun `canGoNext is true on INFO step`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.INFO)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is true on CURRENCY step`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.CURRENCY)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is true on MEMBERS step`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.MEMBERS)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is false on REVIEW step (last)`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.REVIEW)
+            assertFalse(state.canGoNext)
+        }
+    }
+
+    // ── isOnReviewStep ────────────────────────────────────────────────────
+
+    @Nested
+    inner class IsOnReviewStep {
+
+        @Test
+        fun `isOnReviewStep is true when on REVIEW`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.REVIEW)
+            assertTrue(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on INFO`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.INFO)
+            assertFalse(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on CURRENCY`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.CURRENCY)
+            assertFalse(state.isOnReviewStep)
+        }
+    }
+
+    // ── isCurrentStepValid ────────────────────────────────────────────────
+
+    @Nested
+    inner class IsCurrentStepValid {
+
+        @Test
+        fun `INFO step is valid when groupName is not blank and isNameValid`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.INFO,
+                groupName = "My Trip",
+                isNameValid = true
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `INFO step is invalid when groupName is blank`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.INFO,
+                groupName = "",
+                isNameValid = true
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `INFO step is invalid when isNameValid is false`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.INFO,
+                groupName = "Taken Name",
+                isNameValid = false
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `CURRENCY step is valid when currency is selected`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.CURRENCY,
+                selectedCurrency = eurCurrency
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `CURRENCY step is invalid when no currency selected`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.CURRENCY,
+                selectedCurrency = null
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `MEMBERS step is always valid`() {
+            val state = CreateGroupUiState(currentStep = CreateGroupStep.MEMBERS)
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is valid when name is not blank, isNameValid, and currency selected`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.REVIEW,
+                groupName = "Berlin Trip",
+                isNameValid = true,
+                selectedCurrency = eurCurrency
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when groupName is blank`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.REVIEW,
+                groupName = "",
+                isNameValid = true,
+                selectedCurrency = eurCurrency
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when no currency selected`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.REVIEW,
+                groupName = "My Trip",
+                isNameValid = true,
+                selectedCurrency = null
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when isNameValid is false`() {
+            val state = CreateGroupUiState(
+                currentStep = CreateGroupStep.REVIEW,
+                groupName = "Taken",
+                isNameValid = false,
+                selectedCurrency = eurCurrency
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+    }
+}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/di/SettingsUiModule.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/di/SettingsUiModule.kt
@@ -2,7 +2,7 @@ package es.pedrazamiguez.splittrip.features.settings.di
 
 import android.app.Application
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.screen.ScreenUiProvider
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import es.pedrazamiguez.splittrip.domain.service.CloudMetadataService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptOcrService
@@ -55,7 +55,7 @@ val settingsUiModule = module {
         DeveloperServicesViewModel(
             receiptOcrService = get<ReceiptOcrService>(),
             receiptExtractionService = get<ReceiptExtractionService>(),
-            aiModelResolver = get<AiModelResolver>()
+            aiModelResolver = get<AiModelResolverService>()
         )
     }
 

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModel.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModel.kt
@@ -8,7 +8,7 @@ import es.pedrazamiguez.splittrip.domain.model.ExtractionConfidence
 import es.pedrazamiguez.splittrip.domain.model.ExtractionSource
 import es.pedrazamiguez.splittrip.domain.model.RawReceiptText
 import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptOcrService
 import es.pedrazamiguez.splittrip.features.settings.R
@@ -86,7 +86,7 @@ sealed interface DeveloperServicesUiEvent {
 class DeveloperServicesViewModel(
     private val receiptOcrService: ReceiptOcrService,
     private val receiptExtractionService: ReceiptExtractionService,
-    private val aiModelResolver: AiModelResolver
+    private val aiModelResolver: AiModelResolverService
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DeveloperServicesUiState())

--- a/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModelTest.kt
+++ b/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/DeveloperServicesViewModelTest.kt
@@ -7,7 +7,7 @@ import es.pedrazamiguez.splittrip.domain.model.ExtractionConfidence
 import es.pedrazamiguez.splittrip.domain.model.ExtractionSource
 import es.pedrazamiguez.splittrip.domain.model.RawReceiptText
 import es.pedrazamiguez.splittrip.domain.model.TextBlock
-import es.pedrazamiguez.splittrip.domain.service.AiModelResolver
+import es.pedrazamiguez.splittrip.domain.service.AiModelResolverService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptExtractionService
 import es.pedrazamiguez.splittrip.domain.service.ReceiptOcrService
 import io.mockk.clearAllMocks
@@ -42,7 +42,7 @@ class DeveloperServicesViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var receiptOcrService: ReceiptOcrService
     private lateinit var receiptExtractionService: ReceiptExtractionService
-    private lateinit var aiModelResolver: AiModelResolver
+    private lateinit var aiModelResolver: AiModelResolverService
     private val activeEngineFlow = MutableStateFlow(AiEngineType.AI_CORE_GEMMA_4)
     private val overrideEngineFlow = MutableStateFlow<AiEngineType?>(null)
 

--- a/features/subunits/src/test/kotlin/es/pedrazamiguez/splittrip/features/subunit/presentation/viewmodel/state/CreateEditSubunitUiStateTest.kt
+++ b/features/subunits/src/test/kotlin/es/pedrazamiguez/splittrip/features/subunit/presentation/viewmodel/state/CreateEditSubunitUiStateTest.kt
@@ -1,0 +1,194 @@
+package es.pedrazamiguez.splittrip.features.subunit.presentation.viewmodel.state
+
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CreateEditSubunitUiStateTest {
+
+    // ── steps / currentStepIndex ──────────────────────────────────────────
+
+    @Nested
+    inner class StepsAndIndex {
+
+        @Test
+        fun `steps contains all CreateEditSubunitStep entries`() {
+            val state = CreateEditSubunitUiState()
+            assertEquals(CreateEditSubunitStep.entries, state.steps)
+        }
+
+        @Test
+        fun `currentStepIndex returns 0 for NAME (default)`() {
+            val state = CreateEditSubunitUiState()
+            assertEquals(0, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns 1 for MEMBERS`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.MEMBERS)
+            assertEquals(1, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns 2 for SHARES`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.SHARES)
+            assertEquals(2, state.currentStepIndex)
+        }
+
+        @Test
+        fun `currentStepIndex returns 3 for REVIEW`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.REVIEW)
+            assertEquals(3, state.currentStepIndex)
+        }
+    }
+
+    // ── canGoNext ─────────────────────────────────────────────────────────
+
+    @Nested
+    inner class CanGoNext {
+
+        @Test
+        fun `canGoNext is true on NAME step`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.NAME)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is true on MEMBERS step`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.MEMBERS)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is true on SHARES step`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.SHARES)
+            assertTrue(state.canGoNext)
+        }
+
+        @Test
+        fun `canGoNext is false on REVIEW step (last)`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.REVIEW)
+            assertFalse(state.canGoNext)
+        }
+    }
+
+    // ── isOnReviewStep ────────────────────────────────────────────────────
+
+    @Nested
+    inner class IsOnReviewStep {
+
+        @Test
+        fun `isOnReviewStep is true when on REVIEW`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.REVIEW)
+            assertTrue(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on NAME`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.NAME)
+            assertFalse(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on MEMBERS`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.MEMBERS)
+            assertFalse(state.isOnReviewStep)
+        }
+
+        @Test
+        fun `isOnReviewStep is false when on SHARES`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.SHARES)
+            assertFalse(state.isOnReviewStep)
+        }
+    }
+
+    // ── isCurrentStepValid ────────────────────────────────────────────────
+
+    @Nested
+    inner class IsCurrentStepValid {
+
+        @Test
+        fun `NAME step is valid when name is not blank`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.NAME,
+                name = "Couple"
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `NAME step is invalid when name is blank`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.NAME,
+                name = ""
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `NAME step is invalid when name is whitespace only`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.NAME,
+                name = "   "
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `MEMBERS step is valid when at least one member is selected`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.MEMBERS,
+                selectedMemberIds = persistentListOf("user-1")
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `MEMBERS step is invalid when no members selected`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.MEMBERS,
+                selectedMemberIds = persistentListOf()
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `SHARES step is always valid`() {
+            val state = CreateEditSubunitUiState(currentStep = CreateEditSubunitStep.SHARES)
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is valid when name is not blank and members are selected`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.REVIEW,
+                name = "Couple",
+                selectedMemberIds = persistentListOf("user-1", "user-2")
+            )
+            assertTrue(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when name is blank`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.REVIEW,
+                name = "",
+                selectedMemberIds = persistentListOf("user-1")
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+
+        @Test
+        fun `REVIEW step is invalid when no members selected`() {
+            val state = CreateEditSubunitUiState(
+                currentStep = CreateEditSubunitStep.REVIEW,
+                name = "Couple",
+                selectedMemberIds = persistentListOf()
+            )
+            assertFalse(state.isCurrentStepValid)
+        }
+    }
+}

--- a/konsist-tests/src/test/kotlin/es/pedrazamiguez/splittrip/konsist/ArchitectureTest.kt
+++ b/konsist-tests/src/test/kotlin/es/pedrazamiguez/splittrip/konsist/ArchitectureTest.kt
@@ -46,7 +46,44 @@ class ArchitectureTest {
                 // distribution helpers that are co-located for cohesion but are NOT use cases
                 // (e.g. WithdrawalResult, ExpenseResult, BalanceAttribution helpers).
                 .filter { !it.resideInPackage("..domain.usecase..support") }
+                // Exclude the .strategy subpackage — it holds Strategy-pattern implementations
+                // (e.g. PersistExpenseStrategy, BasePersistExpenseStrategy) that are internal
+                // collaborators of use cases, not use cases themselves.
+                .filter { !it.resideInPackage("..domain.usecase..strategy") }
+                // Exclude the .factory subpackage — it holds Factory classes that create strategy
+                // instances (e.g. PersistExpenseStrategyFactory). Factories use their own suffix.
+                .filter { !it.resideInPackage("..domain.usecase..factory") }
                 .assertTrue { it.hasNameEndingWith("UseCase") }
+        }
+
+        @Test
+        @DisplayName("Factory packages must exist and classes residing in them must end with 'Factory'")
+        fun `classes residing in factory packages must end with Factory`() {
+            val factoryClasses = (projectProductionScope.classes() + projectProductionScope.interfaces())
+                .filter { it.resideInPackage("..domain.usecase..factory..") }
+                .filter { it.isTopLevel }
+
+            Assertions.assertTrue(
+                factoryClasses.isNotEmpty(),
+                "Factory package does not exist or has no classes"
+            )
+
+            factoryClasses.assertTrue { it.hasNameEndingWith("Factory") }
+        }
+
+        @Test
+        @DisplayName("Strategy packages must exist and classes residing in them must end with 'Strategy'")
+        fun `classes residing in strategy packages must end with Strategy`() {
+            val strategyClasses = (projectProductionScope.classes() + projectProductionScope.interfaces())
+                .filter { it.resideInPackage("..domain.usecase..strategy..") }
+                .filter { it.isTopLevel }
+
+            Assertions.assertTrue(
+                strategyClasses.isNotEmpty(),
+                "Strategy package does not exist or has no classes"
+            )
+
+            strategyClasses.assertTrue { it.hasNameEndingWith("Strategy") }
         }
 
         @Test

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -3,76 +3,138 @@
 Local coverage gate for SplitTrip.
 
 Parses the merged JaCoCo XML produced by ./gradlew jacocoMergedReport and
-fails (exit 1) if overall LINE coverage is below THRESHOLD_LINE_PCT.
+enforces TWO gates:
+
+  1. Overall LINE coverage >= THRESHOLD_OVERALL_PCT (default 80%).
+  2. Per-source-file LINE coverage >= THRESHOLD_FILE_PCT (default 80%) for
+     every file with at least MIN_FILE_LINES instructionable lines.
+
+The per-file gate mirrors what SonarQube enforces on "New Code" - without
+it, a brand-new module with 0% coverage can slip through as long as the
+overall number stays high.
 
 Usage:
     python3 scripts/check_coverage.py
-    python3 scripts/check_coverage.py --threshold 85   # override threshold
+    python3 scripts/check_coverage.py --threshold 85       # overall
+    python3 scripts/check_coverage.py --file-threshold 70  # per-file
+    python3 scripts/check_coverage.py --min-lines 5        # ignore tiny files
 """
 
+import argparse
 import sys
 import xml.etree.ElementTree as ET
+from typing import List, Tuple
 
 REPORT_PATH = "build/reports/jacoco/merged/jacocoMergedReport.xml"
-THRESHOLD_LINE_PCT = 80.0
+THRESHOLD_OVERALL_PCT = 80.0
+THRESHOLD_FILE_PCT = 80.0
+MIN_FILE_LINES = 10
+MAX_OFFENDERS_PRINTED = 30
 
-# ANSI colours (same palette as the Makefile)
 RED = "\033[0;31m"
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
 NC = "\033[0m"
 
 
-def main() -> None:
-    threshold = THRESHOLD_LINE_PCT
-    for arg in sys.argv[1:]:
-        if arg.startswith("--threshold"):
-            try:
-                threshold = float(arg.split("=")[1] if "=" in arg else sys.argv[sys.argv.index(arg) + 1])
-            except (IndexError, ValueError):
-                print(f"{RED}✗  Invalid --threshold value{NC}")
-                sys.exit(1)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--threshold", type=float, default=THRESHOLD_OVERALL_PCT)
+    parser.add_argument("--file-threshold", type=float, default=THRESHOLD_FILE_PCT)
+    parser.add_argument("--min-lines", type=int, default=MIN_FILE_LINES)
+    return parser.parse_args()
 
+
+def load_report(path: str) -> ET.Element:
     try:
-        tree = ET.parse(REPORT_PATH)
+        return ET.parse(path).getroot()
     except FileNotFoundError:
-        print(f"{RED}✗  Coverage report not found at {REPORT_PATH}{NC}")
-        print(f"   Run './gradlew jacocoMergedReport' first.")
+        print(f"{RED}x  Coverage report not found at {path}{NC}")
+        print("   Run './gradlew jacocoMergedReport' first.")
         sys.exit(1)
 
-    root = tree.getroot()
 
-    for counter in root.findall("counter"):
+def line_counter(node: ET.Element) -> Tuple[int, int]:
+    for counter in node.findall("counter"):
         if counter.get("type") == "LINE":
             missed = int(counter.get("missed", 0))
             covered = int(counter.get("covered", 0))
+            return missed, covered
+    return 0, 0
+
+
+def check_overall(root: ET.Element, threshold: float) -> bool:
+    missed, covered = line_counter(root)
+    total = missed + covered
+    pct = covered / total * 100.0 if total > 0 else 0.0
+    if pct >= threshold:
+        print(
+            f"{GREEN}OK  Overall LINE coverage: {pct:.1f}% "
+            f"({covered}/{total} lines) -- threshold {threshold:.0f}%{NC}"
+        )
+        return True
+    need = max(0, int(threshold / 100.0 * total) - covered + 1)
+    print(
+        f"{RED}x   Overall LINE coverage: {pct:.1f}% "
+        f"({covered}/{total} lines) -- below {threshold:.0f}% threshold{NC}"
+    )
+    print(f"{YELLOW}    Cover at least {need} more line(s) to reach {threshold:.0f}%.{NC}")
+    return False
+
+
+def check_per_file(
+    root: ET.Element, threshold: float, min_lines: int
+) -> Tuple[bool, List[Tuple[str, float, int, int]]]:
+    offenders: List[Tuple[str, float, int, int]] = []
+    for package in root.findall("package"):
+        pkg_name = package.get("name", "")
+        for sf in package.findall("sourcefile"):
+            missed, covered = line_counter(sf)
             total = missed + covered
+            if total < min_lines:
+                continue
             pct = covered / total * 100.0 if total > 0 else 0.0
+            if pct < threshold:
+                path = f"{pkg_name}/{sf.get('name', '')}"
+                offenders.append((path, pct, covered, total))
+    offenders.sort(key=lambda x: (x[1], -x[3]))
+    return (len(offenders) == 0), offenders
 
-            if pct >= threshold:
-                print(
-                    f"{GREEN}✅  LINE coverage: {pct:.1f}%"
-                    f" ({covered}/{total} lines) — threshold {threshold:.0f}% ✓{NC}"
-                )
-                sys.exit(0)
-            else:
-                need = max(0, int(threshold / 100.0 * total) - covered + 1)
-                print(
-                    f"{RED}✗   LINE coverage: {pct:.1f}%"
-                    f" ({covered}/{total} lines)"
-                    f" — below {threshold:.0f}% threshold{NC}"
-                )
-                print(
-                    f"{YELLOW}    Cover at least {need} more line(s) to reach {threshold:.0f}%.{NC}"
-                )
-                print(
-                    f"    Run: python3 scripts/coverage_analysis.py"
-                    f" — for a breakdown of uncovered classes."
-                )
-                sys.exit(1)
 
-    print(f"{RED}✗  No LINE counter found in merged coverage report.{NC}")
-    sys.exit(1)
+def print_offenders(
+    offenders: List[Tuple[str, float, int, int]], threshold: float
+) -> None:
+    print(
+        f"{RED}x   {len(offenders)} file(s) below per-file threshold "
+        f"({threshold:.0f}%):{NC}"
+    )
+    for path, pct, covered, total in offenders[:MAX_OFFENDERS_PRINTED]:
+        print(f"    {RED}{pct:5.1f}%{NC}  {covered:>4}/{total:<4}  {path}")
+    if len(offenders) > MAX_OFFENDERS_PRINTED:
+        remaining = len(offenders) - MAX_OFFENDERS_PRINTED
+        print(f"    {YELLOW}... {remaining} more file(s) omitted.{NC}")
+    print(
+        f"{YELLOW}    Add unit tests for the files above, or exclude genuinely "
+        f"untestable files in build-logic/.../JacocoExclusions.kt.{NC}"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    root = load_report(REPORT_PATH)
+
+    overall_ok = check_overall(root, args.threshold)
+    per_file_ok, offenders = check_per_file(root, args.file_threshold, args.min_lines)
+
+    if per_file_ok:
+        print(
+            f"{GREEN}OK  Per-file LINE coverage: every file >= "
+            f"{args.file_threshold:.0f}% (min {args.min_lines} lines){NC}"
+        )
+    else:
+        print_offenders(offenders, args.file_threshold)
+
+    sys.exit(0 if overall_ok and per_file_ok else 1)
 
 
 if __name__ == "__main__":

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -28,8 +28,17 @@ from typing import List, Tuple
 REPORT_PATH = "build/reports/jacoco/merged/jacocoMergedReport.xml"
 THRESHOLD_OVERALL_PCT = 80.0
 THRESHOLD_FILE_PCT = 80.0
-MIN_FILE_LINES = 10
+MIN_FILE_LINES = 3
 MAX_OFFENDERS_PRINTED = 30
+
+# Source file names to skip in the per-file gate regardless of line count.
+# Used for Kotlin internals that the compiler generates into our own package
+# directories (e.g. coroutine SafeCollector bridge classes). These appear in
+# the JaCoCo XML with our package paths but originate from the kotlinx-coroutines
+# runtime, so they cannot be excluded via JacocoExclusions class-path patterns.
+IGNORED_SOURCEFILES = {
+    "SafeCollector.common.kt",
+}
 
 RED = "\033[0;31m"
 GREEN = "\033[0;32m"
@@ -89,6 +98,9 @@ def check_per_file(
     for package in root.findall("package"):
         pkg_name = package.get("name", "")
         for sf in package.findall("sourcefile"):
+            sf_name = sf.get("name", "")
+            if sf_name in IGNORED_SOURCEFILES:
+                continue
             missed, covered = line_counter(sf)
             total = missed + covered
             if total < min_lines:

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -21,6 +21,7 @@ Usage:
 """
 
 import argparse
+import math
 import sys
 import xml.etree.ElementTree as ET
 from typing import List, Tuple
@@ -82,7 +83,7 @@ def check_overall(root: ET.Element, threshold: float) -> bool:
             f"({covered}/{total} lines) -- threshold {threshold:.0f}%{NC}"
         )
         return True
-    need = max(0, int(threshold / 100.0 * total) - covered + 1)
+    need = max(0, math.ceil(threshold / 100.0 * total) - covered)
     print(
         f"{RED}x   Overall LINE coverage: {pct:.1f}% "
         f"({covered}/{total} lines) -- below {threshold:.0f}% threshold{NC}"

--- a/wiki/code-quality-and-static-analysis.md
+++ b/wiki/code-quality-and-static-analysis.md
@@ -104,6 +104,10 @@ JaCoCo is configured for all subprojects via the root `build.gradle.kts`. It sup
 - **Android modules:** Coverage is collected from `testDebugUnitTest` execution data (`build/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec`). Classes are read from `build/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes` (AGP 9.x output location).
 - **JVM modules:** Coverage is collected from `test` execution data (`build/jacoco/test.exec`). Classes are read from `build/classes/kotlin/main`.
 - **Merged report:** The `jacocoMergedReport` task aggregates all subproject execution data into a single HTML + XML report at `build/reports/jacoco/merged/`.
+- **Local coverage gate (`scripts/check_coverage.py`):** Run via `make coverage` / `make check`. Enforces **two** thresholds against the merged report:
+  1. **Overall** LINE coverage ≥ 80%.
+  2. **Per-file** LINE coverage ≥ 80% for every source file with ≥ 10 instructionable lines.
+  The per-file gate mirrors SonarQube's "New Code" coverage rule — a brand-new module with 0% coverage no longer slips through when the overall number stays high. Files that are genuinely untestable (Composables, DI modules, Room DAOs, …) must be added to `JacocoExclusions.classExcludes` in `build-logic/` rather than silenced via thresholds. Override locally with `--threshold`, `--file-threshold`, or `--min-lines` flags.
 
 ### Excluded Classes
 

--- a/wiki/code-quality-and-static-analysis.md
+++ b/wiki/code-quality-and-static-analysis.md
@@ -106,7 +106,7 @@ JaCoCo is configured for all subprojects via the root `build.gradle.kts`. It sup
 - **Merged report:** The `jacocoMergedReport` task aggregates all subproject execution data into a single HTML + XML report at `build/reports/jacoco/merged/`.
 - **Local coverage gate (`scripts/check_coverage.py`):** Run via `make coverage` / `make check`. Enforces **two** thresholds against the merged report:
   1. **Overall** LINE coverage ≥ 80%.
-  2. **Per-file** LINE coverage ≥ 80% for every source file with ≥ 10 instructionable lines.
+  2. **Per-file** LINE coverage ≥ 80% for every source file with ≥ 3 instructionable lines.
   The per-file gate mirrors SonarQube's "New Code" coverage rule — a brand-new module with 0% coverage no longer slips through when the overall number stays high. Files that are genuinely untestable (Composables, DI modules, Room DAOs, …) must be added to `JacocoExclusions.classExcludes` in `build-logic/` rather than silenced via thresholds. Override locally with `--threshold`, `--file-threshold`, or `--min-lines` flags.
 
 ### Excluded Classes


### PR DESCRIPTION
Introduce a strategy-based persistence model for expenses and wire up an edit flow. Added PersistExpenseStrategy, BasePersistExpenseStrategy, AddExpensePersistStrategy, UpdateExpensePersistStrategy and PersistExpenseStrategyFactory; refactored AddExpenseUseCase to use the factory and added UpdateExpenseUseCase. Added GetContributionByExpenseIdUseCase and CashWithdrawalRepository.getWithdrawalById (with implementation). Exposed EDIT_EXPENSE route and navigation target, passed expenseId into the AddExpense feature/ViewModel, and updated UI DI to provide separate add/edit screen providers. Also added allowForwardJumps to the WizardStepIndicator to permit forward navigation in step indicators. Tests updated to use the new factory.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1144 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
