### PR TITLE
[SPLTRP-1153]: Block UI with a morphing scanning animation during receipt AI auto-fill extraction

### DIFF
--- a/features/expenses/build.gradle.kts
+++ b/features/expenses/build.gradle.kts
@@ -9,4 +9,7 @@ android {
 dependencies {
     // Image loading for receipt photos
     implementation(libs.coil.compose)
+
+    // Morphing polygon shapes for the receipt analysis overlay animation
+    implementation(libs.androidx.graphics.shapes)
 }

--- a/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ReceiptAnalysisOverlayPreviews.kt
+++ b/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ReceiptAnalysisOverlayPreviews.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import es.pedrazamiguez.splittrip.core.designsystem.preview.PreviewComplete
 import es.pedrazamiguez.splittrip.core.designsystem.preview.PreviewThemeWrapper
-import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.receipt.ReceiptAnalysisOverlay
+import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.receipt.ReceiptAnalysisContent
 
 @PreviewComplete
 @Composable
@@ -19,7 +19,7 @@ private fun ReceiptAnalysisOverlayVisiblePreview() {
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface)
         ) {
-            ReceiptAnalysisOverlay(visible = true)
+            ReceiptAnalysisContent(modifier = Modifier.fillMaxSize())
         }
     }
 }

--- a/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ReceiptAnalysisOverlayPreviews.kt
+++ b/features/expenses/src/debug/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/preview/ReceiptAnalysisOverlayPreviews.kt
@@ -1,0 +1,25 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.preview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import es.pedrazamiguez.splittrip.core.designsystem.preview.PreviewComplete
+import es.pedrazamiguez.splittrip.core.designsystem.preview.PreviewThemeWrapper
+import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.receipt.ReceiptAnalysisOverlay
+
+@PreviewComplete
+@Composable
+private fun ReceiptAnalysisOverlayVisiblePreview() {
+    PreviewThemeWrapper {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface)
+        ) {
+            ReceiptAnalysisOverlay(visible = true)
+        }
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/receipt/ReceiptAnalysisOverlay.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/receipt/ReceiptAnalysisOverlay.kt
@@ -1,8 +1,6 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.component.form.receipt
 
 import android.graphics.Path as AndroidPath
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -10,8 +8,6 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,6 +35,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.graphics.shapes.CornerRounding
 import androidx.graphics.shapes.Morph
 import androidx.graphics.shapes.RoundedPolygon
@@ -47,7 +45,7 @@ import androidx.graphics.shapes.toPath
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
 import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
 import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.PhotoAi
-import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.BodyText
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.SheetTitleText
 import es.pedrazamiguez.splittrip.features.expense.R
 
 /** Test tag for the receipt analysis overlay container, used in UI tests. */
@@ -85,7 +83,7 @@ private const val SCAN_GLOW_HEIGHT_FRACTION = 0.20f
 private const val SCAN_CORE_HEIGHT_FRACTION = 0.03f
 private const val SCAN_GLOW_ALPHA = 0.22f
 private const val SCAN_CORE_ALPHA = 0.9f
-private const val SCRIM_ALPHA = 0.86f
+private const val SCRIM_ALPHA = 0.60f
 
 // ── Layout Constants ────────────────────────────────────────────────────
 
@@ -132,39 +130,55 @@ fun ReceiptAnalysisOverlay(
     visible: Boolean,
     modifier: Modifier = Modifier
 ) {
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(),
-        exit = fadeOut(),
-        modifier = modifier
-    ) {
-        BackHandler(enabled = visible) {}
+    if (visible) {
+        Dialog(
+            onDismissRequest = {},
+            properties = DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false
+            )
+        ) {
+            ReceiptAnalysisContent(
+                modifier = modifier
+                    .fillMaxSize()
+                    .testTag(RECEIPT_ANALYSIS_OVERLAY_TEST_TAG)
+            )
+        }
+    }
+}
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.scrim.copy(alpha = SCRIM_ALPHA))
-                .pointerInput(Unit) {
-                    awaitPointerEventScope {
-                        while (true) {
-                            awaitPointerEvent()
-                        }
+/**
+ * The actual content of the receipt analysis overlay.
+ * Extracted so Compose previews can render it directly without issues related to separate dialog windows.
+ */
+@Composable
+internal fun ReceiptAnalysisContent(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = SCRIM_ALPHA))
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        awaitPointerEvent()
                     }
                 }
