### PR TITLE
[SPLTRP-1124]: [Authentication]: Ensure User Profile Creation on Email Sign-In

### DIFF
--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserRepositoryImpl.kt
@@ -13,12 +13,14 @@ class UserRepositoryImpl(
     private val authenticationService: AuthenticationService
 ) : UserRepository {
 
-    override suspend fun saveGoogleUser(user: User): Result<Unit> = runCatching {
+    override suspend fun saveUser(user: User): Result<Unit> = runCatching {
         cloudUserDataSource.saveUser(user)
         // Also cache locally so the current user's display name is
         // available offline immediately without a Firestore round-trip.
         localUserDataSource.saveUsers(listOf(user))
     }
+
+    override suspend fun saveGoogleUser(user: User): Result<Unit> = saveUser(user)
 
     override suspend fun getCurrentUserProfile(): User? {
         val userId = authenticationService.currentUserId() ?: return null

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserRepositoryImplTest.kt
@@ -71,6 +71,7 @@ class UserRepositoryImplTest {
             val result = repository.saveUser(testUser)
 
             assertTrue(result.isFailure)
+            coVerify(exactly = 0) { localUserDataSource.saveUsers(any()) }
         }
     }
 
@@ -96,6 +97,7 @@ class UserRepositoryImplTest {
             val result = repository.saveGoogleUser(testUser)
 
             assertTrue(result.isFailure)
+            coVerify(exactly = 0) { localUserDataSource.saveUsers(any()) }
         }
     }
 

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserRepositoryImplTest.kt
@@ -50,6 +50,31 @@ class UserRepositoryImplTest {
     }
 
     @Nested
+    inner class SaveUser {
+
+        @Test
+        fun `saves user to cloud and caches locally`() = runTest {
+            coEvery { cloudUserDataSource.saveUser(testUser) } just Runs
+            coEvery { localUserDataSource.saveUsers(listOf(testUser)) } just Runs
+
+            val result = repository.saveUser(testUser)
+
+            assertTrue(result.isSuccess)
+            coVerify { cloudUserDataSource.saveUser(testUser) }
+            coVerify { localUserDataSource.saveUsers(listOf(testUser)) }
+        }
+
+        @Test
+        fun `returns failure when cloud save throws`() = runTest {
+            coEvery { cloudUserDataSource.saveUser(testUser) } throws RuntimeException("Cloud error")
+
+            val result = repository.saveUser(testUser)
+
+            assertTrue(result.isFailure)
+        }
+    }
+
+    @Nested
     inner class SaveGoogleUser {
 
         @Test

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/AuthenticationDomainModule.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/AuthenticationDomainModule.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.di
 
+import es.pedrazamiguez.splittrip.domain.repository.UserRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.service.LocalDatabaseCleanerService
 import es.pedrazamiguez.splittrip.domain.usecase.auth.SignInWithEmailUseCase
@@ -13,6 +14,7 @@ val authenticationDomainModule = module {
     factory {
         SignInWithEmailUseCase(
             authenticationService = get<AuthenticationService>(),
+            userRepository = get<UserRepository>(),
             registerDeviceTokenUseCase = get<RegisterDeviceTokenUseCase>()
         )
     }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/UserRepository.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/UserRepository.kt
@@ -6,6 +6,11 @@ interface UserRepository {
     suspend fun saveGoogleUser(user: User): Result<Unit>
 
     /**
+     * Saves a user profile to the cloud database and caches it locally.
+     */
+    suspend fun saveUser(user: User): Result<Unit>
+
+    /**
      * Returns the current authenticated user's profile.
      *
      * Checks the local cache (Room) first, then fetches from the cloud

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/UserRepository.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/UserRepository.kt
@@ -6,14 +6,14 @@ interface UserRepository {
     suspend fun saveGoogleUser(user: User): Result<Unit>
 
     /**
-     * Saves a user profile to the cloud database and caches it locally.
+     * Saves a user profile to the remote data source and caches it locally.
      */
     suspend fun saveUser(user: User): Result<Unit>
 
     /**
      * Returns the current authenticated user's profile.
      *
-     * Checks the local cache (Room) first, then fetches from the cloud
+     * Checks the local cache first, then fetches from the remote data source
      * if not found locally, and caches the result.
      */
     suspend fun getCurrentUserProfile(): User?
@@ -21,14 +21,14 @@ interface UserRepository {
     /**
      * Returns a map of userId → [User] for the given IDs.
      *
-     * Checks the local cache (Room) first, then fetches any missing users
-     * from the cloud and caches them locally for future lookups.
+     * Checks the local cache first, then fetches any missing users
+     * from the remote data source and caches them locally for future lookups.
      */
     suspend fun getUsersByIds(userIds: List<String>): Map<String, User>
 
     /**
      * Searches for users by email address (exact match).
-     * This is a cloud-only lookup — results are not cached locally.
+     * This is a remote-only lookup — results are not cached locally.
      *
      * @param email The email address to search for
      * @return List of matching users, excluding the current user

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/auth/SignInWithEmailUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/auth/SignInWithEmailUseCase.kt
@@ -5,6 +5,7 @@ import es.pedrazamiguez.splittrip.domain.repository.UserRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.notification.RegisterDeviceTokenUseCase
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class SignInWithEmailUseCase(
     private val authenticationService: AuthenticationService,
@@ -24,7 +25,7 @@ class SignInWithEmailUseCase(
                 email = email,
                 displayName = email.substringBefore('@'),
                 profileImagePath = null,
-                createdAt = LocalDateTime.now()
+                createdAt = LocalDateTime.now(ZoneOffset.UTC)
             )
             userRepository.saveUser(defaultUser).getOrThrow()
         }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/auth/SignInWithEmailUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/auth/SignInWithEmailUseCase.kt
@@ -1,10 +1,14 @@
 package es.pedrazamiguez.splittrip.domain.usecase.auth
 
+import es.pedrazamiguez.splittrip.domain.model.User
+import es.pedrazamiguez.splittrip.domain.repository.UserRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.notification.RegisterDeviceTokenUseCase
+import java.time.LocalDateTime
 
 class SignInWithEmailUseCase(
     private val authenticationService: AuthenticationService,
+    private val userRepository: UserRepository,
     private val registerDeviceTokenUseCase: RegisterDeviceTokenUseCase
 ) {
 
@@ -12,6 +16,18 @@ class SignInWithEmailUseCase(
         val userId = authenticationService
             .signIn(email, password)
             .getOrThrow()
+
+        val profile = userRepository.getCurrentUserProfile()
+        if (profile == null) {
+            val defaultUser = User(
+                userId = userId,
+                email = email,
+                displayName = email.substringBefore('@'),
+                profileImagePath = null,
+                createdAt = LocalDateTime.now()
+            )
+            userRepository.saveUser(defaultUser).getOrThrow()
+        }
 
         registerDeviceTokenUseCase()
             .onFailure {

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/auth/SignInWithEmailUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/auth/SignInWithEmailUseCaseTest.kt
@@ -1,5 +1,7 @@
 package es.pedrazamiguez.splittrip.domain.usecase.auth
 
+import es.pedrazamiguez.splittrip.domain.model.User
+import es.pedrazamiguez.splittrip.domain.repository.UserRepository
 import es.pedrazamiguez.splittrip.domain.service.AuthenticationService
 import es.pedrazamiguez.splittrip.domain.usecase.notification.RegisterDeviceTokenUseCase
 import io.mockk.coEvery
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.Test
 class SignInWithEmailUseCaseTest {
 
     private lateinit var authenticationService: AuthenticationService
+    private lateinit var userRepository: UserRepository
     private lateinit var registerDeviceTokenUseCase: RegisterDeviceTokenUseCase
     private lateinit var useCase: SignInWithEmailUseCase
 
@@ -25,11 +28,15 @@ class SignInWithEmailUseCaseTest {
     @BeforeEach
     fun setUp() {
         authenticationService = mockk()
+        userRepository = mockk()
         registerDeviceTokenUseCase = mockk()
         useCase = SignInWithEmailUseCase(
             authenticationService = authenticationService,
+            userRepository = userRepository,
             registerDeviceTokenUseCase = registerDeviceTokenUseCase
         )
+        coEvery { userRepository.getCurrentUserProfile() } returns User(userId, email, "user", null, null)
+        coEvery { userRepository.saveUser(any()) } returns Result.success(Unit)
     }
 
     @Nested
@@ -88,6 +95,46 @@ class SignInWithEmailUseCaseTest {
             assertTrue(result.isSuccess)
             assertEquals(userId, result.getOrNull())
         }
+
+        @Test
+        fun `does not save user if profile already exists`() = runTest {
+            // Given
+            coEvery { authenticationService.signIn(email, password) } returns Result.success(userId)
+            coEvery { registerDeviceTokenUseCase() } returns Result.success(Unit)
+            coEvery { userRepository.getCurrentUserProfile() } returns User(userId, email, "user", null, null)
+
+            // When
+            useCase(email, password)
+
+            // Then
+            coVerify(exactly = 0) { userRepository.saveUser(any()) }
+        }
+
+        @Test
+        fun `creates and saves default profile if it does not exist`() = runTest {
+            // Given
+            coEvery { authenticationService.signIn(email, password) } returns Result.success(userId)
+            coEvery { registerDeviceTokenUseCase() } returns Result.success(Unit)
+            coEvery { userRepository.getCurrentUserProfile() } returns null
+            coEvery { userRepository.saveUser(any()) } returns Result.success(Unit)
+
+            // When
+            val result = useCase(email, password)
+
+            // Then
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 1) {
+                userRepository.saveUser(
+                    withArg {
+                        assertEquals(userId, it.userId)
+                        assertEquals(email, it.email)
+                        assertEquals("user", it.displayName)
+                        org.junit.jupiter.api.Assertions.assertNull(it.profileImagePath)
+                        org.junit.jupiter.api.Assertions.assertNotNull(it.createdAt)
+                    }
+                )
+            }
+        }
     }
 
     @Nested
@@ -106,6 +153,21 @@ class SignInWithEmailUseCaseTest {
             assertTrue(result.isFailure)
             assertEquals("Auth failed", result.exceptionOrNull()?.message)
             coVerify(exactly = 0) { registerDeviceTokenUseCase() }
+        }
+
+        @Test
+        fun `fails when profile creation fails`() = runTest {
+            // Given
+            coEvery { authenticationService.signIn(email, password) } returns Result.success(userId)
+            coEvery { userRepository.getCurrentUserProfile() } returns null
+            coEvery { userRepository.saveUser(any()) } returns Result.failure(RuntimeException("Save failed"))
+
+            // When
+            val result = useCase(email, password)
+
+            // Then
+            assertTrue(result.isFailure)
+            assertEquals("Save failed", result.exceptionOrNull()?.message)
         }
     }
 }


### PR DESCRIPTION
Introduce a generic saveUser API in UserRepository and implement it in UserRepositoryImpl (cloud save + local cache). saveGoogleUser now delegates to saveUser. SignInWithEmailUseCase is updated to inject UserRepository; after successful sign-in it checks for an existing profile and creates/saves a default User (with createdAt) when missing. DI module updated to provide UserRepository. Unit tests added/extended for saveUser and the new sign-in profile creation and failure cases.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1124 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
