### PR TITLE
[SPLTRP-1172]: Align SonarQube and JaCoCo coverage exclusions and cover missing domain classes

### DIFF
--- a/build-logic/src/main/kotlin/JacocoExclusions.kt
+++ b/build-logic/src/main/kotlin/JacocoExclusions.kt
@@ -157,11 +157,20 @@ object JacocoExclusions {
         "**/repository/CashWithdrawalRepository*.*",
         "**/domain/service/ReceiptExtractionService*.*",
         "**/presentation/mapper/SubunitUiMapper*.*",
-        "**/presentation/viewmodel/strategy/ExpenseFlowStrategy*.*",
+        "**/presentation/viewmodel/strategy/ExpenseFlowStrategy.*",
+        "**/presentation/viewmodel/strategy/ExpenseFlowStrategy\$*.*",
         // ── Mapper interfaces with default method bodies (trivial 1-arg delegate wrappers) ─
         // The default `toGroupUiModel(group)` body just calls `toGroupUiModel(group, emptyMap())`.
         // The Impl is 100% tested; the interface convenience overloads are structural, not logical.
         "**/presentation/mapper/GroupUiMapper*.*",
+        // ── Design-system: constants-only objects — JaCoCo instruments static class initializer ──
+        "**/designsystem/constant/**/*.class",
+        // ── Sealed UiEvent hierarchies — pure data classes with no logic ─────────
+        "**/features/authentication/presentation/model/AuthenticationUiAction*.*",
+        "**/features/authentication/presentation/model/AuthenticationUiEvent*.*",
+        // ── Repository & datasource interfaces ───────────────────────────────────
+        "**/domain/repository/CurrencyRepository*.*",
+        "**/domain/datasource/cloud/CloudUserDataSource*.*",
         // ── Kotlin coroutines internals leaking into the JaCoCo class path ────────
         // SafeCollector.common is an internal coroutines file; it's not our code.
         "**/SafeCollector*.*",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,21 @@ sonarqube {
                 "**/remote/datasource/impl/**/*.kt",
                 // Database migrations — raw DDL SQL; no meaningful unit-test path
                 "**/database/DatabaseMigrations.kt",
+                // UiEvent, AppCheck, data-holders, mapping and interfaces
+                "**/presentation/viewmodel/event/**/*.kt",
+                "**/appcheck/AppCheckProviderHelper*.kt",
+                "**/presentation/model/CashBalanceUiModel*.kt",
+                "**/presentation/view/SettingItemView*.kt",
+                "**/presentation/extensions/AddOnValueTypeExtensions*.kt",
+                "**/repository/CashWithdrawalRepository*.kt",
+                "**/domain/service/ReceiptExtractionService*.kt",
+                "**/presentation/mapper/SubunitUiMapper*.kt",
+                "**/presentation/viewmodel/strategy/ExpenseFlowStrategy.kt",
+                "**/presentation/mapper/GroupUiMapper*.kt",
+                "**/features/authentication/presentation/model/AuthenticationUiAction*.kt",
+                "**/features/authentication/presentation/model/AuthenticationUiEvent*.kt",
+                "**/domain/repository/CurrencyRepository.kt",
+                "**/domain/datasource/cloud/CloudUserDataSource.kt",
             ).joinToString(","),
         )
 

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/model/BalanceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/model/BalanceTest.kt
@@ -1,0 +1,49 @@
+package es.pedrazamiguez.splittrip.domain.model
+
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class BalanceTest {
+
+    private val eur = Currency("EUR", "€", "Euro", 2)
+    private val usd = Currency("USD", "$", "US Dollar", 2)
+
+    @Test
+    fun `equals returns true for same fields`() {
+        val balance1 = Balance("user_1", BigDecimal("10.00"), eur)
+        val balance2 = Balance("user_1", BigDecimal("10.00"), eur)
+
+        assertEquals(balance1, balance2)
+    }
+
+    @Test
+    fun `equals returns false for different fields`() {
+        val balance1 = Balance("user_1", BigDecimal("10.00"), eur)
+        val balance2 = Balance("user_2", BigDecimal("10.00"), eur)
+        val balance3 = Balance("user_1", BigDecimal("20.00"), eur)
+        val balance4 = Balance("user_1", BigDecimal("10.00"), usd)
+
+        assertNotEquals(balance1, balance2)
+        assertNotEquals(balance1, balance3)
+        assertNotEquals(balance1, balance4)
+    }
+
+    @Test
+    fun `hashCode is consistent`() {
+        val balance1 = Balance("user_1", BigDecimal("10.00"), eur)
+        val balance2 = Balance("user_1", BigDecimal("10.00"), eur)
+
+        assertEquals(balance1.hashCode(), balance2.hashCode())
+    }
+
+    @Test
+    fun `toString output format is correct`() {
+        val balance = Balance("user_1", BigDecimal("10.00"), eur)
+        val expected = "Balance(userId=user_1, amount=10.00, " +
+            "currency=Currency(code=EUR, symbol=€, defaultName=Euro, decimalDigits=2))"
+
+        assertEquals(expected, balance.toString())
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetCashWithdrawalsFlowUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetCashWithdrawalsFlowUseCaseTest.kt
@@ -1,0 +1,28 @@
+package es.pedrazamiguez.splittrip.domain.usecase.balance
+
+import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
+import es.pedrazamiguez.splittrip.domain.repository.CashWithdrawalRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetCashWithdrawalsFlowUseCaseTest {
+
+    private val repository: CashWithdrawalRepository = mockk()
+    private val useCase = GetCashWithdrawalsFlowUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() {
+        val groupId = "group_123"
+        val expectedFlow = flowOf(emptyList<CashWithdrawal>())
+        every { repository.getGroupWithdrawalsFlow(groupId) } returns expectedFlow
+
+        val resultFlow = useCase(groupId)
+
+        assertEquals(expectedFlow, resultFlow)
+        verify(exactly = 1) { repository.getGroupWithdrawalsFlow(groupId) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetGroupContributionsFlowUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/balance/GetGroupContributionsFlowUseCaseTest.kt
@@ -1,0 +1,28 @@
+package es.pedrazamiguez.splittrip.domain.usecase.balance
+
+import es.pedrazamiguez.splittrip.domain.model.Contribution
+import es.pedrazamiguez.splittrip.domain.repository.ContributionRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetGroupContributionsFlowUseCaseTest {
+
+    private val repository: ContributionRepository = mockk()
+    private val useCase = GetGroupContributionsFlowUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() {
+        val groupId = "group_123"
+        val expectedFlow = flowOf(emptyList<Contribution>())
+        every { repository.getGroupContributionsFlow(groupId) } returns expectedFlow
+
+        val resultFlow = useCase(groupId)
+
+        assertEquals(expectedFlow, resultFlow)
+        verify(exactly = 1) { repository.getGroupContributionsFlow(groupId) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetGroupExpensesFlowUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/GetGroupExpensesFlowUseCaseTest.kt
@@ -1,0 +1,28 @@
+package es.pedrazamiguez.splittrip.domain.usecase.expense
+
+import es.pedrazamiguez.splittrip.domain.model.Expense
+import es.pedrazamiguez.splittrip.domain.repository.ExpenseRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetGroupExpensesFlowUseCaseTest {
+
+    private val repository: ExpenseRepository = mockk()
+    private val useCase = GetGroupExpensesFlowUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() {
+        val groupId = "group_123"
+        val expectedFlow = flowOf(emptyList<Expense>())
+        every { repository.getGroupExpensesFlow(groupId) } returns expectedFlow
+
+        val resultFlow = useCase(groupId)
+
+        assertEquals(expectedFlow, resultFlow)
+        verify(exactly = 1) { repository.getGroupExpensesFlow(groupId) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/GetGroupByIdUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/GetGroupByIdUseCaseTest.kt
@@ -1,0 +1,28 @@
+package es.pedrazamiguez.splittrip.domain.usecase.group
+
+import es.pedrazamiguez.splittrip.domain.model.Group
+import es.pedrazamiguez.splittrip.domain.repository.GroupRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetGroupByIdUseCaseTest {
+
+    private val repository: GroupRepository = mockk()
+    private val useCase = GetGroupByIdUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() = runTest {
+        val groupId = "group_123"
+        val expectedGroup: Group = mockk()
+        coEvery { repository.getGroupById(groupId) } returns expectedGroup
+
+        val result = useCase(groupId)
+
+        assertEquals(expectedGroup, result)
+        coVerify(exactly = 1) { repository.getGroupById(groupId) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/GetGroupByIdUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/GetGroupByIdUseCaseTest.kt
@@ -17,7 +17,7 @@ class GetGroupByIdUseCaseTest {
     @Test
     fun `invoke delegates to repository`() = runTest {
         val groupId = "group_123"
-        val expectedGroup: Group = mockk()
+        val expectedGroup = Group(id = groupId, name = "Test Group")
         coEvery { repository.getGroupById(groupId) } returns expectedGroup
 
         val result = useCase(groupId)

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/GetUserGroupsFlowUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/group/GetUserGroupsFlowUseCaseTest.kt
@@ -1,0 +1,27 @@
+package es.pedrazamiguez.splittrip.domain.usecase.group
+
+import es.pedrazamiguez.splittrip.domain.model.Group
+import es.pedrazamiguez.splittrip.domain.repository.GroupRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetUserGroupsFlowUseCaseTest {
+
+    private val repository: GroupRepository = mockk()
+    private val useCase = GetUserGroupsFlowUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() {
+        val expectedFlow = flowOf(emptyList<Group>())
+        every { repository.getAllGroupsFlow() } returns expectedFlow
+
+        val resultFlow = useCase()
+
+        assertEquals(expectedFlow, resultFlow)
+        verify(exactly = 1) { repository.getAllGroupsFlow() }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/subunit/GetGroupSubunitsUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/subunit/GetGroupSubunitsUseCaseTest.kt
@@ -1,0 +1,28 @@
+package es.pedrazamiguez.splittrip.domain.usecase.subunit
+
+import es.pedrazamiguez.splittrip.domain.model.Subunit
+import es.pedrazamiguez.splittrip.domain.repository.SubunitRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetGroupSubunitsUseCaseTest {
+
+    private val repository: SubunitRepository = mockk()
+    private val useCase = GetGroupSubunitsUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() = runTest {
+        val groupId = "group_123"
+        val expectedList: List<Subunit> = emptyList()
+        coEvery { repository.getGroupSubunits(groupId) } returns expectedList
+
+        val result = useCase(groupId)
+
+        assertEquals(expectedList, result)
+        coVerify(exactly = 1) { repository.getGroupSubunits(groupId) }
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/user/GetMemberProfilesUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/user/GetMemberProfilesUseCaseTest.kt
@@ -1,0 +1,28 @@
+package es.pedrazamiguez.splittrip.domain.usecase.user
+
+import es.pedrazamiguez.splittrip.domain.model.User
+import es.pedrazamiguez.splittrip.domain.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetMemberProfilesUseCaseTest {
+
+    private val repository: UserRepository = mockk()
+    private val useCase = GetMemberProfilesUseCase(repository)
+
+    @Test
+    fun `invoke delegates to repository`() = runTest {
+        val userIds = listOf("user_1", "user_2")
+        val expectedMap: Map<String, User> = emptyMap()
+        coEvery { repository.getUsersByIds(userIds) } returns expectedMap
+
+        val result = useCase(userIds)
+
+        assertEquals(expectedMap, result)
+        coVerify(exactly = 1) { repository.getUsersByIds(userIds) }
+    }
+}


### PR DESCRIPTION
Add unit tests for domain model and use-case delegation (BalanceTest and multiple Get*UseCaseTest files) to validate equals/hashCode/toString and repository delegation behavior. Update JaCoCo and SonarQube exclusion patterns (build-logic/JacocoExclusions.kt and build.gradle.kts) to ignore structural/trivial code (e.g. ExpenseFlowStrategy nested classes, mapper interfaces, design-system constants, UiEvent/data-holder classes, repository/datasource interfaces, coroutine internals) so coverage reports don't count boilerplate or generated-like artifacts.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1172 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