-                .testTag(RECEIPT_ANALYSIS_OVERLAY_TEST_TAG),
-            contentAlignment = Alignment.Center
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                ScanningMorphShape()
-                BodyText(
-                    text = stringResource(R.string.expense_autofill_in_progress),
-                    color = MaterialTheme.colorScheme.inverseOnSurface,
-                    modifier = Modifier.padding(top = MaterialTheme.spacing.ExtraLarge)
-                )
-            }
+            ScanningMorphShape()
+            SheetTitleText(
+                text = stringResource(R.string.expense_autofill_in_progress),
+                color = Color.White,
+                modifier = Modifier.padding(top = MaterialTheme.spacing.ExtraLarge)
+            )
         }
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/receipt/ReceiptAnalysisOverlay.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/receipt/ReceiptAnalysisOverlay.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -32,6 +33,7 @@ import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -130,6 +132,13 @@ fun ReceiptAnalysisOverlay(
     visible: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val focusManager = LocalFocusManager.current
+    LaunchedEffect(visible) {
+        if (visible) {
+            focusManager.clearFocus()
+        }
+    }
+
     if (visible) {
         Dialog(
             onDismissRequest = {},

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/receipt/ReceiptAnalysisOverlay.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/receipt/ReceiptAnalysisOverlay.kt
@@ -1,0 +1,284 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.component.form.receipt
+
+import android.graphics.Path as AndroidPath
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.CornerRounding
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.star
+import androidx.graphics.shapes.toPath
+import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.PhotoAi
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.BodyText
+import es.pedrazamiguez.splittrip.features.expense.R
+
+/** Test tag for the receipt analysis overlay container, used in UI tests. */
+const val RECEIPT_ANALYSIS_OVERLAY_TEST_TAG = "receipt_analysis_overlay"
+
+// ── Shape Constants ─────────────────────────────────────────────────────
+
+private const val CIRCLE_VERTEX_COUNT = 8
+private const val CIRCLE_CORNER_ROUNDING = 0.8f
+
+private const val BLOB_VERTEX_COUNT = 7
+private const val BLOB_INNER_RADIUS = 0.9f
+private const val BLOB_CORNER_RADIUS = 0.5f
+private const val BLOB_CORNER_SMOOTHING = 0.5f
+
+private const val FLOWER_VERTEX_COUNT = 5
+private const val FLOWER_INNER_RADIUS = 0.75f
+private const val FLOWER_CORNER_RADIUS = 0.4f
+private const val FLOWER_CORNER_SMOOTHING = 0.4f
+
+private const val SOFT_STAR_VERTEX_COUNT = 6
+private const val SOFT_STAR_INNER_RADIUS = 0.85f
+private const val SOFT_STAR_CORNER_RADIUS = 0.3f
+private const val SOFT_STAR_CORNER_SMOOTHING = 0.3f
+
+// ── Animation Constants ─────────────────────────────────────────────────
+
+private const val MORPH_SEGMENT_DURATION_MS = 900
+private const val BREATHING_DURATION_MS = 2200
+private const val BREATHING_MIN_SCALE = 0.94f
+private const val BREATHING_MAX_SCALE = 1.0f
+private const val SCAN_DURATION_MS = 1400
+
+private const val SCAN_GLOW_HEIGHT_FRACTION = 0.20f
+private const val SCAN_CORE_HEIGHT_FRACTION = 0.03f
+private const val SCAN_GLOW_ALPHA = 0.22f
+private const val SCAN_CORE_ALPHA = 0.9f
+private const val SCRIM_ALPHA = 0.86f
+
+// ── Layout Constants ────────────────────────────────────────────────────
+
+private val CONTAINER_SIZE = 200.dp
+private val ICON_SIZE = 88.dp
+
+// ── Shape Definitions ───────────────────────────────────────────────────
+
+private val analysisShapes = listOf(
+    RoundedPolygon(
+        numVertices = CIRCLE_VERTEX_COUNT,
+        rounding = CornerRounding(CIRCLE_CORNER_ROUNDING)
+    ),
+    RoundedPolygon.star(
+        numVerticesPerRadius = BLOB_VERTEX_COUNT,
+        radius = 1f,
+        innerRadius = BLOB_INNER_RADIUS,
+        rounding = CornerRounding(BLOB_CORNER_RADIUS, BLOB_CORNER_SMOOTHING)
+    ),
+    RoundedPolygon.star(
+        numVerticesPerRadius = FLOWER_VERTEX_COUNT,
+        radius = 1f,
+        innerRadius = FLOWER_INNER_RADIUS,
+        rounding = CornerRounding(FLOWER_CORNER_RADIUS, FLOWER_CORNER_SMOOTHING)
+    ),
+    RoundedPolygon.star(
+        numVerticesPerRadius = SOFT_STAR_VERTEX_COUNT,
+        radius = 1f,
+        innerRadius = SOFT_STAR_INNER_RADIUS,
+        rounding = CornerRounding(SOFT_STAR_CORNER_RADIUS, SOFT_STAR_CORNER_SMOOTHING)
+    )
+)
+
+private val analysisMorphs = analysisShapes.indices.map { i ->
+    Morph(analysisShapes[i], analysisShapes[(i + 1) % analysisShapes.size])
+}
+
+/**
+ * Full-screen blocking overlay shown while on-device AI extracts receipt fields.
+ * Blocks back navigation and all pointer input until [visible] turns false.
+ */
+@Composable
+fun ReceiptAnalysisOverlay(
+    visible: Boolean,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier
+    ) {
+        BackHandler(enabled = visible) {}
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.scrim.copy(alpha = SCRIM_ALPHA))
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            awaitPointerEvent()
+                        }
+                    }
+                }
+                .testTag(RECEIPT_ANALYSIS_OVERLAY_TEST_TAG),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                ScanningMorphShape()
+                BodyText(
+                    text = stringResource(R.string.expense_autofill_in_progress),
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                    modifier = Modifier.padding(top = MaterialTheme.spacing.ExtraLarge)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanningMorphShape() {
+    val transition = rememberInfiniteTransition(label = "receipt-analysis")
+
+    val morphProgressState = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = analysisMorphs.size.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = analysisMorphs.size * MORPH_SEGMENT_DURATION_MS,
+                easing = LinearEasing
+            ),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "morph-progress"
+    )
+
+    val scaleState = transition.animateFloat(
+        initialValue = BREATHING_MIN_SCALE,
+        targetValue = BREATHING_MAX_SCALE,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = BREATHING_DURATION_MS, easing = EaseInOut),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "breathing-scale"
+    )
+
+    val scanState = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = SCAN_DURATION_MS, easing = EaseInOut),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scan-sweep"
+    )
+
+    MorphScanBox(
+        morphProgressState = morphProgressState,
+        scaleState = scaleState,
+        scanState = scanState
+    )
+}
+
+// Animation State is read only in the draw phase; paths/matrix are reused to avoid per-frame GC.
+@Composable
+private fun MorphScanBox(
+    morphProgressState: State<Float>,
+    scaleState: State<Float>,
+    scanState: State<Float>
+) {
+    val reusablePath = remember { AndroidPath() }
+    val composePath = remember { reusablePath.asComposePath() }
+    val transformMatrix = remember { Matrix() }
+
+    val gradientColors = listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.secondary,
+        MaterialTheme.colorScheme.tertiary
+    )
+    val gradientBrush = remember(gradientColors) { Brush.linearGradient(gradientColors) }
+    val glowColor = Color.White.copy(alpha = SCAN_GLOW_ALPHA)
+    val coreColor = Color.White.copy(alpha = SCAN_CORE_ALPHA)
+
+    Box(
+        modifier = Modifier
+            .size(CONTAINER_SIZE)
+            .graphicsLayer {
+                val s = scaleState.value
+                scaleX = s
+                scaleY = s
+            }
+            .drawWithContent {
+                val progress = morphProgressState.value
+                val idx = progress.toInt() % analysisMorphs.size
+                val segment = (progress - idx.toFloat()).coerceIn(0f, 1f)
+
+                analysisMorphs[idx].toPath(progress = segment, path = reusablePath)
+                transformMatrix.reset()
+                transformMatrix.scale(size.width / 2f, size.height / 2f)
+                transformMatrix.translate(1f, 1f)
+                composePath.transform(transformMatrix)
+
+                clipPath(composePath) {
+                    drawRect(brush = gradientBrush)
+
+                    val centerY = scanState.value * size.height
+                    val glowHeight = size.height * SCAN_GLOW_HEIGHT_FRACTION
+                    val coreHeight = size.height * SCAN_CORE_HEIGHT_FRACTION
+                    drawRect(
+                        color = glowColor,
+                        topLeft = Offset(0f, centerY - glowHeight / 2f),
+                        size = Size(size.width, glowHeight)
+                    )
+                    drawRect(
+                        color = coreColor,
+                        topLeft = Offset(0f, centerY - coreHeight / 2f),
+                        size = Size(size.width, coreHeight)
+                    )
+
+                    this@drawWithContent.drawContent()
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = TablerIcons.Outline.PhotoAi,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(ICON_SIZE)
+        )
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
@@ -244,7 +244,16 @@ private fun WizardStepContent(
         targetState = uiState.currentStep,
         modifier = modifier,
         transitionSpec = {
-            val direction = if (targetState.ordinal > initialState.ordinal) 1 else -1
+            val direction = if (initialState == AddExpenseStep.RECEIPT && targetState == AddExpenseStep.TITLE) {
+                1
+            } else if (initialState == AddExpenseStep.TITLE && targetState == AddExpenseStep.RECEIPT) {
+                -1
+            } else {
+                val steps = uiState.applicableSteps
+                val initialIndex = steps.indexOf(initialState)
+                val targetIndex = steps.indexOf(targetState)
+                if (targetIndex > initialIndex) 1 else -1
+            }
             (slideInHorizontally { fullWidth -> direction * fullWidth } + fadeIn())
                 .togetherWith(
                     slideOutHorizontally { fullWidth -> -direction * fullWidth } + fadeOut()

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/AddExpenseScreen.kt
@@ -52,6 +52,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizar
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard.WizardStepIndicator
 import es.pedrazamiguez.splittrip.core.designsystem.transition.SharedTransitionSurface
 import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.component.form.receipt.ReceiptAnalysisOverlay
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.step.expense.AddOnsStep
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.step.expense.AmountStep
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.step.expense.CategoryStep
@@ -163,6 +164,8 @@ private fun ExpenseWizard(
                 .align(Alignment.BottomCenter)
                 .padding(bottom = bottomPadding)
         )
+
+        ReceiptAnalysisOverlay(visible = uiState.isAnalyzingReceipt)
     }
 }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
@@ -93,12 +93,6 @@ class ReceiptAutoFillEventHandler(
         val preScanPaymentMethod = state.selectedPaymentMethod
 
         scope.launch {
-            _actionsFlow.emit(
-                AddExpenseUiAction.ShowPill(
-                    UiText.StringResource(R.string.expense_autofill_in_progress)
-                )
-            )
-
             _uiState.update { it.copy(isAnalyzingReceipt = true) }
 
             extractReceiptFieldsUseCase(attachment)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
@@ -19,6 +19,7 @@ import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.
 import java.math.BigDecimal
 import java.time.ZoneOffset
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -95,7 +96,15 @@ class ReceiptAutoFillEventHandler(
         scope.launch {
             _uiState.update { it.copy(isAnalyzingReceipt = true) }
 
-            extractReceiptFieldsUseCase(attachment)
+            val result = try {
+                extractReceiptFieldsUseCase(attachment)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+            result
                 .onSuccess { extracted ->
                     mergeExtractedFields(extracted, preScanCurrency, preScanPaymentMethod)
                     _uiState.update {

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
@@ -99,12 +99,16 @@ class ReceiptAutoFillEventHandler(
                 )
             )
 
+            _uiState.update { it.copy(isAnalyzingReceipt = true) }
+
             extractReceiptFieldsUseCase(attachment)
                 .onSuccess { extracted ->
                     mergeExtractedFields(extracted, preScanCurrency, preScanPaymentMethod)
+                    _uiState.update { it.copy(isAnalyzingReceipt = false) }
                 }
                 .onFailure { error ->
                     Timber.e(error, "Receipt auto-fill failed")
+                    _uiState.update { it.copy(isAnalyzingReceipt = false) }
                     _actionsFlow.emit(
                         AddExpenseUiAction.ShowPill(
                             UiText.StringResource(R.string.expense_autofill_failed)

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandler.kt
@@ -98,7 +98,16 @@ class ReceiptAutoFillEventHandler(
             extractReceiptFieldsUseCase(attachment)
                 .onSuccess { extracted ->
                     mergeExtractedFields(extracted, preScanCurrency, preScanPaymentMethod)
-                    _uiState.update { it.copy(isAnalyzingReceipt = false) }
+                    _uiState.update {
+                        val nextStep = it.applicableSteps.let { steps ->
+                            val idx = steps.indexOf(AddExpenseStep.RECEIPT)
+                            if (idx >= 0 && idx < steps.lastIndex) steps[idx + 1] else null
+                        }
+                        it.copy(
+                            isAnalyzingReceipt = false,
+                            currentStep = nextStep ?: it.currentStep
+                        )
+                    }
                 }
                 .onFailure { error ->
                     Timber.e(error, "Receipt auto-fill failed")
@@ -153,7 +162,7 @@ class ReceiptAutoFillEventHandler(
         tryMergePaymentMethod(extracted, preScanPaymentMethod, bannerFields)
         tryMergeNotes(extracted, bannerFields)
 
-        // 5. Update banner state and notify success
+        // 5. Update banner state
         if (bannerFields.isNotEmpty()) {
             _uiState.update {
                 it.copy(
@@ -163,11 +172,6 @@ class ReceiptAutoFillEventHandler(
                     )
                 )
             }
-            _actionsFlow.emit(
-                AddExpenseUiAction.ShowPill(
-                    UiText.StringResource(R.string.expense_autofill_success)
-                )
-            )
         }
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -188,6 +188,7 @@ data class AddExpenseUiState(
     // ── AI Auto-fill ────────────────────────────────────────────────────
     val isAiCapable: Boolean = false,
     val isAiModeActive: Boolean = false,
+    val isAnalyzingReceipt: Boolean = false,
     val autoFillBanner: AutoFillBanner? = null,
     val expenseDateMillis: Long? = null,
 

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
@@ -422,4 +422,65 @@ class ReceiptAutoFillEventHandlerTest {
             assertTrue(capturedAmountChanges.isEmpty())
         }
     }
+
+    @Nested
+    inner class AnalyzingReceiptState {
+
+        private val attachment = ReceiptAttachment(
+            localUri = "uri",
+            mimeType = "image/webp",
+            capturedAtMillis = 1000L
+        )
+
+        private val extracted = ExtractedReceipt(
+            title = "Starbucks",
+            amount = BigDecimal("12.50"),
+            currency = "EUR",
+            date = LocalDate.of(2025, 1, 1),
+            confidence = ExtractionConfidence.HIGH,
+            source = ExtractionSource.AI_CORE
+        )
+
+        @Test
+        fun `toggles analyzing flag true during extraction then false on success`() = runTest {
+            every { receiptExtractionService.capability() } returns ExtractionCapability.ON_DEVICE_AI
+            val observedDuringExtraction = mutableListOf<Boolean>()
+            coEvery { extractReceiptFieldsUseCase(attachment) } answers {
+                observedDuringExtraction.add(uiState.value.isAnalyzingReceipt)
+                Result.success(extracted)
+            }
+            every { formattingHelper.formatCentsValue(1250L, 2) } returns "12.50"
+
+            assertFalse(uiState.value.isAnalyzingReceipt)
+
+            handler.handleReceiptAttached(attachment)
+
+            assertEquals(listOf(true), observedDuringExtraction)
+            assertFalse(uiState.value.isAnalyzingReceipt)
+        }
+
+        @Test
+        fun `toggles analyzing flag true during extraction then false on failure`() = runTest {
+            every { receiptExtractionService.capability() } returns ExtractionCapability.ON_DEVICE_AI
+            val observedDuringExtraction = mutableListOf<Boolean>()
+            coEvery { extractReceiptFieldsUseCase(attachment) } answers {
+                observedDuringExtraction.add(uiState.value.isAnalyzingReceipt)
+                Result.failure(RuntimeException("boom"))
+            }
+
+            handler.handleReceiptAttached(attachment)
+
+            assertEquals(listOf(true), observedDuringExtraction)
+            assertFalse(uiState.value.isAnalyzingReceipt)
+        }
+
+        @Test
+        fun `does not set analyzing flag when device is not AI capable`() = runTest {
+            every { receiptExtractionService.capability() } returns ExtractionCapability.UNSUPPORTED
+
+            handler.handleReceiptAttached(attachment)
+
+            assertFalse(uiState.value.isAnalyzingReceipt)
+        }
+    }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
@@ -421,6 +421,32 @@ class ReceiptAutoFillEventHandlerTest {
 
             assertTrue(capturedAmountChanges.isEmpty())
         }
+
+        @Test
+        fun `navigates to next step on successful extraction`() = runTest {
+            every { receiptExtractionService.capability() } returns ExtractionCapability.ON_DEVICE_AI
+            coEvery { extractReceiptFieldsUseCase(attachment) } returns Result.success(
+                ExtractedReceipt(
+                    title = "Starbucks",
+                    amount = BigDecimal("12.50"),
+                    currency = "EUR",
+                    date = LocalDate.of(2025, 1, 1),
+                    confidence = ExtractionConfidence.HIGH,
+                    source = ExtractionSource.AI_CORE
+                )
+            )
+            every { formattingHelper.formatCentsValue(1250L, 2) } returns "12.50"
+
+            uiState.value = uiState.value.copy(
+                isAiCapable = true,
+                isAiModeActive = true,
+                currentStep = AddExpenseStep.RECEIPT
+            )
+
+            handler.handleReceiptAttached(attachment)
+
+            assertEquals(AddExpenseStep.TITLE, uiState.value.currentStep)
+        }
     }
 
     @Nested

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/ReceiptAutoFillEventHandlerTest.kt
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class ReceiptAutoFillEventHandlerTest {
 
+    private class TestException(message: String) : Exception(message)
+
     private lateinit var handler: ReceiptAutoFillEventHandler
     private lateinit var extractReceiptFieldsUseCase: ExtractReceiptFieldsUseCase
     private lateinit var receiptExtractionService: ReceiptExtractionService
@@ -498,6 +500,34 @@ class ReceiptAutoFillEventHandlerTest {
 
             assertEquals(listOf(true), observedDuringExtraction)
             assertFalse(uiState.value.isAnalyzingReceipt)
+        }
+
+        @Test
+        fun `toggles analyzing flag true during extraction then false on unexpected exception`() = runTest {
+            every { receiptExtractionService.capability() } returns ExtractionCapability.ON_DEVICE_AI
+            val observedDuringExtraction = mutableListOf<Boolean>()
+            coEvery { extractReceiptFieldsUseCase(attachment) } answers {
+                observedDuringExtraction.add(uiState.value.isAnalyzingReceipt)
+                throw TestException("unexpected throw")
+            }
+
+            handler.handleReceiptAttached(attachment)
+
+            assertEquals(listOf(true), observedDuringExtraction)
+            assertFalse(uiState.value.isAnalyzingReceipt)
+        }
+
+        @Test
+        fun `rethrows CancellationException when extraction throws it`() = runTest {
+            every { receiptExtractionService.capability() } returns ExtractionCapability.ON_DEVICE_AI
+            coEvery { extractReceiptFieldsUseCase(attachment) } throws
+                kotlinx.coroutines.CancellationException("cancelled")
+
+            handler.handleReceiptAttached(attachment)
+
+            val actionList = actions.replayCache
+            assertFalse(actionList.any { it is AddExpenseUiAction.ShowPill })
+            assertTrue(uiState.value.isAnalyzingReceipt)
         }
 
         @Test


### PR DESCRIPTION
Introduce a full-screen ReceiptAnalysisOverlay composable (with preview) to indicate on-device AI receipt extraction and block input/back navigation. Add androidx.graphics.shapes dependency for morphing shape animations and integrate the overlay into AddExpenseScreen. Add isAnalyzingReceipt to AddExpenseUiState and update ReceiptAutoFillEventHandler to toggle this flag before and after extraction (on success or failure). Include unit tests covering the analyzing flag behavior during extraction.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1153 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
