### PR TITLE
[SPLTRP-1163]: Fix expense validation failure due to timezone offset and relax future datetime checks for travelers

### DIFF
--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationService.kt
@@ -21,10 +21,9 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
         val currentLocalAsUtcMillis = LocalDateTime.now()
             .toInstant(ZoneOffset.UTC)
             .toEpochMilli()
-        val gracePeriodMillis = 36 * 60 * 60 * 1000L // 36 hours grace period
 
         return when {
-            dateMillis > (currentLocalAsUtcMillis + gracePeriodMillis) -> ValidationResult.Invalid(
+            dateMillis > (currentLocalAsUtcMillis + GRACE_PERIOD_MILLIS) -> ValidationResult.Invalid(
                 "Expense date and time cannot be in the future"
             )
             else -> ValidationResult.Valid
@@ -42,27 +41,11 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
         }
     }
 
-    /**
-     * Validates that the number of users is positive before performing
-     * division-based operations (e.g., equal split).
-     *
-     * @param count The number of users to split an expense among.
-     * @return [ValidationResult.Valid] if count > 0, otherwise [ValidationResult.Invalid].
-     */
     fun validateUserCount(count: Int): ValidationResult = when {
         count <= 0 -> ValidationResult.Invalid("User count must be greater than zero")
         else -> ValidationResult.Valid
     }
 
-    /**
-     * Validates expense splits by delegating to the appropriate strategy's validation.
-     *
-     * @param splitType       The split strategy being used.
-     * @param splits          The user-provided split data.
-     * @param totalAmountCents The total expense amount in cents.
-     * @param participantIds  The user IDs of all active (non-excluded) participants.
-     * @return [ValidationResult.Valid] if the splits are valid, otherwise [ValidationResult.Invalid].
-     */
     fun validateSplits(
         splitType: SplitType,
         splits: List<ExpenseSplit>,
@@ -70,22 +53,12 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
         participantIds: List<String>
     ): ValidationResult = try {
         val calculator = splitCalculatorFactory.create(splitType)
-        // calculateShares calls validate() internally via Template Method
         calculator.calculateShares(totalAmountCents, participantIds, splits)
         ValidationResult.Valid
     } catch (e: Exception) {
         ValidationResult.Invalid(e.message ?: "Invalid split configuration")
     }
 
