### PR TITLE
[SPLTRP-1154]: Add bottom padding to login screen scrollable form to prevent button shadow clipping

### DIFF
--- a/app/src/androidTest/kotlin/es/pedrazamiguez/splittrip/screens/LoginScreenTest.kt
+++ b/app/src/androidTest/kotlin/es/pedrazamiguez/splittrip/screens/LoginScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -79,8 +80,8 @@ class LoginScreenTest {
 
         composeRule.waitForIdle()
 
-        composeRule.onNodeWithText(emailLabel).assertIsNotEnabled()
-        composeRule.onNodeWithText(passwordLabel).assertIsNotEnabled()
+        composeRule.onNodeWithContentDescription(emailLabel).assertIsNotEnabled()
+        composeRule.onNodeWithContentDescription(passwordLabel).assertIsNotEnabled()
     }
 
     // ═════════════════════════════════════════════════════════════════════

--- a/features/authentication/src/main/kotlin/es/pedrazamiguez/splittrip/features/authentication/presentation/screen/LoginScreen.kt
+++ b/features/authentication/src/main/kotlin/es/pedrazamiguez/splittrip/features/authentication/presentation/screen/LoginScreen.kt
@@ -58,7 +58,11 @@ fun LoginScreen(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.Default),
-                modifier = Modifier.fillMaxWidth(FORM_WIDTH_FRACTION).verticalScroll(rememberScrollState()).imePadding()
+                modifier = Modifier
+                    .fillMaxWidth(FORM_WIDTH_FRACTION)
+                    .verticalScroll(rememberScrollState())
+                    .padding(bottom = MaterialTheme.spacing.Large)
+                    .imePadding()
             ) {
                 LoginFormContent(
                     uiState = uiState,


### PR DESCRIPTION
Switch the LoginScreen instrumented test to query the email and password nodes by contentDescription (adds onNodeWithContentDescription import) instead of onNodeWithText. In LoginScreen, reformat the Column modifier chain and add a bottom padding (MaterialTheme.spacing.Large) before imePadding() to ensure proper spacing when the keyboard is shown.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1154 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
