### PR TITLE
[SPLTRP-1151]: Improve layout of summary step fields in add/modify expense wizard and fix 'Credit scope' copy

### DIFF
--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/ReviewStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/ReviewStep.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.layout.SectionCard
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.BodyText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.wizard.WizardStepLayout
@@ -19,6 +20,9 @@ import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
 import java.util.Locale
+
+private const val LABEL_WEIGHT = 0.4f
+private const val VALUE_WEIGHT = 0.6f
 
 /**
  * Step 11 (final): Read-only summary of all entered data.
@@ -212,13 +216,16 @@ private fun ReviewRow(label: String, value: String) {
     ) {
         BodyText(
             text = label,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(LABEL_WEIGHT)
         )
         Text(
             text = value,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(VALUE_WEIGHT),
+            textAlign = TextAlign.End
         )
     }
 }

--- a/features/expenses/src/main/res/values-es/strings.xml
+++ b/features/expenses/src/main/res/values-es/strings.xml
@@ -236,7 +236,7 @@
     <string name="expense_contribution_scope_for_me">Para mí</string>
     <string name="expense_contribution_scope_for_subunit">Para %1$s</string>
     <string name="expense_wizard_step_contribution_scope">Crédito</string>
-    <string name="expense_review_contribution_scope">Alcance del crédito</string>
+    <string name="expense_review_contribution_scope">Pagado para</string>
     <string name="expense_review_scope_personal">Personal</string>
     <string name="expense_review_scope_group">Grupo</string>
 

--- a/features/expenses/src/main/res/values/strings.xml
+++ b/features/expenses/src/main/res/values/strings.xml
@@ -235,7 +235,7 @@
     <string name="expense_contribution_scope_for_me">For me</string>
     <string name="expense_contribution_scope_for_subunit">For %1$s</string>
     <string name="expense_wizard_step_contribution_scope">Credit</string>
-    <string name="expense_review_contribution_scope">Credit scope</string>
+    <string name="expense_review_contribution_scope">Paid for</string>
     <string name="expense_review_scope_personal">Personal</string>
     <string name="expense_review_scope_group">Group</string>
 


### PR DESCRIPTION
Give review rows fixed label/value weights and right-align values for better layout in ReviewStep (add TextAlign import, LABEL_WEIGHT and VALUE_WEIGHT constants, apply Modifier.weight and TextAlign.End). Also update the localized string for contribution scope from "Credit scope"/"Alcance del crédito" to "Paid for"/"Pagado para" in English and Spanish resources.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1151 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
