### PR TITLE
[SPLTRP-1178]: Gracefully handle unconfigured Open Exchange Rates API key in debug builds

### DIFF
--- a/data/remote/src/main/kotlin/es/pedrazamiguez/splittrip/data/remote/datasource/impl/RemoteCurrencyDataSourceImpl.kt
+++ b/data/remote/src/main/kotlin/es/pedrazamiguez/splittrip/data/remote/datasource/impl/RemoteCurrencyDataSourceImpl.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.data.remote.datasource.impl
 import es.pedrazamiguez.splittrip.data.remote.api.OpenExchangeRatesApi
 import es.pedrazamiguez.splittrip.data.remote.mapper.CurrencyDtoMapper
 import es.pedrazamiguez.splittrip.domain.datasource.remote.RemoteCurrencyDataSource
+import es.pedrazamiguez.splittrip.domain.exception.ApiKeyNotConfiguredException
 import es.pedrazamiguez.splittrip.domain.model.Currency
 import es.pedrazamiguez.splittrip.domain.model.ExchangeRates
 
@@ -10,15 +11,27 @@ class RemoteCurrencyDataSourceImpl(private val api: OpenExchangeRatesApi, privat
     RemoteCurrencyDataSource {
 
     override suspend fun fetchCurrencies(): List<Currency> {
+        validateApiKey()
         val response = api.getCurrencies(appId)
         return CurrencyDtoMapper.mapCurrencies(response)
     }
 
     override suspend fun fetchExchangeRates(baseCurrencyCode: String): ExchangeRates {
+        validateApiKey()
         val response = api.getExchangeRates(
             appId,
             baseCurrencyCode
         )
         return CurrencyDtoMapper.mapExchangeRates(response)
+    }
+
+    private fun validateApiKey() {
+        if (appId.isBlank() || appId == PLACEHOLDER_APP_ID) {
+            throw ApiKeyNotConfiguredException("API key is not configured.")
+        }
+    }
+
+    companion object {
+        private const val PLACEHOLDER_APP_ID = "YOUR_DEBUG_OER_APP_ID"
     }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImpl.kt
@@ -17,22 +17,20 @@ class CurrencyRepositoryImpl(
 ) : CurrencyRepository {
 
     override suspend fun getCurrencies(forceRefresh: Boolean): List<Currency> {
-        if (!forceRefresh) {
-            val local = localDataSource.getCurrencies()
-            if (local.isNotEmpty()) {
-                return local
-            }
+        val local = if (!forceRefresh) localDataSource.getCurrencies() else null
+        if (local != null && local.isNotEmpty()) {
+            return local
         }
         return try {
             val remote = remoteDataSource.fetchCurrencies()
             localDataSource.saveCurrencies(remote)
             remote
         } catch (ignored: ApiKeyNotConfiguredException) {
-            Timber.w("Failed to fetch currencies: API key is not configured (placeholder is being used).")
-            localDataSource.getCurrencies()
+            Timber.w("Failed to fetch currencies: API key is not configured or placeholder is being used.")
+            local ?: localDataSource.getCurrencies()
         } catch (e: Exception) {
             Timber.e(e, "Failed to fetch currencies")
-            localDataSource.getCurrencies()
+            local ?: localDataSource.getCurrencies()
         }
     }
 
@@ -56,7 +54,7 @@ class CurrencyRepositoryImpl(
                     localDataSource.saveExchangeRates(remoteRates)
                     ExchangeRateResult.Fresh(remoteRates)
                 } catch (ignored: ApiKeyNotConfiguredException) {
-                    Timber.w("Failed to fetch exchange rates: API key is not configured (placeholder is being used).")
+                    Timber.w("Failed to fetch exchange rates: API key is not configured or placeholder is being used.")
                     ExchangeRateResult.Empty
                 } catch (e: Exception) {
                     Timber.e(
@@ -74,7 +72,7 @@ class CurrencyRepositoryImpl(
                     localDataSource.saveExchangeRates(remoteRates)
                     ExchangeRateResult.Fresh(remoteRates)
                 } catch (ignored: ApiKeyNotConfiguredException) {
-                    Timber.w("Failed to fetch exchange rates: API key is not configured (placeholder is being used).")
+                    Timber.w("Failed to fetch exchange rates: API key is not configured or placeholder is being used.")
                     ExchangeRateResult.Stale(localRates)
                 } catch (e: Exception) {
                     Timber.w(

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImpl.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCurrencyDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.remote.RemoteCurrencyDataSource
+import es.pedrazamiguez.splittrip.domain.exception.ApiKeyNotConfiguredException
 import es.pedrazamiguez.splittrip.domain.model.Currency
 import es.pedrazamiguez.splittrip.domain.repository.CurrencyRepository
 import es.pedrazamiguez.splittrip.domain.result.ExchangeRateResult
@@ -15,16 +16,23 @@ class CurrencyRepositoryImpl(
     private val cacheDuration: Duration
 ) : CurrencyRepository {
 
-    override suspend fun getCurrencies(forceRefresh: Boolean): List<Currency> = if (forceRefresh) {
-        val remote = remoteDataSource.fetchCurrencies()
-        localDataSource.saveCurrencies(remote)
-        remote
-    } else {
-        val local = localDataSource.getCurrencies()
-        local.ifEmpty {
+    override suspend fun getCurrencies(forceRefresh: Boolean): List<Currency> {
+        if (!forceRefresh) {
+            val local = localDataSource.getCurrencies()
+            if (local.isNotEmpty()) {
+                return local
+            }
+        }
+        return try {
             val remote = remoteDataSource.fetchCurrencies()
             localDataSource.saveCurrencies(remote)
             remote
+        } catch (ignored: ApiKeyNotConfiguredException) {
+            Timber.w("Failed to fetch currencies: API key is not configured (placeholder is being used).")
+            localDataSource.getCurrencies()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to fetch currencies")
+            localDataSource.getCurrencies()
         }
     }
 
@@ -43,11 +51,14 @@ class CurrencyRepositoryImpl(
 
         return when {
             localRates.exchangeRates.isEmpty() -> {
-                runCatching {
+                try {
                     val remoteRates = remoteDataSource.fetchExchangeRates(baseCurrencyCode)
                     localDataSource.saveExchangeRates(remoteRates)
                     ExchangeRateResult.Fresh(remoteRates)
-                }.getOrElse { e ->
+                } catch (ignored: ApiKeyNotConfiguredException) {
+                    Timber.w("Failed to fetch exchange rates: API key is not configured (placeholder is being used).")
+                    ExchangeRateResult.Empty
+                } catch (e: Exception) {
                     Timber.e(
                         e,
                         "Failed to fetch exchange rates for baseCurrencyCode=%s (no local cache)",
@@ -58,11 +69,14 @@ class CurrencyRepositoryImpl(
             }
 
             isStale -> {
-                runCatching {
+                try {
                     val remoteRates = remoteDataSource.fetchExchangeRates(baseCurrencyCode)
                     localDataSource.saveExchangeRates(remoteRates)
                     ExchangeRateResult.Fresh(remoteRates)
-                }.getOrElse { e ->
+                } catch (ignored: ApiKeyNotConfiguredException) {
+                    Timber.w("Failed to fetch exchange rates: API key is not configured (placeholder is being used).")
+                    ExchangeRateResult.Stale(localRates)
+                } catch (e: Exception) {
                     Timber.w(
                         e,
                         "Failed to refresh exchange rates for baseCurrencyCode=%s" +

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImplTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import timber.log.Timber
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CurrencyRepositoryImplTest {
@@ -57,6 +58,18 @@ class CurrencyRepositoryImplTest {
         lastUpdated = Instant.now()
     )
 
+    private val loggedErrors = mutableListOf<String>()
+    private val loggedWarnings = mutableListOf<String>()
+    private val testTree = object : Timber.Tree() {
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            if (priority == 5) { // Log.WARN
+                loggedWarnings.add(message)
+            } else if (priority == 6) { // Log.ERROR
+                loggedErrors.add(message)
+            }
+        }
+    }
+
     @BeforeEach
     fun setUp() {
         currencyRepositoryImpl = CurrencyRepositoryImpl(
@@ -64,10 +77,14 @@ class CurrencyRepositoryImplTest {
             remote,
             Duration.ofHours(12)
         )
+        Timber.plant(testTree)
     }
 
     @AfterEach
     fun tearDown() {
+        Timber.uproot(testTree)
+        loggedWarnings.clear()
+        loggedErrors.clear()
         clearAllMocks()
     }
 
@@ -84,6 +101,7 @@ class CurrencyRepositoryImplTest {
 
             assertEquals(listOf(usd, eur), result)
             coVerify(exactly = 0) { remote.fetchCurrencies() }
+            coVerify(exactly = 1) { local.getCurrencies() }
         }
 
         @Test
@@ -97,6 +115,7 @@ class CurrencyRepositoryImplTest {
             assertEquals(listOf(usd, eur), result)
             coVerify { remote.fetchCurrencies() }
             coVerify { local.saveCurrencies(listOf(usd, eur)) }
+            coVerify(exactly = 1) { local.getCurrencies() }
         }
 
         @Test
@@ -122,6 +141,9 @@ class CurrencyRepositoryImplTest {
 
             assertEquals(listOf(usd, eur), result)
             coVerify { remote.fetchCurrencies() }
+            coVerify(exactly = 1) { local.getCurrencies() }
+            assertTrue(loggedWarnings.any { it.contains("API key is not configured or placeholder is being used") })
+            assertTrue(loggedErrors.isEmpty())
         }
 
         @Test
@@ -133,6 +155,9 @@ class CurrencyRepositoryImplTest {
 
             assertEquals(emptyList<Currency>(), result)
             coVerify { remote.fetchCurrencies() }
+            coVerify(exactly = 1) { local.getCurrencies() }
+            assertTrue(loggedWarnings.any { it.contains("API key is not configured or placeholder is being used") })
+            assertTrue(loggedErrors.isEmpty())
         }
 
         @Test
@@ -144,6 +169,8 @@ class CurrencyRepositoryImplTest {
 
             assertEquals(listOf(usd, eur), result)
             coVerify { remote.fetchCurrencies() }
+            coVerify(exactly = 1) { local.getCurrencies() }
+            assertTrue(loggedErrors.isNotEmpty())
         }
     }
 
@@ -247,6 +274,8 @@ class CurrencyRepositoryImplTest {
             val result = currencyRepositoryImpl.getExchangeRates("USD")
 
             assertInstanceOf(ExchangeRateResult.Empty::class.java, result)
+            assertTrue(loggedWarnings.any { it.contains("API key is not configured or placeholder is being used") })
+            assertTrue(loggedErrors.isEmpty())
         }
 
         @Test
@@ -263,6 +292,8 @@ class CurrencyRepositoryImplTest {
 
             val result = currencyRepositoryImpl.getExchangeRates("USD")
             assertTrue(result is ExchangeRateResult.Stale)
+            assertTrue(loggedWarnings.any { it.contains("API key is not configured or placeholder is being used") })
+            assertTrue(loggedErrors.isEmpty())
         }
     }
 }

--- a/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImplTest.kt
+++ b/data/src/test/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/CurrencyRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.data.repository.impl
 
 import es.pedrazamiguez.splittrip.domain.datasource.local.LocalCurrencyDataSource
 import es.pedrazamiguez.splittrip.domain.datasource.remote.RemoteCurrencyDataSource
+import es.pedrazamiguez.splittrip.domain.exception.ApiKeyNotConfiguredException
 import es.pedrazamiguez.splittrip.domain.model.Currency
 import es.pedrazamiguez.splittrip.domain.model.ExchangeRate
 import es.pedrazamiguez.splittrip.domain.model.ExchangeRates
@@ -111,6 +112,39 @@ class CurrencyRepositoryImplTest {
             // Should NOT query local when forceRefresh=true
             coVerify(exactly = 0) { local.getCurrencies() }
         }
+
+        @Test
+        fun `returns local currencies on ApiKeyNotConfiguredException`() = runTest {
+            coEvery { local.getCurrencies() } returns listOf(usd, eur)
+            coEvery { remote.fetchCurrencies() } throws ApiKeyNotConfiguredException("Missing key")
+
+            val result = currencyRepositoryImpl.getCurrencies(forceRefresh = true)
+
+            assertEquals(listOf(usd, eur), result)
+            coVerify { remote.fetchCurrencies() }
+        }
+
+        @Test
+        fun `returns empty list on ApiKeyNotConfiguredException and empty local`() = runTest {
+            coEvery { local.getCurrencies() } returns emptyList()
+            coEvery { remote.fetchCurrencies() } throws ApiKeyNotConfiguredException("Missing key")
+
+            val result = currencyRepositoryImpl.getCurrencies(forceRefresh = false)
+
+            assertEquals(emptyList<Currency>(), result)
+            coVerify { remote.fetchCurrencies() }
+        }
+
+        @Test
+        fun `returns local currencies on remote fetch general exception`() = runTest {
+            coEvery { local.getCurrencies() } returns listOf(usd, eur)
+            coEvery { remote.fetchCurrencies() } throws RuntimeException("network error")
+
+            val result = currencyRepositoryImpl.getCurrencies(forceRefresh = true)
+
+            assertEquals(listOf(usd, eur), result)
+            coVerify { remote.fetchCurrencies() }
+        }
     }
 
     // ── getExchangeRates ───────────────────────────────────────────────────
@@ -200,6 +234,35 @@ class CurrencyRepositoryImplTest {
 
             assertTrue(result is ExchangeRateResult.Fresh)
             coVerify { local.saveExchangeRates(newRemoteRates) }
+        }
+
+        @Test
+        fun `returns Empty on ApiKeyNotConfiguredException and empty local rates`() = runTest {
+            val emptyRates = ExchangeRates(usd, emptyList(), Instant.EPOCH)
+
+            coEvery { local.getExchangeRates("USD") } returns emptyRates
+            coEvery { local.getLastUpdated("USD") } returns null
+            coEvery { remote.fetchExchangeRates("USD") } throws ApiKeyNotConfiguredException("Missing key")
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+
+            assertInstanceOf(ExchangeRateResult.Empty::class.java, result)
+        }
+
+        @Test
+        fun `falls back to stale on ApiKeyNotConfiguredException`() = runTest {
+            val staleRates = freshRates.copy(
+                lastUpdated = Instant
+                    .now()
+                    .minusSeconds(86_400)
+            )
+
+            coEvery { local.getExchangeRates("USD") } returns staleRates
+            coEvery { local.getLastUpdated("USD") } returns staleRates.lastUpdated.epochSecond
+            coEvery { remote.fetchExchangeRates("USD") } throws ApiKeyNotConfiguredException("Missing key")
+
+            val result = currencyRepositoryImpl.getExchangeRates("USD")
+            assertTrue(result is ExchangeRateResult.Stale)
         }
     }
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/exception/ApiKeyNotConfiguredException.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/exception/ApiKeyNotConfiguredException.kt
@@ -1,0 +1,3 @@
+package es.pedrazamiguez.splittrip.domain.exception
+
+class ApiKeyNotConfiguredException(message: String) : Exception(message)


### PR DESCRIPTION
Add ApiKeyNotConfiguredException and validate the OpenExchangeRates appId in RemoteCurrencyDataSourceImpl (checks blank or placeholder). RemoteCurrencyDataSource now throws this exception when the API key isn't configured. CurrencyRepositoryImpl catches the exception, logs a warning, and falls back to local cache (returning local, stale, or empty results as appropriate) instead of failing. Tests were added to cover the new fallback behaviors for both currency list and exchange rates scenarios.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1178 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