-    /**
-     * Validates a single add-on.
-     *
-     * Rules:
-     * - [AddOn.amountCents] must be > 0.
-     * - [AddOn.currency] must not be blank.
-     * - For [AddOnMode.INCLUDED] add-ons, [AddOn.amountCents] must be < [sourceAmountCents]
-     *   (can't extract more than the total).
-     */
     fun validateAddOn(addOn: AddOn, sourceAmountCents: Long): ValidationResult {
         if (addOn.amountCents <= 0) {
             return ValidationResult.Invalid("Add-on amount must be greater than zero")
@@ -101,10 +74,6 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
         return ValidationResult.Valid
     }
 
-    /**
-     * Validates all add-ons in the list.
-     * Returns the first invalid result, or [ValidationResult.Valid] if all pass.
-     */
     fun validateAddOns(
         addOns: List<AddOn>,
         sourceAmountCents: Long
@@ -114,5 +83,11 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
             if (result is ValidationResult.Invalid) return result
         }
         return ValidationResult.Valid
+    }
+
+    companion object {
+        private const val GRACE_PERIOD_HOURS = 36L
+        private const val MILLIS_IN_HOUR = 60L * 60L * 1000L
+        const val GRACE_PERIOD_MILLIS = GRACE_PERIOD_HOURS * MILLIS_IN_HOUR
     }
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationService.kt
@@ -7,6 +7,8 @@ import es.pedrazamiguez.splittrip.domain.model.AddOn
 import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
 import es.pedrazamiguez.splittrip.domain.model.ValidationResult
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitCalculatorFactory) {
 
@@ -15,11 +17,18 @@ class ExpenseValidationService(private val splitCalculatorFactory: ExpenseSplitC
         else -> ValidationResult.Valid
     }
 
-    fun validateExpenseDate(dateMillis: Long): ValidationResult = when {
-        dateMillis > System.currentTimeMillis() -> ValidationResult.Invalid(
-            "Expense date and time cannot be in the future"
-        )
-        else -> ValidationResult.Valid
+    fun validateExpenseDate(dateMillis: Long): ValidationResult {
+        val currentLocalAsUtcMillis = LocalDateTime.now()
+            .toInstant(ZoneOffset.UTC)
+            .toEpochMilli()
+        val gracePeriodMillis = 36 * 60 * 60 * 1000L // 36 hours grace period
+
+        return when {
+            dateMillis > (currentLocalAsUtcMillis + gracePeriodMillis) -> ValidationResult.Invalid(
+                "Expense date and time cannot be in the future"
+            )
+            else -> ValidationResult.Valid
+        }
     }
 
     fun validateAmount(amountString: String): ValidationResult {

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
@@ -9,6 +9,8 @@ import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
 import es.pedrazamiguez.splittrip.domain.model.ValidationResult
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
 import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -383,32 +385,39 @@ class ExpenseValidationServiceTest {
 
         @Test
         fun `current or past date returns Valid`() {
-            val now = java.time.LocalDateTime.now()
-                .toInstant(java.time.ZoneOffset.UTC)
+            val now = LocalDateTime.now()
+                .toInstant(ZoneOffset.UTC)
                 .toEpochMilli()
-            val past = now - 100000L
+            val past = now - PAST_OFFSET_MILLIS
             assertEquals(ValidationResult.Valid, service.validateExpenseDate(now))
             assertEquals(ValidationResult.Valid, service.validateExpenseDate(past))
         }
 
         @Test
         fun `future date within 36 hours returns Valid`() {
-            val now = java.time.LocalDateTime.now()
-                .toInstant(java.time.ZoneOffset.UTC)
+            val now = LocalDateTime.now()
+                .toInstant(ZoneOffset.UTC)
                 .toEpochMilli()
-            val futureWithinGrace = now + 35 * 60 * 60 * 1000L // 35 hours future
+            val futureWithinGrace = now + THIRTY_FIVE_HOURS_MILLIS
             assertEquals(ValidationResult.Valid, service.validateExpenseDate(futureWithinGrace))
         }
 
         @Test
         fun `future date beyond 36 hours returns Invalid`() {
-            val now = java.time.LocalDateTime.now()
-                .toInstant(java.time.ZoneOffset.UTC)
+            val now = LocalDateTime.now()
+                .toInstant(ZoneOffset.UTC)
                 .toEpochMilli()
-            val futureBeyondGrace = now + 37 * 60 * 60 * 1000L // 37 hours future
+            val futureBeyondGrace = now + THIRTY_SEVEN_HOURS_MILLIS
             val result = service.validateExpenseDate(futureBeyondGrace)
             assertTrue(result is ValidationResult.Invalid)
             assertEquals("Expense date and time cannot be in the future", (result as ValidationResult.Invalid).message)
         }
+    }
+
+    companion object {
+        private const val MILLIS_IN_HOUR = 60L * 60L * 1000L
+        private const val PAST_OFFSET_MILLIS = 100_000L
+        private const val THIRTY_FIVE_HOURS_MILLIS = 35 * MILLIS_IN_HOUR
+        private const val THIRTY_SEVEN_HOURS_MILLIS = 37 * MILLIS_IN_HOUR
     }
 }

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseValidationServiceTest.kt
@@ -383,18 +383,32 @@ class ExpenseValidationServiceTest {
 
         @Test
         fun `current or past date returns Valid`() {
-            val now = System.currentTimeMillis()
+            val now = java.time.LocalDateTime.now()
+                .toInstant(java.time.ZoneOffset.UTC)
+                .toEpochMilli()
             val past = now - 100000L
             assertEquals(ValidationResult.Valid, service.validateExpenseDate(now))
             assertEquals(ValidationResult.Valid, service.validateExpenseDate(past))
         }
 
         @Test
-        fun `future date returns Invalid`() {
-            val future = System.currentTimeMillis() + 100000L
-            val result = service.validateExpenseDate(future)
+        fun `future date within 36 hours returns Valid`() {
+            val now = java.time.LocalDateTime.now()
+                .toInstant(java.time.ZoneOffset.UTC)
+                .toEpochMilli()
+            val futureWithinGrace = now + 35 * 60 * 60 * 1000L // 35 hours future
+            assertEquals(ValidationResult.Valid, service.validateExpenseDate(futureWithinGrace))
+        }
+
+        @Test
+        fun `future date beyond 36 hours returns Invalid`() {
+            val now = java.time.LocalDateTime.now()
+                .toInstant(java.time.ZoneOffset.UTC)
+                .toEpochMilli()
+            val futureBeyondGrace = now + 37 * 60 * 60 * 1000L // 37 hours future
+            val result = service.validateExpenseDate(futureBeyondGrace)
             assertTrue(result is ValidationResult.Invalid)
-            assertTrue((result as ValidationResult.Invalid).message.isNotBlank())
+            assertEquals("Expense date and time cannot be in the future", (result as ValidationResult.Invalid).message)
         }
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
@@ -30,8 +30,6 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.text.
 import es.pedrazamiguez.splittrip.features.expense.R
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.ZoneOffset
 import java.util.Calendar as JavaCalendar
 
@@ -86,7 +84,6 @@ internal fun ExpenseDateSection(
 
     if (showTimePicker) {
         ExpenseTimePickerDialog(
-            selectedDateMillis = tempSelectedDateMillis ?: System.currentTimeMillis(),
             initialTimeMillis = expenseDateMillis,
             onDismiss = { showTimePicker = false },
             onTimeSelected = { hour, minute ->
@@ -108,15 +105,19 @@ private fun ExpenseDatePickerDialog(
     onDismiss: () -> Unit,
     onDateSelected: (Long) -> Unit
 ) {
+    val currentLocalDateMillis = LocalDate.now()
+        .atStartOfDay()
+        .toInstant(ZoneOffset.UTC)
+        .toEpochMilli()
     val datePickerState = rememberDatePickerState(
-        initialSelectedDateMillis = initialDateMillis ?: System.currentTimeMillis(),
+        initialSelectedDateMillis = initialDateMillis ?: currentLocalDateMillis,
         selectableDates = object : SelectableDates {
             override fun isSelectableDate(utcTimeMillis: Long): Boolean {
-                return utcTimeMillis <= System.currentTimeMillis()
+                return utcTimeMillis <= currentLocalDateMillis
             }
 
             override fun isSelectableYear(year: Int): Boolean {
-                return year <= LocalDate.now(ZoneOffset.UTC).year
+                return year <= LocalDate.now().year
             }
         }
     )
@@ -146,13 +147,16 @@ private fun ExpenseDatePickerDialog(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpenseTimePickerDialog(
-    selectedDateMillis: Long,
     initialTimeMillis: Long?,
     onDismiss: () -> Unit,
     onTimeSelected: (hour: Int, minute: Int) -> Unit
 ) {
-    val calendar = JavaCalendar.getInstance(java.util.TimeZone.getTimeZone("UTC")).apply {
-        initialTimeMillis?.let { timeInMillis = it }
+    val calendar = if (initialTimeMillis != null) {
+        JavaCalendar.getInstance(java.util.TimeZone.getTimeZone("UTC")).apply {
+            timeInMillis = initialTimeMillis
+        }
+    } else {
+        JavaCalendar.getInstance()
     }
     val initialHour = calendar.get(JavaCalendar.HOUR_OF_DAY)
     val initialMinute = calendar.get(JavaCalendar.MINUTE)
@@ -162,18 +166,9 @@ private fun ExpenseTimePickerDialog(
         is24Hour = true
     )
 
-    // Validate selectable times for today to prevent future times
-    val selectedLocalDate = Instant.ofEpochMilli(selectedDateMillis).atZone(ZoneOffset.UTC).toLocalDate()
-    val nowUtc = LocalDateTime.now(ZoneOffset.UTC)
-    val isToday = selectedLocalDate == nowUtc.toLocalDate()
-
-    val isValidTime = if (isToday) {
-        val selectedTime = LocalTime.of(timePickerState.hour, timePickerState.minute)
-        val nowTime = nowUtc.toLocalTime()
-        !selectedTime.isAfter(nowTime)
-    } else {
-        true
-    }
+    // Always allow future selections in the time picker since future dates/times
+    // are demoted to a soft warning and handled during form submission.
+    val isValidTime = true
 
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/form/ExpenseDateSection.kt
@@ -32,6 +32,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.Calendar as JavaCalendar
+import java.util.TimeZone
 
 /**
  * Expense date and time picker section.
@@ -152,7 +153,7 @@ private fun ExpenseTimePickerDialog(
     onTimeSelected: (hour: Int, minute: Int) -> Unit
 ) {
     val calendar = if (initialTimeMillis != null) {
-        JavaCalendar.getInstance(java.util.TimeZone.getTimeZone("UTC")).apply {
+        JavaCalendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
             timeInMillis = initialTimeMillis
         }
     } else {
@@ -166,18 +167,13 @@ private fun ExpenseTimePickerDialog(
         is24Hour = true
     )
 
-    // Always allow future selections in the time picker since future dates/times
-    // are demoted to a soft warning and handled during form submission.
-    val isValidTime = true
-
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
             TextButton(
                 onClick = {
                     onTimeSelected(timePickerState.hour, timePickerState.minute)
-                },
-                enabled = isValidTime
+                }
             ) {
                 Text(stringResource(R.string.expense_date_time_ok))
             }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -151,17 +151,23 @@ class SubmitEventHandler(
                     currentState.expenseDateMillis,
                     dateValidation.message
                 )
-                val errorText = UiText.StringResource(R.string.expense_error_date_future)
+                // Future date validation is demoted to a soft warning.
+                // We show a top pill warning and mark the field invalid visually, but do not block submission.
+                val warningText = UiText.StringResource(R.string.expense_error_date_future)
                 _uiState.update {
                     it.copy(
-                        isExpenseDateValid = false,
-                        error = errorText
+                        isExpenseDateValid = false
                     )
                 }
                 scope.launch {
-                    _actions.emit(AddExpenseUiAction.ShowError(errorText))
+                    _actions.emit(AddExpenseUiAction.ShowPill(warningText))
                 }
-                return
+            } else {
+                _uiState.update {
+                    it.copy(
+                        isExpenseDateValid = true
+                    )
+                }
             }
         }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandler.kt
@@ -82,7 +82,6 @@ class SubmitEventHandler(
 
         val currentState = _uiState.value
 
-        // Validate title using domain service
         val titleValidation = expenseValidationService.validateTitle(currentState.expenseTitle)
         if (titleValidation is ValidationResult.Invalid) {
             Timber.w("submitExpense: title validation failed — length=%d", currentState.expenseTitle.length)
@@ -99,7 +98,6 @@ class SubmitEventHandler(
             return
         }
 
-        // Validate amount using domain service
         val amountValidation = expenseValidationService.validateAmount(currentState.sourceAmount)
         if (amountValidation is ValidationResult.Invalid) {
             Timber.w(
@@ -119,7 +117,6 @@ class SubmitEventHandler(
             return
         }
 
-        // Validate due date when payment status is SCHEDULED
         if (currentState.selectedPaymentStatus?.id == PaymentStatus.SCHEDULED.name &&
             currentState.dueDateMillis == null
         ) {
@@ -140,7 +137,6 @@ class SubmitEventHandler(
             return
         }
 
-        // Validate expense date/time when not scheduled
         if (!currentState.showDueDateSection) {
             val dateValidation = expenseValidationService.validateExpenseDate(
                 currentState.expenseDateMillis ?: System.currentTimeMillis()
@@ -151,27 +147,20 @@ class SubmitEventHandler(
                     currentState.expenseDateMillis,
                     dateValidation.message
                 )
-                // Future date validation is demoted to a soft warning.
-                // We show a top pill warning and mark the field invalid visually, but do not block submission.
                 val warningText = UiText.StringResource(R.string.expense_error_date_future)
-                _uiState.update {
-                    it.copy(
-                        isExpenseDateValid = false
-                    )
+                _uiState.update { state ->
+                    state.copy(isExpenseDateValid = false).clearFutureDateError()
                 }
                 scope.launch {
                     _actions.emit(AddExpenseUiAction.ShowPill(warningText))
                 }
             } else {
-                _uiState.update {
-                    it.copy(
-                        isExpenseDateValid = true
-                    )
+                _uiState.update { state ->
+                    state.copy(isExpenseDateValid = true).clearFutureDateError()
                 }
             }
         }
 
-        // Validate add-ons (only those with non-empty input)
         val addOnsWithInput = currentState.addOns.filter { it.amountInput.isNotBlank() }
         if (addOnsWithInput.any { it.resolvedAmountCents <= 0 }) {
             Timber.w(
@@ -439,4 +428,13 @@ class SubmitEventHandler(
             split.copy(amountCents = rescaled[index])
         }
     }
+
+    private fun AddExpenseUiState.clearFutureDateError(): AddExpenseUiState =
+        if (error is UiText.StringResource &&
+            (error as UiText.StringResource).resId == R.string.expense_error_date_future
+        ) {
+            copy(error = null)
+        } else {
+            this
+        }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.handler
 
+import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
 import es.pedrazamiguez.splittrip.domain.enums.AddOnType
@@ -15,16 +16,19 @@ import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
 import es.pedrazamiguez.splittrip.domain.service.ExpenseValidationService
 import es.pedrazamiguez.splittrip.domain.service.RemainderDistributionService
 import es.pedrazamiguez.splittrip.domain.service.split.ExpenseSplitCalculatorFactory
+import es.pedrazamiguez.splittrip.features.expense.R
 import es.pedrazamiguez.splittrip.features.expense.presentation.mapper.AddExpenseUiMapper
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.AddOnUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.PaymentStatusUiModel
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.AddExpenseUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.AddExpenseUiState
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategy
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -58,8 +62,7 @@ import org.junit.jupiter.api.Test
 class SubmitEventHandlerTest {
 
     private lateinit var handler: SubmitEventHandler
-    private lateinit var strategy:
-        es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.strategy.ExpenseFlowStrategy
+    private lateinit var strategy: ExpenseFlowStrategy
     private lateinit var addExpenseUiMapper: AddExpenseUiMapper
 
     /** A minimal [Expense] stub — only the fields used by adjustForIncludedAddOns matter. */
@@ -604,13 +607,13 @@ class SubmitEventHandlerTest {
                     actionsFlow.collect { actions.add(it) }
                 }
                 handler.bind(stateFlow, actionsFlow, this)
-                val currentLocalAsUtc = java.time.LocalDateTime.now()
-                    .toInstant(java.time.ZoneOffset.UTC)
+                val currentLocalAsUtc = LocalDateTime.now()
+                    .toInstant(ZoneOffset.UTC)
                     .toEpochMilli()
                 stateFlow.value = AddExpenseUiState(
                     expenseTitle = "Dinner",
                     sourceAmount = "50",
-                    expenseDateMillis = currentLocalAsUtc + 37 * 60 * 60 * 1000L // 37 hours future
+                    expenseDateMillis = currentLocalAsUtc + THIRTY_SEVEN_HOURS_MILLIS
                 )
                 val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
                 every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
@@ -629,6 +632,30 @@ class SubmitEventHandlerTest {
             }
 
         @Test
+        fun `future date beyond 36h clears stale future date error from state`() =
+            runTest(testDispatcher) {
+                handler.bind(stateFlow, actionsFlow, this)
+                val currentLocalAsUtc = LocalDateTime.now()
+                    .toInstant(ZoneOffset.UTC)
+                    .toEpochMilli()
+                stateFlow.value = AddExpenseUiState(
+                    expenseTitle = "Dinner",
+                    sourceAmount = "50",
+                    expenseDateMillis = currentLocalAsUtc + THIRTY_SEVEN_HOURS_MILLIS,
+                    error = UiText.StringResource(R.string.expense_error_date_future)
+                )
+                val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
+                every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
+                coEvery { strategy.saveExpense(any(), any(), any()) } returns Result.success(Unit)
+
+                handler.submitExpense("group-1") {}
+                advanceUntilIdle()
+
+                assertFalse(stateFlow.value.isExpenseDateValid)
+                assertNull(stateFlow.value.error)
+            }
+
+        @Test
         fun `future date within 36h submits successfully`() =
             runTest(testDispatcher) {
                 val actions = mutableListOf<AddExpenseUiAction>()
@@ -636,13 +663,13 @@ class SubmitEventHandlerTest {
                     actionsFlow.collect { actions.add(it) }
                 }
                 handler.bind(stateFlow, actionsFlow, this)
-                val currentLocalAsUtc = java.time.LocalDateTime.now()
-                    .toInstant(java.time.ZoneOffset.UTC)
+                val currentLocalAsUtc = LocalDateTime.now()
+                    .toInstant(ZoneOffset.UTC)
                     .toEpochMilli()
                 stateFlow.value = AddExpenseUiState(
                     expenseTitle = "Dinner",
                     sourceAmount = "50",
-                    expenseDateMillis = currentLocalAsUtc + 24 * 60 * 60 * 1000L // 24 hours future
+                    expenseDateMillis = currentLocalAsUtc + TWENTY_FOUR_HOURS_MILLIS
                 )
                 val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
                 every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
@@ -775,5 +802,11 @@ class SubmitEventHandlerTest {
             // Error is shown via UiAction (Snackbar), not inline
             assertNull(stateFlow.value.error)
         }
+    }
+
+    companion object {
+        private const val MILLIS_IN_HOUR = 60L * 60L * 1000L
+        private const val THIRTY_SEVEN_HOURS_MILLIS = 37 * MILLIS_IN_HOUR
+        private const val TWENTY_FOUR_HOURS_MILLIS = 24 * MILLIS_IN_HOUR
     }
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/SubmitEventHandlerTest.kt
@@ -597,27 +597,67 @@ class SubmitEventHandlerTest {
         }
 
         @Test
-        fun `future expense date sets isExpenseDateValid false and error`() = runTest(testDispatcher) {
-            val actions = mutableListOf<AddExpenseUiAction>()
-            val collectJob = launch(UnconfinedTestDispatcher()) {
-                actionsFlow.collect { actions.add(it) }
+        fun `future date beyond 36h shows warning pill and submits`() =
+            runTest(testDispatcher) {
+                val actions = mutableListOf<AddExpenseUiAction>()
+                val collectJob = launch(UnconfinedTestDispatcher()) {
+                    actionsFlow.collect { actions.add(it) }
+                }
+                handler.bind(stateFlow, actionsFlow, this)
+                val currentLocalAsUtc = java.time.LocalDateTime.now()
+                    .toInstant(java.time.ZoneOffset.UTC)
+                    .toEpochMilli()
+                stateFlow.value = AddExpenseUiState(
+                    expenseTitle = "Dinner",
+                    sourceAmount = "50",
+                    expenseDateMillis = currentLocalAsUtc + 37 * 60 * 60 * 1000L // 37 hours future
+                )
+                val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
+                every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
+                coEvery { strategy.saveExpense(any(), any(), any()) } returns Result.success(Unit)
+
+                var successCalled = false
+                handler.submitExpense("group-1") { successCalled = true }
+                advanceUntilIdle()
+
+                assertFalse(stateFlow.value.isExpenseDateValid)
+                assertNull(stateFlow.value.error)
+                assertEquals(1, actions.size)
+                assertTrue(actions[0] is AddExpenseUiAction.ShowPill)
+                assertTrue(successCalled)
+                collectJob.cancel()
             }
-            handler.bind(stateFlow, actionsFlow, this)
-            stateFlow.value = AddExpenseUiState(
-                expenseTitle = "Dinner",
-                sourceAmount = "50",
-                expenseDateMillis = System.currentTimeMillis() + 1000000L
-            )
 
-            handler.submitExpense("group-1") {}
-            advanceUntilIdle()
+        @Test
+        fun `future date within 36h submits successfully`() =
+            runTest(testDispatcher) {
+                val actions = mutableListOf<AddExpenseUiAction>()
+                val collectJob = launch(UnconfinedTestDispatcher()) {
+                    actionsFlow.collect { actions.add(it) }
+                }
+                handler.bind(stateFlow, actionsFlow, this)
+                val currentLocalAsUtc = java.time.LocalDateTime.now()
+                    .toInstant(java.time.ZoneOffset.UTC)
+                    .toEpochMilli()
+                stateFlow.value = AddExpenseUiState(
+                    expenseTitle = "Dinner",
+                    sourceAmount = "50",
+                    expenseDateMillis = currentLocalAsUtc + 24 * 60 * 60 * 1000L // 24 hours future
+                )
+                val expense = makeExpense(sourceAmount = 5000L, groupAmount = 5000L)
+                every { addExpenseUiMapper.mapToDomain(any(), any()) } returns Result.success(expense)
+                coEvery { strategy.saveExpense(any(), any(), any()) } returns Result.success(Unit)
 
-            assertFalse(stateFlow.value.isExpenseDateValid)
-            assertNotNull(stateFlow.value.error)
-            assertEquals(1, actions.size)
-            assertTrue(actions[0] is AddExpenseUiAction.ShowError)
-            collectJob.cancel()
-        }
+                var successCalled = false
+                handler.submitExpense("group-1") { successCalled = true }
+                advanceUntilIdle()
+
+                assertTrue(stateFlow.value.isExpenseDateValid)
+                assertNull(stateFlow.value.error)
+                assertTrue(actions.isEmpty())
+                assertTrue(successCalled)
+                collectJob.cancel()
+            }
 
         @Test
         fun `add-on with zero resolved amount sets addOnError`() = runTest(testDispatcher) {


### PR DESCRIPTION
Introduce a 36-hour grace period to expense date validation (compare date against current local time as UTC + 36h) in ExpenseValidationService and update tests accordingly. Adjust ExpenseDateSection to use local start-of-day for the date picker, allow future times in the time picker, and simplify calendar initialization. Change SubmitEventHandler to demote future-date failures to a non-blocking top pill warning (mark field visually invalid but proceed with submission) and update related tests to reflect the new behavior.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1163 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
