### PR TITLE
[SPLTRP-1152]: Fix layout alignment and wrap notes field in receipt extraction cards

### DIFF
--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/navigation/FloatingNavigationBar.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/navigation/FloatingNavigationBar.kt
@@ -53,7 +53,7 @@ fun FloatingNavigationBar(
 ) {
     val selectedIndex = items.indexOfFirst { it.id == selectedId }.coerceAtLeast(0)
 
-    // Lift the pill above the system navigation bar regardless of navigation mode.
+    // Lift the pill above the system navigation bar unless the parent already applies insets.
     val navBarInset = if (applyWindowInsets) {
         WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     } else {

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/navigation/FloatingNavigationBar.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/navigation/FloatingNavigationBar.kt
@@ -48,12 +48,17 @@ fun FloatingNavigationBar(
     selectedId: String = "",
     onTabSelected: (String) -> Unit = {},
     items: List<FloatingNavTab> = emptyList(),
-    hazeState: HazeState? = null
+    hazeState: HazeState? = null,
+    applyWindowInsets: Boolean = true
 ) {
     val selectedIndex = items.indexOfFirst { it.id == selectedId }.coerceAtLeast(0)
 
     // Lift the pill above the system navigation bar regardless of navigation mode.
-    val navBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val navBarInset = if (applyWindowInsets) {
+        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    } else {
+        0.dp
+    }
 
     Box(
         modifier = modifier.fillMaxWidth(),

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/component/ExtractionCards.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/component/ExtractionCards.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
 import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
@@ -32,6 +33,8 @@ import es.pedrazamiguez.splittrip.domain.model.ExtractionSource
 import es.pedrazamiguez.splittrip.features.settings.R
 
 private val FIELD_ICON_SIZE = 18.dp
+private const val FIELD_LABEL_WEIGHT = 0.45f
+private const val FIELD_VALUE_WEIGHT = 0.55f
 
 @Suppress("LongParameterList")
 @Composable
@@ -124,12 +127,14 @@ private fun ExtractionFieldRow(
             text = label,
             style = MaterialTheme.typography.titleSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(FIELD_LABEL_WEIGHT)
         )
         Text(
             text = value ?: stringResource(R.string.developer_services_extraction_na),
             style = MaterialTheme.typography.bodyMedium,
-            color = if (value != null) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline
+            color = if (value != null) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(FIELD_VALUE_WEIGHT)
         )
     }
 }

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/DeveloperServicesScreen.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/DeveloperServicesScreen.kt
@@ -140,7 +140,8 @@ fun DeveloperServicesScreen(
             onTabSelected = { id ->
                 onEvent(DeveloperServicesUiEvent.SwitchTab(id.toDeveloperServicesTab()))
             },
-            items = SERVICE_TABS
+            items = SERVICE_TABS,
+            applyWindowInsets = false
             // No hazeState — this screen has no scrollable hazeSource behind the bar.
         )
     }


### PR DESCRIPTION
Add applyWindowInsets:Boolean (default true) to FloatingNavigationBar and use it to conditionally compute navBarInset so the bar can opt out of WindowInsets. Update DeveloperServicesScreen to pass applyWindowInsets=false for that screen. Also tweak ExtractionCards: add TextAlign import, introduce FIELD_LABEL_WEIGHT and FIELD_VALUE_WEIGHT, align field values to end and apply explicit weights to label/value for better layout balance.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1152 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
