### PR TITLE
[SPLTRP-1130]: [Settings]: Implement App Theme Selection (Dark/Light Mode)

### DIFF
--- a/app/src/main/kotlin/es/pedrazamiguez/splittrip/MainActivity.kt
+++ b/app/src/main/kotlin/es/pedrazamiguez/splittrip/MainActivity.kt
@@ -5,13 +5,20 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.SplitTripTheme
 import es.pedrazamiguez.splittrip.core.designsystem.navigation.Routes
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
 import es.pedrazamiguez.splittrip.features.main.navigation.DeepLinkHolder
 import es.pedrazamiguez.splittrip.navigation.AppNavHost
 import org.koin.android.ext.android.inject
+import org.koin.compose.getKoin
 
 class MainActivity : AppCompatActivity() {
 
@@ -34,7 +41,17 @@ class MainActivity : AppCompatActivity() {
 
         enableEdgeToEdge()
         setContent {
-            SplitTripTheme {
+            val koin = getKoin()
+            val getAppThemeUseCase = remember(koin) { koin.get<GetAppThemeUseCase>() }
+            val themeState by getAppThemeUseCase().collectAsStateWithLifecycle(initialValue = AppTheme.SYSTEM.code)
+
+            val darkTheme = when (AppTheme.fromCode(themeState)) {
+                AppTheme.SYSTEM -> isSystemInDarkTheme()
+                AppTheme.LIGHT -> false
+                AppTheme.DARK -> true
+            }
+
+            SplitTripTheme(darkTheme = darkTheme) {
                 val navController = rememberNavController()
                 navHostController = navController
                 AppNavHost(navController = navController)

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/navigation/Routes.kt
@@ -19,6 +19,7 @@ object Routes {
     const val SETTINGS_LANGUAGE = "settings_language"
     const val SETTINGS_NOTIFICATIONS = "settings_notifications"
     const val SETTINGS_DEVELOPER_SERVICES = "settings_developer_services"
+    const val SETTINGS_THEME = "settings_theme"
     const val GROUP_DETAIL = "group_detail/{groupId}"
     const val EXPENSE_DETAIL = "expense_detail/{expenseId}"
     const val EDIT_EXPENSE = "edit_expense/{expenseId}"

--- a/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datastore/UserPreferences.kt
+++ b/data/local/src/main/kotlin/es/pedrazamiguez/splittrip/data/local/datastore/UserPreferences.kt
@@ -24,6 +24,7 @@ class UserPreferences(
         private val PENDING_FCM_TOKEN_KEY = stringPreferencesKey("pending_fcm_token")
         private val APP_LANGUAGE_KEY = stringPreferencesKey("app_language")
         private val SHOULD_SHOW_LANGUAGE_PILL_KEY = booleanPreferencesKey("should_show_language_pill")
+        private val APP_THEME_KEY = stringPreferencesKey("app_theme")
 
         // User-scoped key name constants (prefixed at access time via userKey())
         private const val SELECTED_GROUP_ID = "selected_group_id"
@@ -42,6 +43,18 @@ class UserPreferences(
     suspend fun setAppLanguage(languageCode: String) {
         context.dataStore.edit { prefs ->
             prefs[APP_LANGUAGE_KEY] = languageCode
+        }
+    }
+
+    // ── App Theme (Device-scoped) ────────────────────────────────────────
+
+    val appTheme: Flow<String?> = context.dataStore.data.map { prefs ->
+        prefs[APP_THEME_KEY]
+    }
+
+    suspend fun setAppTheme(themeCode: String) {
+        context.dataStore.edit { prefs ->
+            prefs[APP_THEME_KEY] = themeCode
         }
     }
 

--- a/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/datastore/UserPreferencesTest.kt
+++ b/data/local/src/test/kotlin/es/pedrazamiguez/splittrip/data/local/datastore/UserPreferencesTest.kt
@@ -432,4 +432,24 @@ class UserPreferencesTest {
         val result = prefs.shouldShowLanguagePill.first()
         assertFalse(result)
     }
+
+    // ── App Theme (Device-scoped) ────────────────────────────────────────
+
+    @Test
+    fun `appTheme is shared across users (device-scoped)`() = runTest {
+        val prefsA = createUserPreferences(USER_A_ID)
+        prefsA.setAppTheme("dark")
+
+        val prefsB = createUserPreferences(USER_B_ID)
+        val result = prefsB.appTheme.first()
+
+        assertEquals("dark", result)
+    }
+
+    @Test
+    fun `appTheme defaults to null`() = runTest {
+        val prefs = createUserPreferences(USER_A_ID)
+        val result = prefs.appTheme.first()
+        assertNull(result)
+    }
 }

--- a/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserPreferenceRepositoryImpl.kt
+++ b/data/src/main/kotlin/es/pedrazamiguez/splittrip/data/repository/impl/UserPreferenceRepositoryImpl.kt
@@ -33,6 +33,12 @@ class UserPreferenceRepositoryImpl(
         userPreferences.setShouldShowLanguagePill(show)
     }
 
+    override fun getAppTheme(): Flow<String?> = userPreferences.appTheme
+
+    override suspend fun setAppTheme(themeCode: String) {
+        userPreferences.setAppTheme(themeCode)
+    }
+
     override suspend fun clearAll() {
         userPreferences.clearAll()
     }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/SettingsDomainModule.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/di/SettingsDomainModule.kt
@@ -7,6 +7,7 @@ import es.pedrazamiguez.splittrip.domain.repository.UserPreferenceRepository
 import es.pedrazamiguez.splittrip.domain.usecase.setting.ConsumeLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetActiveAiEngineUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppLanguageUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCategoryUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetGroupLastUsedPaymentMethodUseCase
@@ -19,6 +20,7 @@ import es.pedrazamiguez.splittrip.domain.usecase.setting.GetUserDefaultCurrencyU
 import es.pedrazamiguez.splittrip.domain.usecase.setting.IsOnboardingCompleteUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetActiveAiEngineUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetAppLanguageUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.SetAppThemeUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedCategoryUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetGroupLastUsedPaymentMethodUseCase
@@ -158,6 +160,18 @@ val settingsDomainModule = module {
 
     factory<ConsumeLanguagePillUseCase> {
         ConsumeLanguagePillUseCase(
+            preferenceRepository = get<UserPreferenceRepository>()
+        )
+    }
+
+    factory<GetAppThemeUseCase> {
+        GetAppThemeUseCase(
+            preferenceRepository = get<UserPreferenceRepository>()
+        )
+    }
+
+    factory<SetAppThemeUseCase> {
+        SetAppThemeUseCase(
             preferenceRepository = get<UserPreferenceRepository>()
         )
     }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/enums/AppTheme.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/enums/AppTheme.kt
@@ -1,0 +1,16 @@
+package es.pedrazamiguez.splittrip.domain.enums
+
+enum class AppTheme(val code: String, val englishName: String) {
+    SYSTEM("system", "System default"),
+    LIGHT("light", "Light"),
+    DARK("dark", "Dark");
+
+    companion object {
+        fun fromCode(code: String?): AppTheme {
+            if (code != null) {
+                return entries.find { it.code.equals(code, ignoreCase = true) } ?: SYSTEM
+            }
+            return SYSTEM
+        }
+    }
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/UserPreferenceRepository.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/repository/UserPreferenceRepository.kt
@@ -17,5 +17,8 @@ interface UserPreferenceRepository {
     fun getShouldShowLanguagePill(): Flow<Boolean>
     suspend fun setShouldShowLanguagePill(show: Boolean)
 
+    fun getAppTheme(): Flow<String?>
+    suspend fun setAppTheme(themeCode: String)
+
     suspend fun clearAll()
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/GetAppThemeUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/GetAppThemeUseCase.kt
@@ -1,0 +1,9 @@
+package es.pedrazamiguez.splittrip.domain.usecase.setting
+
+import es.pedrazamiguez.splittrip.domain.repository.UserPreferenceRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetAppThemeUseCase(private val preferenceRepository: UserPreferenceRepository) {
+
+    operator fun invoke(): Flow<String?> = preferenceRepository.getAppTheme()
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/SetAppThemeUseCase.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/SetAppThemeUseCase.kt
@@ -1,0 +1,10 @@
+package es.pedrazamiguez.splittrip.domain.usecase.setting
+
+import es.pedrazamiguez.splittrip.domain.repository.UserPreferenceRepository
+
+class SetAppThemeUseCase(private val preferenceRepository: UserPreferenceRepository) {
+
+    suspend operator fun invoke(themeCode: String) {
+        preferenceRepository.setAppTheme(themeCode)
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/GetAppThemeUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/GetAppThemeUseCaseTest.kt
@@ -1,0 +1,26 @@
+package es.pedrazamiguez.splittrip.domain.usecase.setting
+
+import es.pedrazamiguez.splittrip.domain.repository.UserPreferenceRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetAppThemeUseCaseTest {
+
+    private val repository: UserPreferenceRepository = mockk()
+    private val useCase = GetAppThemeUseCase(repository)
+
+    @Test
+    fun `returns app theme flow from repository`() = runTest {
+        val expectedTheme = "DARK"
+        every { repository.getAppTheme() } returns flowOf(expectedTheme)
+
+        val result = useCase().first()
+
+        assertEquals(expectedTheme, result)
+    }
+}

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/SetAppThemeUseCaseTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/usecase/setting/SetAppThemeUseCaseTest.kt
@@ -1,0 +1,26 @@
+package es.pedrazamiguez.splittrip.domain.usecase.setting
+
+import es.pedrazamiguez.splittrip.domain.repository.UserPreferenceRepository
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class SetAppThemeUseCaseTest {
+
+    private val repository: UserPreferenceRepository = mockk()
+    private val useCase = SetAppThemeUseCase(repository)
+
+    @Test
+    fun `sets app theme in repository`() = runTest {
+        val theme = "LIGHT"
+        coJustRun { repository.setAppTheme(theme) }
+
+        useCase(theme)
+
+        coVerify(exactly = 1) {
+            repository.setAppTheme(theme)
+        }
+    }
+}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/di/SettingsUiModule.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/di/SettingsUiModule.kt
@@ -11,15 +11,18 @@ import es.pedrazamiguez.splittrip.domain.usecase.notification.GetNotificationPre
 import es.pedrazamiguez.splittrip.domain.usecase.notification.UpdateNotificationPreferenceUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.ConsumeLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppLanguageUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetShouldShowLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetUserDefaultCurrencyUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetAppLanguageUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.SetAppThemeUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.SetUserDefaultCurrencyUseCase
 import es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl.DefaultCurrencyScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl.DeveloperServicesScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl.LanguageScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl.NotificationPreferencesScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl.SettingsScreenUiProviderImpl
+import es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl.ThemeScreenUiProviderImpl
 import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.AppVersionViewModel
 import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.DefaultCurrencyViewModel
 import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.DeveloperServicesViewModel
@@ -27,6 +30,7 @@ import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.Insta
 import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.LanguageViewModel
 import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.NotificationPreferencesViewModel
 import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.SettingsViewModel
+import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.ThemeViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -39,7 +43,8 @@ val settingsUiModule = module {
             getUserDefaultCurrencyUseCase = get<GetUserDefaultCurrencyUseCase>(),
             getAppLanguageUseCase = get<GetAppLanguageUseCase>(),
             getShouldShowLanguagePillUseCase = get<GetShouldShowLanguagePillUseCase>(),
-            consumeLanguagePillUseCase = get<ConsumeLanguagePillUseCase>()
+            consumeLanguagePillUseCase = get<ConsumeLanguagePillUseCase>(),
+            getAppThemeUseCase = get<GetAppThemeUseCase>()
         )
     }
 
@@ -75,9 +80,17 @@ val settingsUiModule = module {
         )
     }
 
+    viewModel {
+        ThemeViewModel(
+            getAppThemeUseCase = get<GetAppThemeUseCase>(),
+            setAppThemeUseCase = get<SetAppThemeUseCase>()
+        )
+    }
+
     single { DefaultCurrencyScreenUiProviderImpl() } bind ScreenUiProvider::class
     single { LanguageScreenUiProviderImpl() } bind ScreenUiProvider::class
     single { NotificationPreferencesScreenUiProviderImpl() } bind ScreenUiProvider::class
     single { SettingsScreenUiProviderImpl() } bind ScreenUiProvider::class
     single { DeveloperServicesScreenUiProviderImpl() } bind ScreenUiProvider::class
+    single { ThemeScreenUiProviderImpl() } bind ScreenUiProvider::class
 }

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/navigation/SettingsNavigation.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/navigation/SettingsNavigation.kt
@@ -8,6 +8,7 @@ import es.pedrazamiguez.splittrip.features.settings.presentation.feature.Develop
 import es.pedrazamiguez.splittrip.features.settings.presentation.feature.LanguageFeature
 import es.pedrazamiguez.splittrip.features.settings.presentation.feature.NotificationPreferencesFeature
 import es.pedrazamiguez.splittrip.features.settings.presentation.feature.SettingsFeature
+import es.pedrazamiguez.splittrip.features.settings.presentation.feature.ThemeFeature
 
 fun NavGraphBuilder.settingsGraph() {
     composable(Routes.SETTINGS) {
@@ -18,6 +19,9 @@ fun NavGraphBuilder.settingsGraph() {
     }
     composable(Routes.SETTINGS_LANGUAGE) {
         LanguageFeature()
+    }
+    composable(Routes.SETTINGS_THEME) {
+        ThemeFeature()
     }
     composable(Routes.SETTINGS_NOTIFICATIONS) {
         NotificationPreferencesFeature()

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/component/ThemeDescription.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/component/ThemeDescription.kt
@@ -1,0 +1,17 @@
+package es.pedrazamiguez.splittrip.features.settings.presentation.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
+import es.pedrazamiguez.splittrip.features.settings.R
+
+@Composable
+internal fun ThemeDescription(currentThemeCode: String?) {
+    val themeName = when (AppTheme.fromCode(currentThemeCode)) {
+        AppTheme.SYSTEM -> stringResource(R.string.settings_preferences_theme_system)
+        AppTheme.LIGHT -> stringResource(R.string.settings_preferences_theme_light)
+        AppTheme.DARK -> stringResource(R.string.settings_preferences_theme_dark)
+    }
+    Text(text = themeName)
+}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/component/ThemeDescription.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/component/ThemeDescription.kt
@@ -7,7 +7,7 @@ import es.pedrazamiguez.splittrip.domain.enums.AppTheme
 import es.pedrazamiguez.splittrip.features.settings.R
 
 @Composable
-internal fun ThemeDescription(currentThemeCode: String?) {
+internal fun ThemeDescription(currentThemeCode: String) {
     val themeName = when (AppTheme.fromCode(currentThemeCode)) {
         AppTheme.SYSTEM -> stringResource(R.string.settings_preferences_theme_system)
         AppTheme.LIGHT -> stringResource(R.string.settings_preferences_theme_light)

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/data/SettingsData.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/data/SettingsData.kt
@@ -24,6 +24,7 @@ import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.UserPin
 import es.pedrazamiguez.splittrip.features.settings.R
 import es.pedrazamiguez.splittrip.features.settings.presentation.component.CurrencyDescription
 import es.pedrazamiguez.splittrip.features.settings.presentation.component.LanguageDescription
+import es.pedrazamiguez.splittrip.features.settings.presentation.component.ThemeDescription
 import es.pedrazamiguez.splittrip.features.settings.presentation.feature.AppVersionFeature
 import es.pedrazamiguez.splittrip.features.settings.presentation.feature.InstallationIdFeature
 import es.pedrazamiguez.splittrip.features.settings.presentation.model.SettingsItemModel
@@ -78,10 +79,13 @@ private fun preferencesSection(
 ) = SettingsSectionModel(
     titleRes = R.string.settings_section_preferences,
     items = listOf(
-        SettingsItemModel.Standard(
+        SettingsItemModel.WithCustomDescription(
             icon = TablerIcons.Outline.MoonStars,
             titleRes = R.string.settings_preferences_theme_title,
-            descriptionRes = R.string.settings_preferences_theme_description
+            onClick = params.onThemeClick,
+            descriptionContent = {
+                ThemeDescription(params.currentThemeCode)
+            }
         ),
         SettingsItemModel.WithCustomDescription(
             icon = TablerIcons.Outline.Language,

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/data/SettingsPreferencesParams.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/data/SettingsPreferencesParams.kt
@@ -10,6 +10,6 @@ data class SettingsPreferencesParams(
     val onDefaultCurrencyClick: () -> Unit,
     val currentLanguageCode: String,
     val onLanguageClick: () -> Unit,
-    val currentThemeCode: String?,
+    val currentThemeCode: String,
     val onThemeClick: () -> Unit
 )

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/data/SettingsPreferencesParams.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/data/SettingsPreferencesParams.kt
@@ -9,5 +9,7 @@ data class SettingsPreferencesParams(
     val currentCurrency: Currency?,
     val onDefaultCurrencyClick: () -> Unit,
     val currentLanguageCode: String,
-    val onLanguageClick: () -> Unit
+    val onLanguageClick: () -> Unit,
+    val currentThemeCode: String?,
+    val onThemeClick: () -> Unit
 )

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/feature/SettingsFeature.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/feature/SettingsFeature.kt
@@ -43,6 +43,7 @@ fun SettingsFeature(
     val hasPermission by settingsViewModel.hasNotificationPermission.collectAsStateWithLifecycle()
     val currentLanguageCode by settingsViewModel.currentLanguageCode.collectAsStateWithLifecycle()
     val shouldShowLanguagePill by settingsViewModel.shouldShowLanguagePill.collectAsStateWithLifecycle()
+    val currentThemeCode by settingsViewModel.currentThemeCode.collectAsStateWithLifecycle()
 
     var showLogoutDialog by remember { mutableStateOf(false) }
 
@@ -103,6 +104,8 @@ fun SettingsFeature(
             },
             currentLanguageCode = currentLanguageCode,
             onLanguageClick = { navController.navigate(Routes.SETTINGS_LANGUAGE) },
+            currentThemeCode = currentThemeCode,
+            onThemeClick = { navController.navigate(Routes.SETTINGS_THEME) },
             onLogoutClick = { showLogoutDialog = true },
             onDeveloperServicesTestClick = {
                 navController.navigate(Routes.SETTINGS_DEVELOPER_SERVICES)

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/feature/ThemeFeature.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/feature/ThemeFeature.kt
@@ -1,0 +1,58 @@
+package es.pedrazamiguez.splittrip.features.settings.presentation.feature
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import es.pedrazamiguez.splittrip.core.designsystem.constant.UiConstants
+import es.pedrazamiguez.splittrip.core.designsystem.navigation.LocalRootNavController
+import es.pedrazamiguez.splittrip.core.designsystem.navigation.Routes
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.scaffold.FeatureScaffold
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.notification.LocalTopPillController
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
+import es.pedrazamiguez.splittrip.features.settings.R
+import es.pedrazamiguez.splittrip.features.settings.presentation.screen.ThemeScreen
+import es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel.ThemeViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun ThemeFeature(viewModel: ThemeViewModel = koinViewModel()) {
+    val selectedTheme by viewModel.selectedThemeCode.collectAsStateWithLifecycle()
+
+    val navController = LocalRootNavController.current
+    val scope = rememberCoroutineScope()
+    val pillController = LocalTopPillController.current
+
+    val themeNames = viewModel.availableThemes.associate { theme ->
+        theme.code to when (theme) {
+            AppTheme.SYSTEM -> stringResource(R.string.settings_preferences_theme_system)
+            AppTheme.LIGHT -> stringResource(R.string.settings_preferences_theme_light)
+            AppTheme.DARK -> stringResource(R.string.settings_preferences_theme_dark)
+        }
+    }
+    val themeChangedFormat = stringResource(R.string.settings_preferences_theme_changed_format)
+
+    FeatureScaffold(currentRoute = Routes.SETTINGS_THEME) {
+        ThemeScreen(
+            availableThemes = viewModel.availableThemes,
+            selectedThemeCode = selectedTheme,
+            onThemeSelected = { newThemeCode ->
+                viewModel.onThemeSelected(newThemeCode)
+
+                val themeName = themeNames[newThemeCode] ?: newThemeCode
+
+                pillController.showPill(
+                    themeChangedFormat.format(themeName)
+                )
+
+                scope.launch {
+                    delay(UiConstants.NAV_FEEDBACK_DELAY)
+                    navController.popBackStack()
+                }
+            }
+        )
+    }
+}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/SettingsScreen.kt
@@ -22,6 +22,8 @@ fun SettingsScreen(
     onDefaultCurrencyClick: () -> Unit = {},
     currentLanguageCode: String = "en",
     onLanguageClick: () -> Unit = {},
+    currentThemeCode: String? = null,
+    onThemeClick: () -> Unit = {},
     onLogoutClick: () -> Unit = {},
     onDeveloperServicesTestClick: () -> Unit = {}
 ) {
@@ -32,7 +34,9 @@ fun SettingsScreen(
         currentCurrency = currentCurrency,
         onDefaultCurrencyClick = onDefaultCurrencyClick,
         currentLanguageCode = currentLanguageCode,
-        onLanguageClick = onLanguageClick
+        onLanguageClick = onLanguageClick,
+        currentThemeCode = currentThemeCode,
+        onThemeClick = onThemeClick
     )
 
     val sections = buildSettingsSections(

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
 import es.pedrazamiguez.splittrip.domain.enums.Currency
 import es.pedrazamiguez.splittrip.features.settings.presentation.component.LogoutButton
 import es.pedrazamiguez.splittrip.features.settings.presentation.component.settingsSections
@@ -22,7 +23,7 @@ fun SettingsScreen(
     onDefaultCurrencyClick: () -> Unit = {},
     currentLanguageCode: String = "en",
     onLanguageClick: () -> Unit = {},
-    currentThemeCode: String? = null,
+    currentThemeCode: String = AppTheme.SYSTEM.code,
     onThemeClick: () -> Unit = {},
     onLogoutClick: () -> Unit = {},
     onDeveloperServicesTestClick: () -> Unit = {}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/ThemeScreen.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/ThemeScreen.kt
@@ -1,0 +1,53 @@
+package es.pedrazamiguez.splittrip.features.settings.presentation.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
+import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.Check
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
+import es.pedrazamiguez.splittrip.features.settings.R
+
+@Composable
+fun ThemeScreen(
+    availableThemes: List<AppTheme>,
+    selectedThemeCode: String,
+    onThemeSelected: (String) -> Unit
+) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(availableThemes) { theme ->
+
+            val isSelected = theme.code == selectedThemeCode
+            val displayName = stringResource(id = theme.getDisplayNameRes())
+
+            ListItem(
+                headlineContent = { Text(text = displayName) },
+                supportingContent = { Text(text = theme.englishName) },
+                trailingContent = {
+                    if (isSelected) {
+                        Icon(
+                            imageVector = TablerIcons.Outline.Check,
+                            contentDescription = null
+                        )
+                    }
+                },
+                modifier = Modifier.clickable {
+                    onThemeSelected(theme.code)
+                }
+            )
+        }
+    }
+}
+
+private fun AppTheme.getDisplayNameRes(): Int = when (this) {
+    AppTheme.SYSTEM -> R.string.settings_preferences_theme_system
+    AppTheme.LIGHT -> R.string.settings_preferences_theme_light
+    AppTheme.DARK -> R.string.settings_preferences_theme_dark
+}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/impl/ThemeScreenUiProviderImpl.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/screen/impl/ThemeScreenUiProviderImpl.kt
@@ -1,0 +1,23 @@
+package es.pedrazamiguez.splittrip.features.settings.presentation.screen.impl
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import es.pedrazamiguez.splittrip.core.designsystem.navigation.LocalRootNavController
+import es.pedrazamiguez.splittrip.core.designsystem.navigation.Routes
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.screen.ScreenUiProvider
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.topbar.DynamicTopAppBar
+import es.pedrazamiguez.splittrip.features.settings.R
+
+class ThemeScreenUiProviderImpl(override val route: String = Routes.SETTINGS_THEME) :
+    ScreenUiProvider {
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override val topBar: @Composable () -> Unit = {
+        val navController = LocalRootNavController.current
+        DynamicTopAppBar(
+            title = stringResource(R.string.settings_preferences_theme_dialog_title),
+            onBack = { navController.popBackStack() }
+        )
+    }
+}

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import es.pedrazamiguez.splittrip.core.common.constant.AppConstants
 import es.pedrazamiguez.splittrip.domain.enums.AppLanguage
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
 import es.pedrazamiguez.splittrip.domain.enums.Currency
 import es.pedrazamiguez.splittrip.domain.usecase.auth.SignOutUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.ConsumeLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppLanguageUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetShouldShowLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetUserDefaultCurrencyUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +26,8 @@ class SettingsViewModel(
     private val getUserDefaultCurrencyUseCase: GetUserDefaultCurrencyUseCase,
     private val getAppLanguageUseCase: GetAppLanguageUseCase,
     private val getShouldShowLanguagePillUseCase: GetShouldShowLanguagePillUseCase,
-    private val consumeLanguagePillUseCase: ConsumeLanguagePillUseCase
+    private val consumeLanguagePillUseCase: ConsumeLanguagePillUseCase,
+    private val getAppThemeUseCase: GetAppThemeUseCase
 ) : ViewModel() {
 
     val currentCurrency: StateFlow<Currency?> = getUserDefaultCurrencyUseCase().map { code ->
@@ -51,6 +54,15 @@ class SettingsViewModel(
             replayExpirationMillis = AppConstants.FLOW_REPLAY_EXPIRATION
         ),
         initialValue = AppLanguage.fromCode(null).code
+    )
+
+    val currentThemeCode: StateFlow<String?> = getAppThemeUseCase().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(
+            stopTimeoutMillis = AppConstants.FLOW_RETENTION_TIME,
+            replayExpirationMillis = AppConstants.FLOW_REPLAY_EXPIRATION
+        ),
+        initialValue = AppTheme.SYSTEM.code
     )
 
     val shouldShowLanguagePill: StateFlow<Boolean> = getShouldShowLanguagePillUseCase().stateIn(

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModel.kt
@@ -56,13 +56,15 @@ class SettingsViewModel(
         initialValue = AppLanguage.fromCode(null).code
     )
 
-    val currentThemeCode: StateFlow<String?> = getAppThemeUseCase().stateIn(
+    val currentThemeCode: StateFlow<String> = getAppThemeUseCase().map { themeCode ->
+        AppTheme.fromCode(themeCode).code
+    }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(
             stopTimeoutMillis = AppConstants.FLOW_RETENTION_TIME,
             replayExpirationMillis = AppConstants.FLOW_REPLAY_EXPIRATION
         ),
-        initialValue = AppTheme.SYSTEM.code
+        initialValue = AppTheme.fromCode(null).code
     )
 
     val shouldShowLanguagePill: StateFlow<Boolean> = getShouldShowLanguagePillUseCase().stateIn(

--- a/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/ThemeViewModel.kt
+++ b/features/settings/src/main/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/ThemeViewModel.kt
@@ -1,0 +1,39 @@
+package es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import es.pedrazamiguez.splittrip.core.common.constant.AppConstants
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.SetAppThemeUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class ThemeViewModel(
+    private val getAppThemeUseCase: GetAppThemeUseCase,
+    private val setAppThemeUseCase: SetAppThemeUseCase
+) : ViewModel() {
+
+    val availableThemes = AppTheme.entries
+
+    val selectedThemeCode: StateFlow<String> = getAppThemeUseCase().map { themeCode ->
+        AppTheme.fromCode(themeCode).code
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(
+            stopTimeoutMillis = AppConstants.FLOW_RETENTION_TIME,
+            replayExpirationMillis = AppConstants.FLOW_REPLAY_EXPIRATION
+        ),
+        initialValue = AppTheme.fromCode(null).code
+    )
+
+    fun onThemeSelected(themeCode: String): Job {
+        return viewModelScope.launch {
+            setAppThemeUseCase(themeCode)
+        }
+    }
+}

--- a/features/settings/src/main/res/values-es-rAN/strings.xml
+++ b/features/settings/src/main/res/values-es-rAN/strings.xml
@@ -123,4 +123,9 @@
     <string name="settings_preferences_language_andaluz">Andalûh (Andalû EPA)</string>
     <string name="settings_preferences_language_changed_format">Idioma cambiao a %1$s</string>
     <string name="settings_preferences_currency_changed_format">Moneda por defêtto cambiá a %1$s</string>
+    <string name="settings_preferences_theme_dialog_title">Çelêççionâh tema</string>
+    <string name="settings_preferences_theme_system">Predeterminao der çîttema</string>
+    <string name="settings_preferences_theme_light">Claro</string>
+    <string name="settings_preferences_theme_dark">Ôccuro</string>
+    <string name="settings_preferences_theme_changed_format">Tema cambiao a %1$s</string>
 </resources>

--- a/features/settings/src/main/res/values-es/strings.xml
+++ b/features/settings/src/main/res/values-es/strings.xml
@@ -147,4 +147,11 @@
     <string name="settings_preferences_language_andaluz">Andaluz (Andalûh EPA)</string>
     <string name="settings_preferences_language_changed_format">Idioma cambiado a %1$s</string>
     <string name="settings_preferences_currency_changed_format">Moneda por defecto cambiada a %1$s</string>
+
+    <!-- Theme Selection -->
+    <string name="settings_preferences_theme_dialog_title">Seleccionar tema</string>
+    <string name="settings_preferences_theme_system">Predeterminado del sistema</string>
+    <string name="settings_preferences_theme_light">Claro</string>
+    <string name="settings_preferences_theme_dark">Oscuro</string>
+    <string name="settings_preferences_theme_changed_format">Tema cambiado a %1$s</string>
 </resources>

--- a/features/settings/src/main/res/values/strings.xml
+++ b/features/settings/src/main/res/values/strings.xml
@@ -148,4 +148,11 @@
     <string name="settings_preferences_language_andaluz">Andaluz (Andalûh EPA)</string>
     <string name="settings_preferences_language_changed_format">Language changed to %1$s</string>
     <string name="settings_preferences_currency_changed_format">Default currency changed to %1$s</string>
+
+    <!-- Theme Selection -->
+    <string name="settings_preferences_theme_dialog_title">Select Theme</string>
+    <string name="settings_preferences_theme_system">System default</string>
+    <string name="settings_preferences_theme_light">Light</string>
+    <string name="settings_preferences_theme_dark">Dark</string>
+    <string name="settings_preferences_theme_changed_format">Theme changed to %1$s</string>
 </resources>

--- a/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.domain.enums.Currency
 import es.pedrazamiguez.splittrip.domain.usecase.auth.SignOutUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.ConsumeLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppLanguageUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetShouldShowLanguagePillUseCase
 import es.pedrazamiguez.splittrip.domain.usecase.setting.GetUserDefaultCurrencyUseCase
 import io.mockk.coEvery
@@ -40,6 +41,7 @@ class SettingsViewModelTest {
     private lateinit var getAppLanguageUseCase: GetAppLanguageUseCase
     private lateinit var getShouldShowLanguagePillUseCase: GetShouldShowLanguagePillUseCase
     private lateinit var consumeLanguagePillUseCase: ConsumeLanguagePillUseCase
+    private lateinit var getAppThemeUseCase: GetAppThemeUseCase
 
     @BeforeEach
     fun setUp() {
@@ -49,9 +51,11 @@ class SettingsViewModelTest {
         getAppLanguageUseCase = mockk()
         getShouldShowLanguagePillUseCase = mockk()
         consumeLanguagePillUseCase = mockk()
+        getAppThemeUseCase = mockk()
 
         every { getAppLanguageUseCase() } returns flowOf(null)
         every { getShouldShowLanguagePillUseCase() } returns flowOf(false)
+        every { getAppThemeUseCase() } returns flowOf("system")
     }
 
     @AfterEach
@@ -64,7 +68,8 @@ class SettingsViewModelTest {
         getUserDefaultCurrencyUseCase = getUserDefaultCurrencyUseCase,
         getAppLanguageUseCase = getAppLanguageUseCase,
         getShouldShowLanguagePillUseCase = getShouldShowLanguagePillUseCase,
-        consumeLanguagePillUseCase = consumeLanguagePillUseCase
+        consumeLanguagePillUseCase = consumeLanguagePillUseCase,
+        getAppThemeUseCase = getAppThemeUseCase
     )
 
     // ── currentCurrency StateFlow ───────────────────────────────────────────
@@ -196,6 +201,27 @@ class SettingsViewModelTest {
 
             val expected = if (Locale.getDefault().language == "es") "es" else "en"
             assertEquals(expected, viewModel.currentLanguageCode.value)
+            collectJob.cancel()
+        }
+    }
+
+    // ── currentThemeCode StateFlow ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("currentThemeCode")
+    inner class CurrentThemeCode {
+
+        @Test
+        fun `emits Theme from use case flow`() = runTest(testDispatcher) {
+            every { getUserDefaultCurrencyUseCase() } returns flowOf("EUR")
+            every { getAppThemeUseCase() } returns flowOf("dark")
+
+            val viewModel = createViewModel()
+
+            val collectJob = launch { viewModel.currentThemeCode.collect {} }
+            advanceUntilIdle()
+
+            assertEquals("dark", viewModel.currentThemeCode.value)
             collectJob.cancel()
         }
     }

--- a/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/SettingsViewModelTest.kt
@@ -224,6 +224,29 @@ class SettingsViewModelTest {
             assertEquals("dark", viewModel.currentThemeCode.value)
             collectJob.cancel()
         }
+
+        @Test
+        fun `null theme code maps to system theme code`() = runTest(testDispatcher) {
+            every { getUserDefaultCurrencyUseCase() } returns flowOf("EUR")
+            every { getAppThemeUseCase() } returns flowOf(null)
+
+            val viewModel = createViewModel()
+
+            val collectJob = launch { viewModel.currentThemeCode.collect {} }
+            advanceUntilIdle()
+
+            assertEquals("system", viewModel.currentThemeCode.value)
+            collectJob.cancel()
+        }
+
+        @Test
+        fun `initial value is system before flow emits`() = runTest(testDispatcher) {
+            every { getUserDefaultCurrencyUseCase() } returns flowOf("EUR")
+            every { getAppThemeUseCase() } returns flowOf("dark")
+
+            val viewModel = createViewModel()
+            assertEquals("system", viewModel.currentThemeCode.value)
+        }
     }
 
     // ── shouldShowLanguagePill StateFlow ────────────────────────────────────

--- a/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/ThemeViewModelTest.kt
+++ b/features/settings/src/test/kotlin/es/pedrazamiguez/splittrip/features/settings/presentation/viewmodel/ThemeViewModelTest.kt
@@ -1,0 +1,83 @@
+package es.pedrazamiguez.splittrip.features.settings.presentation.viewmodel
+
+import es.pedrazamiguez.splittrip.domain.enums.AppTheme
+import es.pedrazamiguez.splittrip.domain.usecase.setting.GetAppThemeUseCase
+import es.pedrazamiguez.splittrip.domain.usecase.setting.SetAppThemeUseCase
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThemeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var getAppThemeUseCase: GetAppThemeUseCase
+    private lateinit var setAppThemeUseCase: SetAppThemeUseCase
+    private lateinit var viewModel: ThemeViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        getAppThemeUseCase = mockk()
+        setAppThemeUseCase = mockk(relaxed = true)
+        every { getAppThemeUseCase() } returns flowOf("system")
+        viewModel = ThemeViewModel(
+            getAppThemeUseCase = getAppThemeUseCase,
+            setAppThemeUseCase = setAppThemeUseCase
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Nested
+    inner class SelectedThemeCode {
+
+        @Test
+        fun `emits theme code from use case flow`() = runTest(testDispatcher) {
+            val collectJob = launch { viewModel.selectedThemeCode.collect {} }
+            advanceUntilIdle()
+
+            assertEquals("system", viewModel.selectedThemeCode.value)
+            collectJob.cancel()
+        }
+    }
+
+    @Nested
+    inner class AvailableThemes {
+
+        @Test
+        fun `exposes all AppTheme entries`() {
+            assertEquals(AppTheme.entries.size, viewModel.availableThemes.size)
+        }
+    }
+
+    @Nested
+    inner class OnThemeSelected {
+
+        @Test
+        fun `delegates to set use case`() = runTest(testDispatcher) {
+            viewModel.onThemeSelected("dark")
+            advanceUntilIdle()
+
+            coVerify { setAppThemeUseCase("dark") }
+        }
+    }
+}


### PR DESCRIPTION
Introduce persistent app theme selection (system/light/dark) and wire it through domain, data, DI and UI. Changes include: add AppTheme enum and Get/Set AppTheme use cases and tests; extend UserPreferences datastore with APP_THEME key and repository methods; register use cases in SettingsDomainModule and expose them via SettingsUiModule; add ThemeScreen, ThemeFeature, ThemeViewModel, ThemeScreenUiProvider and ThemeDescription component; integrate theme option into SettingsScreen/SettingsFeature and settings navigation; update SettingsViewModel to expose currentThemeCode; make MainActivity observe the stored theme and apply SplitTripTheme(darkTheme) accordingly; add localized strings and unit tests for datastore, use cases and viewmodels. This enables users to choose and persist the app theme and have it applied app-wide.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1130 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
