### PR TITLE
[SPLTRP-1192]: Prevent fallback "1.0" exchange rate and show warning on API fetch failure

### DIFF
--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCard.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCard.kt
@@ -80,15 +80,15 @@ fun CurrencyConversionCard(
             exchangeRateLockedHint = state.exchangeRateLockedHint,
             isInsufficientCash = state.isInsufficientCash
         )
-        val staleRateWarning = if (state.isExchangeRateStale) {
-            UiText.StringResource(R.string.stale_rate_warning)
-        } else {
-            null
+        val warning = when {
+            state.isExchangeRateError -> UiText.StringResource(R.string.failed_rate_warning)
+            state.isExchangeRateStale -> UiText.StringResource(R.string.stale_rate_warning)
+            else -> null
         }
         // Top padding on the AnimatedVisibility container animates in/out with the banner,
         // matching the 8 dp gap the former StaleRateBanner Spacer provided.
         InlineWarningBanner(
-            warning = staleRateWarning,
+            warning = warning,
             modifier = Modifier.padding(top = MaterialTheme.spacing.Small)
         )
     }

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCardState.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/currency/CurrencyConversionCardState.kt
@@ -34,5 +34,6 @@ data class CurrencyConversionCardState(
     val isInsufficientCash: Boolean = false,
     val isGroupAmountError: Boolean = false,
     val isExchangeRateStale: Boolean = false,
+    val isExchangeRateError: Boolean = false,
     val autoFocus: Boolean = false
 )

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/formatter/AmountFormatter.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/formatter/AmountFormatter.kt
@@ -137,7 +137,11 @@ fun es.pedrazamiguez.splittrip.domain.model.Currency.formatDisplay(): String {
                 AppConstants.DEFAULT_CURRENCY_CODE
             )
         }
-    val nativeSymbol = resolveNativeSymbol(currencyInstance)
+    var nativeSymbol = resolveNativeSymbol(currencyInstance)
+
+    if (nativeSymbol == null || nativeSymbol == code) {
+        nativeSymbol = symbol.takeIf { it.isNotBlank() && it != code }
+    }
 
     return if (nativeSymbol?.isNotBlank() == true && nativeSymbol != code) {
         "$code ($nativeSymbol)"

--- a/core/design-system/src/main/res/values-es-rAN/strings.xml
+++ b/core/design-system/src/main/res/values-es-rAN/strings.xml
@@ -56,6 +56,7 @@
     <string name="sync_status_pending">Aún no çincroniçao con er çerbidôh</string>
     <string name="sync_status_failed">Errôh de çincroniçaçión</string>
     <string name="stale_rate_warning">Lô tipô de cambio podrían êttâh deçâttualiçáô</string>
+    <string name="failed_rate_warning">No çe pudo cargâh er tipo de cambio mâh reçiente. Por fabôh, introdúccalo manuarmente.</string>
     <string name="error_generic">¡Ups! Argo çalió mâh</string>
     <string name="error_no_connection">¿Çin intênnêh? Rebiça tu conêççión</string>
     <string name="preview_label_group_name">Nombre der grupo</string>

--- a/core/design-system/src/main/res/values-es/strings.xml
+++ b/core/design-system/src/main/res/values-es/strings.xml
@@ -69,6 +69,7 @@
 
     <!-- Stale Exchange Rate -->
     <string name="stale_rate_warning">Los tipos de cambio podrían estar desactualizados</string>
+    <string name="failed_rate_warning">No se pudo cargar el tipo de cambio más reciente. Por favor, introdúzcalo manualmente.</string>
 
     <!-- Generic Error -->
     <string name="error_generic">¡Ups! Algo salió mal</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
 
     <!-- Stale Exchange Rate -->
     <string name="stale_rate_warning">Rates may be outdated</string>
+    <string name="failed_rate_warning">Failed to load the latest exchange rate. Please enter it manually.</string>
 
     <!-- Generic Error -->
     <string name="error_generic">Oops! Something went wrong</string>

--- a/core/design-system/src/test/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/formatter/AmountFormatterTest.kt
+++ b/core/design-system/src/test/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/formatter/AmountFormatterTest.kt
@@ -298,4 +298,44 @@ class AmountFormatterTest {
             assertTrue("100".isValidDecimalInput())
         }
     }
+
+    // ---------- Currency.formatDisplay ----------
+
+    @Nested
+    @DisplayName("Currency.formatDisplay()")
+    inner class FormatDisplay {
+
+        @Test
+        fun `formats EUR with native symbol`() {
+            val currency = es.pedrazamiguez.splittrip.domain.model.Currency(
+                code = "EUR",
+                symbol = "€",
+                defaultName = "Euro",
+                decimalDigits = 2
+            )
+            assertEquals("EUR (€)", currency.formatDisplay())
+        }
+
+        @Test
+        fun `formats USD with disambiliated native symbol`() {
+            val currency = es.pedrazamiguez.splittrip.domain.model.Currency(
+                code = "USD",
+                symbol = "$",
+                defaultName = "US Dollar",
+                decimalDigits = 2
+            )
+            assertEquals("USD (US$)", currency.formatDisplay())
+        }
+
+        @Test
+        fun `formats THB falling back to model symbol`() {
+            val currency = es.pedrazamiguez.splittrip.domain.model.Currency(
+                code = "THB",
+                symbol = "฿",
+                defaultName = "Thai Baht",
+                decimalDigits = 2
+            )
+            assertEquals("THB (฿)", currency.formatDisplay())
+        }
+    }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/ExchangeRateStep.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/step/expense/ExchangeRateStep.kt
@@ -46,6 +46,7 @@ fun ExchangeRateStep(
                 isInsufficientCash = uiState.isInsufficientCash,
                 isGroupAmountError = !uiState.isAmountValid,
                 isExchangeRateStale = uiState.isExchangeRateStale,
+                isExchangeRateError = uiState.isExchangeRateError,
                 autoFocus = true
             ),
             onExchangeRateChanged = { onEvent(AddExpenseUiEvent.ExchangeRateChanged(it)) },

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandler.kt
@@ -4,6 +4,7 @@ import es.pedrazamiguez.splittrip.core.common.presentation.UiText
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.features.expense.R
@@ -86,6 +87,12 @@ class CurrencyEventHandler(
         // If switching to foreign, fetch the appropriate rate; otherwise default to 1.0
         val isCash = isCashPaymentMethod()
         if (isForeign) {
+            _uiState.update {
+                it.copy(
+                    displayExchangeRate = "",
+                    isExchangeRateError = false
+                )
+            }
             if (isCash) {
                 // Lock immediately so the fields are non-editable from the start,
                 // before the async pool probe + rate fetch completes.
@@ -110,7 +117,8 @@ class CurrencyEventHandler(
                     displayExchangeRate = "1.0",
                     isExchangeRateLocked = false,
                     isInsufficientCash = false,
-                    exchangeRateLockedHint = null
+                    exchangeRateLockedHint = null,
+                    isExchangeRateError = false
                 )
             }
             // Same currency + CASH: probe pools and fetch tranche preview via callback.
@@ -121,12 +129,12 @@ class CurrencyEventHandler(
     }
 
     fun handleExchangeRateChanged(rate: String) {
-        _uiState.update { it.copy(displayExchangeRate = rate) }
+        _uiState.update { it.copy(displayExchangeRate = rate, isExchangeRateError = false) }
         recalculateForward()
     }
 
     fun handleGroupAmountChanged(amount: String) {
-        _uiState.update { it.copy(calculatedGroupAmount = amount) }
+        _uiState.update { it.copy(calculatedGroupAmount = amount, isExchangeRateError = false) }
         recalculateReverse()
     }
 
@@ -137,6 +145,10 @@ class CurrencyEventHandler(
      */
     fun recalculateForward() {
         val state = _uiState.value
+        if (state.displayExchangeRate.isBlank()) {
+            _uiState.update { it.copy(calculatedGroupAmount = "") }
+            return
+        }
         val sourceDecimalPlaces = state.selectedCurrency?.decimalDigits ?: 2
         val targetDecimalPlaces = state.groupCurrency?.decimalDigits ?: 2
         val calculatedAmount = exchangeRateCalculationService.calculateGroupAmountFromDisplayRate(
@@ -196,23 +208,12 @@ class CurrencyEventHandler(
                 )
 
                 _uiState.update { current ->
-                    // If the user changed currencies while the request was in-flight,
-                    // don't overwrite state for the new selection with a stale result.
-                    if (current.groupCurrency?.code != requestedBaseCode ||
-                        current.selectedCurrency?.code != requestedTargetCode
-                    ) {
-                        current.copy(isLoadingRate = false)
-                    } else {
-                        current.copy(
-                            isLoadingRate = false,
-                            // If rate found, update display; otherwise keep existing/default
-                            displayExchangeRate = rateResult?.rate?.let { exchangeRate ->
-                                formattingHelper.formatRateForDisplay(exchangeRate.toPlainString())
-                            } ?: current.displayExchangeRate,
-                            isExchangeRateStale = rateResult?.isStale
-                                ?: current.isExchangeRateStale
-                        )
-                    }
+                    current.updateRateResult(
+                        requestedBaseCode = requestedBaseCode,
+                        requestedTargetCode = requestedTargetCode,
+                        rateResult = rateResult,
+                        isError = rateResult == null
+                    )
                 }
 
                 if (rateResult != null) {
@@ -223,7 +224,14 @@ class CurrencyEventHandler(
                     e,
                     "Failed to fetch exchange rate for $requestedBaseCode -> $requestedTargetCode"
                 )
-                _uiState.update { it.copy(isLoadingRate = false) }
+                _uiState.update { current ->
+                    current.updateRateResult(
+                        requestedBaseCode = requestedBaseCode,
+                        requestedTargetCode = requestedTargetCode,
+                        rateResult = null,
+                        isError = true
+                    )
+                }
             }
         }
     }
@@ -441,5 +449,26 @@ class CurrencyEventHandler(
     internal fun currentPayerId(): String? = when (currentPayerType()) {
         PayerType.USER, PayerType.GROUP -> _uiState.value.currentUserId
         PayerType.SUBUNIT -> _uiState.value.selectedContributionSubunitId
+    }
+
+    private fun AddExpenseUiState.updateRateResult(
+        requestedBaseCode: String,
+        requestedTargetCode: String,
+        rateResult: ExchangeRateWithStaleness?,
+        isError: Boolean
+    ): AddExpenseUiState {
+        if (groupCurrency?.code != requestedBaseCode ||
+            selectedCurrency?.code != requestedTargetCode
+        ) {
+            return copy(isLoadingRate = false)
+        }
+        return copy(
+            isLoadingRate = false,
+            isExchangeRateError = isError,
+            displayExchangeRate = rateResult?.rate?.let { exchangeRate ->
+                formattingHelper.formatRateForDisplay(exchangeRate.toPlainString())
+            } ?: displayExchangeRate,
+            isExchangeRateStale = rateResult?.isStale ?: isExchangeRateStale
+        )
     }
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/state/AddExpenseUiState.kt
@@ -122,6 +122,7 @@ data class AddExpenseUiState(
      * exchange rate section.
      */
     val isExchangeRateStale: Boolean = false,
+    val isExchangeRateError: Boolean = false,
     val showDueDateSection: Boolean = false,
 
     // Due date

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/AddExpenseViewModelTest.kt
@@ -908,10 +908,11 @@ class AddExpenseViewModelTest {
             viewModel.onEvent(AddExpenseUiEvent.CurrencySelected("THB"))
             advanceUntilIdle()
 
-            // Then - Should keep default rate
+            // Then - Should keep default rate (empty string) and flag error
             val state = viewModel.uiState.value
             assertTrue(state.showExchangeRateSection)
-            assertEquals("1.0", state.displayExchangeRate)
+            assertEquals("", state.displayExchangeRate)
+            assertTrue(state.isExchangeRateError)
             assertFalse(state.isLoadingRate)
         }
 
@@ -995,10 +996,11 @@ class AddExpenseViewModelTest {
             viewModel.onEvent(AddExpenseUiEvent.CurrencySelected("THB"))
             advanceUntilIdle()
 
-            // Then - Should set isLoadingRate to false and keep existing rate
+            // Then - Should set isLoadingRate to false, keep existing rate (empty string), and flag error
             val state = viewModel.uiState.value
             assertTrue(state.showExchangeRateSection)
-            assertEquals("1.0", state.displayExchangeRate)
+            assertEquals("", state.displayExchangeRate)
+            assertTrue(state.isExchangeRateError)
             assertFalse(state.isLoadingRate)
             coVerify { getExchangeRateUseCase("EUR", "THB") }
         }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandlerTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/handler/CurrencyEventHandlerTest.kt
@@ -720,4 +720,107 @@ class CurrencyEventHandlerTest {
             coVerify(exactly = 0) { previewCashExchangeRateUseCase(any(), any(), any(), any(), any()) }
         }
     }
+
+    // ── ExchangeRateErrorHandling ────────────────────────────────────────────
+
+    @Nested
+    inner class ExchangeRateErrorHandling {
+
+        @Test
+        fun `successful fetch rate resets error flag to false`() = runTest {
+            uiState.value = nonCashForeignState.copy(isExchangeRateError = true)
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } returns ExchangeRateWithStaleness(rate = BigDecimal("36.8"), isStale = false)
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.fetchRate()
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isExchangeRateError)
+            assertEquals("36.8", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `null rateResult from fetch rate sets error flag to true`() = runTest {
+            uiState.value = nonCashForeignState.copy(isExchangeRateError = false, displayExchangeRate = "")
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } returns null
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.fetchRate()
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertTrue(state.isExchangeRateError)
+            assertEquals("", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `exception from fetch rate sets error flag to true`() = runTest {
+            uiState.value = nonCashForeignState.copy(isExchangeRateError = false, displayExchangeRate = "")
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } throws RuntimeException("Network error")
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.fetchRate()
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertTrue(state.isExchangeRateError)
+            assertEquals("", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `manual exchange rate change resets error flag to false`() = runTest {
+            uiState.value = nonCashForeignState.copy(isExchangeRateError = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleExchangeRateChanged("35.5")
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isExchangeRateError)
+            assertEquals("35.5", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `manual group amount change resets error flag to false`() = runTest {
+            uiState.value = nonCashForeignState.copy(isExchangeRateError = true, displayExchangeRate = "")
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleGroupAmountChanged("28.17")
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isExchangeRateError)
+        }
+
+        @Test
+        fun `recalculateForward leaves calculated amount empty if rate is blank`() = runTest {
+            uiState.value = nonCashForeignState.copy(displayExchangeRate = "", calculatedGroupAmount = "10.00")
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.recalculateForward()
+
+            // Then
+            val state = uiState.value
+            assertEquals("", state.calculatedGroupAmount)
+        }
+    }
 }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/ExchangeRateStep.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/ExchangeRateStep.kt
@@ -32,6 +32,7 @@ fun ExchangeRateStep(
                 isLoadingRate = uiState.isLoadingRate,
                 isExchangeRateLocked = false,
                 isExchangeRateStale = uiState.isExchangeRateStale,
+                isExchangeRateError = uiState.isExchangeRateError,
                 autoFocus = true
             ),
             onExchangeRateChanged = { onEvent(AddCashWithdrawalUiEvent.ExchangeRateChanged(it)) },

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/FeeExchangeRateStep.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/component/step/FeeExchangeRateStep.kt
@@ -34,6 +34,7 @@ fun FeeExchangeRateStep(
                 isLoadingRate = false,
                 isExchangeRateLocked = false,
                 isExchangeRateStale = uiState.isFeeExchangeRateStale,
+                isExchangeRateError = uiState.isFeeExchangeRateError,
                 autoFocus = true
             ),
             onExchangeRateChanged = { onEvent(AddCashWithdrawalUiEvent.FeeExchangeRateChanged(it)) },

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandler.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandler.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.ha
 
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.isValidDecimalInput
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.mapper.AddCashWithdrawalUiMapper
@@ -57,11 +58,13 @@ class WithdrawalCurrencyHandler(
             it.copy(
                 selectedCurrency = selectedUiModel,
                 showExchangeRateSection = isForeign,
-                exchangeRateLabel = exchangeRateLabel
+                exchangeRateLabel = exchangeRateLabel,
+                isExchangeRateError = false
             ).withStepClamped()
         }
 
         if (isForeign) {
+            _uiState.update { it.copy(displayExchangeRate = "") }
             fetchRate()
         } else {
             _uiState.update { it.copy(displayExchangeRate = "1.0", deductedAmount = "") }
@@ -78,12 +81,12 @@ class WithdrawalCurrencyHandler(
     }
 
     fun handleExchangeRateChanged(rate: String) {
-        _uiState.update { it.copy(displayExchangeRate = rate) }
+        _uiState.update { it.copy(displayExchangeRate = rate, isExchangeRateError = false) }
         recalculateDeducted()
     }
 
     fun handleDeductedAmountChanged(amount: String) {
-        _uiState.update { it.copy(deductedAmount = amount) }
+        _uiState.update { it.copy(deductedAmount = amount, isExchangeRateError = false) }
         recalculateRateFromDeducted()
     }
 
@@ -93,6 +96,10 @@ class WithdrawalCurrencyHandler(
     fun recalculateDeducted() {
         val state = _uiState.value
         if (!state.showExchangeRateSection) return
+        if (state.displayExchangeRate.isBlank()) {
+            _uiState.update { it.copy(deductedAmount = "") }
+            return
+        }
 
         val sourceDecimalPlaces = state.selectedCurrency?.decimalDigits ?: 2
         val targetDecimalPlaces = state.groupCurrency?.decimalDigits ?: 2
@@ -139,28 +146,57 @@ class WithdrawalCurrencyHandler(
             return
         }
 
+        val requestedBaseCode = groupCurrency.code
+        val requestedTargetCode = selectedCurrency.code
+
         scope.launch {
             _uiState.update { it.copy(isLoadingRate = true) }
             try {
                 val rateResult = getExchangeRateUseCase(
-                    baseCurrencyCode = groupCurrency.code,
-                    targetCurrencyCode = selectedCurrency.code
+                    baseCurrencyCode = requestedBaseCode,
+                    targetCurrencyCode = requestedTargetCode
                 )
-                _uiState.update {
-                    it.copy(
-                        isLoadingRate = false,
-                        displayExchangeRate = rateResult?.rate?.let { r ->
-                            formattingHelper.formatRateForDisplay(r.toPlainString())
-                        } ?: it.displayExchangeRate,
-                        isExchangeRateStale = rateResult?.isStale
-                            ?: it.isExchangeRateStale
+                _uiState.update { current ->
+                    current.updateRateResult(
+                        requestedBaseCode = requestedBaseCode,
+                        requestedTargetCode = requestedTargetCode,
+                        rateResult = rateResult,
+                        isError = rateResult == null
                     )
                 }
                 if (rateResult != null) recalculateDeducted()
             } catch (e: Exception) {
                 Timber.w(e, "Failed to fetch exchange rate")
-                _uiState.update { it.copy(isLoadingRate = false) }
+                _uiState.update { current ->
+                    current.updateRateResult(
+                        requestedBaseCode = requestedBaseCode,
+                        requestedTargetCode = requestedTargetCode,
+                        rateResult = null,
+                        isError = true
+                    )
+                }
             }
         }
+    }
+
+    private fun AddCashWithdrawalUiState.updateRateResult(
+        requestedBaseCode: String,
+        requestedTargetCode: String,
+        rateResult: ExchangeRateWithStaleness?,
+        isError: Boolean
+    ): AddCashWithdrawalUiState {
+        if (groupCurrency?.code != requestedBaseCode ||
+            selectedCurrency?.code != requestedTargetCode
+        ) {
+            return copy(isLoadingRate = false)
+        }
+        return copy(
+            isLoadingRate = false,
+            isExchangeRateError = isError,
+            displayExchangeRate = rateResult?.rate?.let { r ->
+                formattingHelper.formatRateForDisplay(r.toPlainString())
+            } ?: displayExchangeRate,
+            isExchangeRateStale = rateResult?.isStale ?: isExchangeRateStale
+        )
     }
 }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalFeeHandler.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalFeeHandler.kt
@@ -2,6 +2,7 @@ package es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.ha
 
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.isValidDecimalInput
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.mapper.AddCashWithdrawalUiMapper
@@ -55,7 +56,8 @@ class WithdrawalFeeHandler(
                     feeConvertedAmount = "",
                     feeConvertedLabel = feeConvertedLabel,
                     showFeeExchangeRateSection = false,
-                    isFeeAmountValid = true
+                    isFeeAmountValid = true,
+                    isFeeExchangeRateError = false
                 ).withStepClamped()
             }
         } else {
@@ -69,7 +71,8 @@ class WithdrawalFeeHandler(
                     feeExchangeRateLabel = "",
                     feeConvertedLabel = "",
                     showFeeExchangeRateSection = false,
-                    isFeeAmountValid = true
+                    isFeeAmountValid = true,
+                    isFeeExchangeRateError = false
                 ).withStepClamped()
             }
         }
@@ -101,7 +104,8 @@ class WithdrawalFeeHandler(
                 feeCurrency = feeCurrencyModel,
                 showFeeExchangeRateSection = isForeign,
                 feeExchangeRateLabel = feeExchangeRateLabel,
-                feeExchangeRate = if (isForeign) it.feeExchangeRate else "1.0"
+                feeExchangeRate = if (isForeign) "" else "1.0",
+                isFeeExchangeRateError = false
             ).withStepClamped()
         }
 
@@ -112,19 +116,23 @@ class WithdrawalFeeHandler(
     }
 
     fun handleFeeExchangeRateChanged(rate: String) {
-        _uiState.update { it.copy(feeExchangeRate = rate) }
+        _uiState.update { it.copy(feeExchangeRate = rate, isFeeExchangeRateError = false) }
         recalculateFeeConverted()
     }
 
     fun handleFeeConvertedAmountChanged(amount: String) {
-        _uiState.update { it.copy(feeConvertedAmount = amount) }
+        _uiState.update { it.copy(feeConvertedAmount = amount, isFeeExchangeRateError = false) }
         recalculateFeeRateFromConverted()
     }
 
-    private fun recalculateFeeConverted() {
+    internal fun recalculateFeeConverted() {
         val state = _uiState.value
         if (!state.showFeeExchangeRateSection) {
             _uiState.update { it.copy(feeConvertedAmount = state.feeAmount) }
+            return
+        }
+        if (state.feeExchangeRate.isBlank()) {
+            _uiState.update { it.copy(feeConvertedAmount = "") }
             return
         }
 
@@ -165,20 +173,48 @@ class WithdrawalFeeHandler(
                     baseCurrencyCode = groupCurrencyCode,
                     targetCurrencyCode = feeCurrencyCode
                 )
+                _uiState.update { current ->
+                    current.updateFeeRateResult(
+                        groupCurrencyCode = groupCurrencyCode,
+                        feeCurrencyCode = feeCurrencyCode,
+                        rateResult = rateResult,
+                        isError = rateResult == null
+                    )
+                }
                 if (rateResult != null) {
-                    _uiState.update {
-                        it.copy(
-                            feeExchangeRate = formattingHelper.formatRateForDisplay(
-                                rateResult.rate.toPlainString()
-                            ),
-                            isFeeExchangeRateStale = rateResult.isStale
-                        )
-                    }
                     recalculateFeeConverted()
                 }
             } catch (e: Exception) {
                 Timber.w(e, "Failed to fetch fee exchange rate")
+                _uiState.update { current ->
+                    current.updateFeeRateResult(
+                        groupCurrencyCode = groupCurrencyCode,
+                        feeCurrencyCode = feeCurrencyCode,
+                        rateResult = null,
+                        isError = true
+                    )
+                }
             }
         }
+    }
+
+    private fun AddCashWithdrawalUiState.updateFeeRateResult(
+        groupCurrencyCode: String,
+        feeCurrencyCode: String,
+        rateResult: ExchangeRateWithStaleness?,
+        isError: Boolean
+    ): AddCashWithdrawalUiState {
+        if (groupCurrency?.code != groupCurrencyCode ||
+            feeCurrency?.code != feeCurrencyCode
+        ) {
+            return this
+        }
+        return copy(
+            isFeeExchangeRateError = isError,
+            feeExchangeRate = rateResult?.rate?.let { r ->
+                formattingHelper.formatRateForDisplay(r.toPlainString())
+            } ?: feeExchangeRate,
+            isFeeExchangeRateStale = rateResult?.isStale ?: isFeeExchangeRateStale
+        )
     }
 }

--- a/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiState.kt
+++ b/features/withdrawals/src/main/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/state/AddCashWithdrawalUiState.kt
@@ -38,10 +38,12 @@ data class AddCashWithdrawalUiState(
      * exchange rate section.
      */
     val isExchangeRateStale: Boolean = false,
+    val isExchangeRateError: Boolean = false,
     /**
      * True when the fee exchange rate was served from an expired local cache.
      */
     val isFeeExchangeRateStale: Boolean = false,
+    val isFeeExchangeRateError: Boolean = false,
 
     // ATM Fee (optional)
     val hasFee: Boolean = false,

--- a/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandlerTest.kt
+++ b/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalCurrencyHandlerTest.kt
@@ -328,7 +328,7 @@ class WithdrawalCurrencyHandlerTest {
     inner class FetchRate {
 
         @Test
-        fun `rateResult null keeps existing exchange rate unchanged`() = runTest {
+        fun `rateResult null sets exchange rate to empty and flags error`() = runTest {
             val originalRate = "37.5"
             uiState.value = baseState.copy(
                 selectedCurrency = thbModel,
@@ -340,14 +340,15 @@ class WithdrawalCurrencyHandlerTest {
             handler.handleCurrencySelected("THB")
             advanceUntilIdle()
 
-            assertEquals(originalRate, uiState.value.displayExchangeRate)
+            assertEquals("", uiState.value.displayExchangeRate)
+            assertTrue(uiState.value.isExchangeRateError)
         }
 
         @Test
-        fun `rateResult null skips async recalculate deducted so formatForDisplay called only once`() = runTest {
-            // handleCurrencySelected always calls recalculateDeducted() synchronously (1 call).
-            // When rateResult != null, fetchRate also calls recalculateDeducted() asynchronously (2nd call).
-            // When rateResult == null, the async call is skipped — verify exactly 1 invocation.
+        fun `rateResult null skips async recalculate deducted so formatForDisplay is not called`() = runTest {
+            // handleCurrencySelected always calls recalculateDeducted() synchronously.
+            // Since displayExchangeRate is empty, it returns early.
+            // When rateResult == null, the async call is skipped and rate stays empty — verify 0 invocations.
             uiState.value = baseState.copy(selectedCurrency = thbModel, showExchangeRateSection = true)
             coEvery { getExchangeRateUseCase(any(), any()) } returns null
 
@@ -355,8 +356,8 @@ class WithdrawalCurrencyHandlerTest {
             handler.handleCurrencySelected("THB")
             advanceUntilIdle()
 
-            // Only the synchronous recalculateDeducted() call from handleCurrencySelected fires.
-            verify(exactly = 1) { formattingHelper.formatForDisplay(any(), any(), any()) }
+            // Deducted amount calculation is skipped because exchange rate is empty.
+            verify(exactly = 0) { formattingHelper.formatForDisplay(any(), any(), any()) }
         }
 
         @Test
@@ -384,6 +385,111 @@ class WithdrawalCurrencyHandlerTest {
             advanceUntilIdle()
 
             assertTrue(uiState.value.isExchangeRateStale)
+        }
+    }
+
+    // ── ExchangeRateErrorHandling ────────────────────────────────────────────
+
+    @Nested
+    inner class ExchangeRateErrorHandling {
+
+        @Test
+        fun `successful fetch rate resets error flag to false`() = runTest {
+            uiState.value = baseState.copy(selectedCurrency = thbModel, isExchangeRateError = true)
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } returns ExchangeRateWithStaleness(rate = BigDecimal("37.037"), isStale = false)
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleCurrencySelected("THB")
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isExchangeRateError)
+        }
+
+        @Test
+        fun `null rateResult from fetch rate sets error flag to true`() = runTest {
+            uiState.value =
+                baseState.copy(selectedCurrency = thbModel, isExchangeRateError = false, displayExchangeRate = "")
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } returns null
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleCurrencySelected("THB")
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertTrue(state.isExchangeRateError)
+            assertEquals("", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `exception from fetch rate sets error flag to true`() = runTest {
+            uiState.value =
+                baseState.copy(selectedCurrency = thbModel, isExchangeRateError = false, displayExchangeRate = "")
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } throws IOException("Network error")
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleCurrencySelected("THB")
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertTrue(state.isExchangeRateError)
+            assertEquals("", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `manual exchange rate change resets error flag to false`() = runTest {
+            uiState.value = baseState.copy(isExchangeRateError = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleExchangeRateChanged("35.5")
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isExchangeRateError)
+            assertEquals("35.5", state.displayExchangeRate)
+        }
+
+        @Test
+        fun `manual deducted amount change resets error flag to false`() = runTest {
+            uiState.value = baseState.copy(isExchangeRateError = true, displayExchangeRate = "")
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleDeductedAmountChanged("27.00")
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isExchangeRateError)
+        }
+
+        @Test
+        fun `recalculateDeducted leaves deducted amount empty if rate is blank`() = runTest {
+            uiState.value =
+                baseState.copy(displayExchangeRate = "", deductedAmount = "10.00", showExchangeRateSection = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.recalculateDeducted()
+
+            // Then
+            val state = uiState.value
+            assertEquals("", state.deductedAmount)
         }
     }
 }

--- a/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalFeeHandlerTest.kt
+++ b/features/withdrawals/src/test/kotlin/es/pedrazamiguez/splittrip/features/withdrawal/presentation/viewmodel/handler/WithdrawalFeeHandlerTest.kt
@@ -2,13 +2,16 @@ package es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.ha
 
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.FormattingHelper
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
+import es.pedrazamiguez.splittrip.domain.result.ExchangeRateWithStaleness
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import es.pedrazamiguez.splittrip.domain.usecase.currency.GetExchangeRateUseCase
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.mapper.AddCashWithdrawalUiMapper
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.action.AddCashWithdrawalUiAction
 import es.pedrazamiguez.splittrip.features.withdrawal.presentation.viewmodel.state.AddCashWithdrawalUiState
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import java.math.BigDecimal
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -385,6 +388,147 @@ class WithdrawalFeeHandlerTest {
 
             // formattingHelper.formatRateForDisplay stub returns "37.0"
             assertEquals("37.0", uiState.value.feeExchangeRate)
+        }
+    }
+
+    // ── FeeExchangeRateErrorHandling ─────────────────────────────────────────
+
+    @Nested
+    inner class FeeExchangeRateErrorHandling {
+
+        @Test
+        fun `successful fetch fee rate resets error flag to false`() = runTest {
+            uiState.value = baseState.copy(hasFee = true, feeCurrency = thbModel, isFeeExchangeRateError = true)
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } returns ExchangeRateWithStaleness(rate = BigDecimal("37.0"), isStale = false)
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeCurrencySelected("THB")
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isFeeExchangeRateError)
+        }
+
+        @Test
+        fun `null rateResult from fetch fee rate sets error flag to true`() = runTest {
+            uiState.value =
+                baseState.copy(
+                    hasFee = true,
+                    feeCurrency = thbModel,
+                    isFeeExchangeRateError = false,
+                    feeExchangeRate = ""
+                )
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } returns null
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeCurrencySelected("THB")
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertTrue(state.isFeeExchangeRateError)
+            assertEquals("", state.feeExchangeRate)
+        }
+
+        @Test
+        fun `exception from fetch fee rate sets error flag to true`() = runTest {
+            uiState.value =
+                baseState.copy(
+                    hasFee = true,
+                    feeCurrency = thbModel,
+                    isFeeExchangeRateError = false,
+                    feeExchangeRate = ""
+                )
+            coEvery {
+                getExchangeRateUseCase(any(), any())
+            } throws RuntimeException("Network error")
+
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeCurrencySelected("THB")
+            advanceUntilIdle()
+
+            // Then
+            val state = uiState.value
+            assertTrue(state.isFeeExchangeRateError)
+            assertEquals("", state.feeExchangeRate)
+        }
+
+        @Test
+        fun `manual fee exchange rate change resets error flag to false`() = runTest {
+            uiState.value = baseState.copy(isFeeExchangeRateError = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeExchangeRateChanged("35.5")
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isFeeExchangeRateError)
+            assertEquals("35.5", state.feeExchangeRate)
+        }
+
+        @Test
+        fun `manual fee converted amount change resets error flag to false`() = runTest {
+            uiState.value = baseState.copy(isFeeExchangeRateError = true, feeExchangeRate = "")
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeConvertedAmountChanged("2.70")
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isFeeExchangeRateError)
+        }
+
+        @Test
+        fun `recalculateFeeConverted leaves fee converted amount empty if rate is blank`() = runTest {
+            uiState.value =
+                baseState.copy(feeExchangeRate = "", feeConvertedAmount = "2.70", showFeeExchangeRateSection = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.recalculateFeeConverted()
+
+            // Then
+            val state = uiState.value
+            assertEquals("", state.feeConvertedAmount)
+        }
+
+        @Test
+        fun `enabling fee resets isFeeExchangeRateError to false`() = runTest {
+            uiState.value = baseState.copy(isFeeExchangeRateError = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeToggled(true)
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isFeeExchangeRateError)
+        }
+
+        @Test
+        fun `disabling fee resets isFeeExchangeRateError to false`() = runTest {
+            uiState.value = baseState.copy(isFeeExchangeRateError = true)
+            handler.bind(uiState, actions, this)
+
+            // When
+            handler.handleFeeToggled(false)
+
+            // Then
+            val state = uiState.value
+            assertFalse(state.isFeeExchangeRateError)
         }
     }
 }


### PR DESCRIPTION
Add explicit handling for failed exchange rate fetches: introduce isExchangeRateError flags in various UI states and show a failed_rate_warning banner when an error occurs. Update CurrencyConversionCard to prefer error warning over stale warning and add localized failed_rate_warning strings. Update expense and withdrawal handlers to reset the error flag on manual input, set it on null/exception fetch results, and avoid calculations when the display rate is blank. Add helper methods to apply rate results safely and extend unit tests to cover success, null result and exception scenarios for both exchange rates and fee rates.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1192 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
