### PR TITLE
[SPLTRP-1199]: Centralize DEFAULT_DECIMAL_PLACES and RATE_PRECISION in AppConstants

### DIFF
--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/constant/DomainConstants.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/constant/DomainConstants.kt
@@ -1,0 +1,6 @@
+package es.pedrazamiguez.splittrip.domain.constant
+
+object DomainConstants {
+    const val DEFAULT_DECIMAL_PLACES = 2
+    const val RATE_PRECISION = 6
+}

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExchangeRateCalculationService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExchangeRateCalculationService.kt
@@ -1,39 +1,37 @@
 package es.pedrazamiguez.splittrip.domain.service
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import java.math.BigDecimal
 
 interface ExchangeRateCalculationService {
-    companion object {
-        const val DEFAULT_DECIMAL_PLACES = 2
-    }
     fun calculateGroupAmount(
         sourceAmount: BigDecimal,
         rate: BigDecimal,
-        targetDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES
+        targetDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES
     ): BigDecimal
     fun calculateImpliedRate(sourceAmount: BigDecimal, groupAmount: BigDecimal): BigDecimal
     fun calculateGroupAmountFromStrings(
         sourceAmountString: String,
         exchangeRateString: String,
-        sourceDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES,
-        targetDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES
+        sourceDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES,
+        targetDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES
     ): String
     fun calculateGroupAmountFromDisplayRate(
         sourceAmountString: String,
         displayRateString: String,
-        sourceDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES,
-        targetDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES
+        sourceDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES,
+        targetDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES
     ): String
     fun calculateImpliedDisplayRateFromStrings(
         sourceAmountString: String,
         groupAmountString: String,
-        sourceDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES
+        sourceDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES
     ): String
     fun displayRateToCalculationRate(displayRateString: String): BigDecimal
     fun calculateImpliedRateFromStrings(
         sourceAmountString: String,
         groupAmountString: String,
-        sourceDecimalPlaces: Int = DEFAULT_DECIMAL_PLACES
+        sourceDecimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES
     ): String
     fun calculateExchangeRate(amountWithdrawn: Long, deductedBaseAmount: Long): BigDecimal
     fun calculateBlendedRate(sourceAmountCents: Long, groupAmountCents: Long): BigDecimal

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseCalculatorService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/ExpenseCalculatorService.kt
@@ -1,20 +1,18 @@
 package es.pedrazamiguez.splittrip.domain.service
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.model.CashTranche
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import java.math.BigDecimal
 
 interface ExpenseCalculatorService {
-    companion object {
-        const val DEFAULT_DECIMAL_PLACES = 2
-    }
-    fun centsToBigDecimal(cents: Long, decimalPlaces: Int = DEFAULT_DECIMAL_PLACES): BigDecimal
-    fun centsToBigDecimalString(cents: Long, decimalPlaces: Int = DEFAULT_DECIMAL_PLACES): String
+    fun centsToBigDecimal(cents: Long, decimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES): BigDecimal
+    fun centsToBigDecimalString(cents: Long, decimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES): String
     fun computeProportionalAmount(amount: Long, targetAmount: Long, totalAmount: Long): Long
     fun distributeAmount(
         totalAmount: BigDecimal,
         numberOfUsers: Int,
-        decimalPlaces: Int = DEFAULT_DECIMAL_PLACES
+        decimalPlaces: Int = DomainConstants.DEFAULT_DECIMAL_PLACES
     ): List<BigDecimal>
     fun hasInsufficientCash(amountToCover: Long, availableWithdrawals: List<CashWithdrawal>): Boolean
     fun calculateFifoCashAmount(

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/impl/AddOnCalculationServiceImpl.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/impl/AddOnCalculationServiceImpl.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.service.impl
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.converter.CurrencyConverter
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
 import es.pedrazamiguez.splittrip.domain.enums.AddOnType
@@ -13,10 +14,6 @@ import java.math.RoundingMode
 class AddOnCalculationServiceImpl(
     private val addOnResolverFactory: AddOnResolverFactory = AddOnResolverFactory()
 ) : AddOnCalculationService {
-
-    private companion object {
-        const val RATE_PRECISION = 6
-    }
 
     // ── Add-On Amount Resolution ────────────────────────────────────────
 
@@ -205,12 +202,12 @@ class AddOnCalculationServiceImpl(
 
         val nonDiscountFraction = totalIncludedPercentage.divide(
             BigDecimal("100"),
-            RATE_PRECISION,
+            DomainConstants.RATE_PRECISION,
             RoundingMode.HALF_UP
         )
         val discountFraction = totalIncludedDiscountPercentage.divide(
             BigDecimal("100"),
-            RATE_PRECISION,
+            DomainConstants.RATE_PRECISION,
             RoundingMode.HALF_UP
         )
         // Non-discount add-ons increase the base, discounts decrease it

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/impl/ExchangeRateCalculationServiceImpl.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/impl/ExchangeRateCalculationServiceImpl.kt
@@ -1,16 +1,12 @@
 package es.pedrazamiguez.splittrip.domain.service.impl
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.converter.CurrencyConverter
 import es.pedrazamiguez.splittrip.domain.service.ExchangeRateCalculationService
 import java.math.BigDecimal
 import java.math.RoundingMode
 
 class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
-
-    private companion object {
-        const val RATE_PRECISION = 6
-        const val DEFAULT_DECIMAL_PLACES = 2
-    }
 
     // ── Core BigDecimal-based Calculations ───────────────────────────────
 
@@ -42,7 +38,7 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
     override fun calculateImpliedRate(sourceAmount: BigDecimal, groupAmount: BigDecimal): BigDecimal {
         if (sourceAmount.compareTo(BigDecimal.ZERO) == 0) return BigDecimal.ZERO
         // Target / Source = Rate (e.g. 27.35 EUR / 1000 THB = 0.02735)
-        return groupAmount.divide(sourceAmount, RATE_PRECISION, RoundingMode.HALF_UP)
+        return groupAmount.divide(sourceAmount, DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
     }
 
     // ── String-based Convenience Methods ─────────────────────────────────
@@ -95,7 +91,11 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
 
         // Convert display rate (group to source) to calculation rate (source to group)
         // If 1 EUR = 37 THB, then 1 THB = 1/37 EUR
-        val calculationRate = BigDecimal.ONE.divide(displayRate, RATE_PRECISION, RoundingMode.HALF_UP)
+        val calculationRate = BigDecimal.ONE.divide(
+            displayRate,
+            DomainConstants.RATE_PRECISION,
+            RoundingMode.HALF_UP
+        )
 
         val result = calculateGroupAmount(sourceAmount, calculationRate, targetDecimalPlaces)
         return result.toPlainString()
@@ -123,7 +123,11 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
         if (targetAmount.compareTo(BigDecimal.ZERO) == 0) return BigDecimal.ZERO.toPlainString()
 
         // Display rate = source / target (e.g., 1000 THB / 27 EUR = 37 THB per EUR)
-        val displayRate = sourceAmount.divide(targetAmount, RATE_PRECISION, RoundingMode.HALF_UP)
+        val displayRate = sourceAmount.divide(
+            targetAmount,
+            DomainConstants.RATE_PRECISION,
+            RoundingMode.HALF_UP
+        )
         return displayRate.stripTrailingZeros().toPlainString()
     }
 
@@ -136,7 +140,7 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
     override fun displayRateToCalculationRate(displayRateString: String): BigDecimal {
         val displayRate = parseRate(displayRateString)
         if (displayRate.compareTo(BigDecimal.ZERO) == 0) return BigDecimal.ZERO
-        return BigDecimal.ONE.divide(displayRate, RATE_PRECISION, RoundingMode.HALF_UP)
+        return BigDecimal.ONE.divide(displayRate, DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
     }
 
     /**
@@ -176,7 +180,7 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
     override fun calculateExchangeRate(amountWithdrawn: Long, deductedBaseAmount: Long): BigDecimal {
         if (deductedBaseAmount <= 0) return BigDecimal.ONE
         return BigDecimal(amountWithdrawn)
-            .divide(BigDecimal(deductedBaseAmount), RATE_PRECISION, RoundingMode.HALF_UP)
+            .divide(BigDecimal(deductedBaseAmount), DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
     }
 
     /**
@@ -195,7 +199,7 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
     override fun calculateBlendedRate(sourceAmountCents: Long, groupAmountCents: Long): BigDecimal {
         if (sourceAmountCents <= 0 || groupAmountCents <= 0) return BigDecimal.ONE
         return BigDecimal(groupAmountCents)
-            .divide(BigDecimal(sourceAmountCents), RATE_PRECISION, RoundingMode.HALF_UP)
+            .divide(BigDecimal(sourceAmountCents), DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
     }
 
     /**
@@ -214,7 +218,7 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
     override fun calculateBlendedDisplayRate(sourceAmountCents: Long, groupAmountCents: Long): BigDecimal {
         if (sourceAmountCents <= 0 || groupAmountCents <= 0) return BigDecimal.ONE
         return BigDecimal(sourceAmountCents)
-            .divide(BigDecimal(groupAmountCents), RATE_PRECISION, RoundingMode.HALF_UP)
+            .divide(BigDecimal(groupAmountCents), DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
     }
 
     /**
@@ -238,7 +242,11 @@ class ExchangeRateCalculationServiceImpl : ExchangeRateCalculationService {
         val displayRate = normalized.toBigDecimalOrNull() ?: return 0L
         if (displayRate.compareTo(BigDecimal.ZERO) == 0) return 0L
 
-        val calculationRate = BigDecimal.ONE.divide(displayRate, RATE_PRECISION, RoundingMode.HALF_UP)
+        val calculationRate = BigDecimal.ONE.divide(
+            displayRate,
+            DomainConstants.RATE_PRECISION,
+            RoundingMode.HALF_UP
+        )
 
         return BigDecimal(amountCents)
             .multiply(calculationRate)

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/impl/ExpenseCalculatorServiceImpl.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/impl/ExpenseCalculatorServiceImpl.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.service.impl
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.model.CashTranche
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import es.pedrazamiguez.splittrip.domain.service.ExpenseCalculatorService
@@ -8,10 +9,6 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 
 class ExpenseCalculatorServiceImpl : ExpenseCalculatorService {
-
-    companion object {
-        private const val RATE_PRECISION = 6
-    }
 
     // ── Cents Conversion ─────────────────────────────────────────────────
 
@@ -178,7 +175,11 @@ class ExpenseCalculatorServiceImpl : ExpenseCalculatorService {
             // rate = deductedBaseAmount / amountWithdrawn (base per cash unit)
             val rate = if (withdrawal.amountWithdrawn > 0) {
                 BigDecimal(withdrawal.deductedBaseAmount)
-                    .divide(BigDecimal(withdrawal.amountWithdrawn), RATE_PRECISION, RoundingMode.HALF_UP)
+                    .divide(
+                        BigDecimal(withdrawal.amountWithdrawn),
+                        DomainConstants.RATE_PRECISION,
+                        RoundingMode.HALF_UP
+                    )
             } else {
                 BigDecimal.ZERO
             }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/split/SplitPreviewService.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/service/split/SplitPreviewService.kt
@@ -1,12 +1,10 @@
 package es.pedrazamiguez.splittrip.domain.service.split
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.model.SplitPreviewShare
 import java.math.BigDecimal
 
 interface SplitPreviewService {
-    companion object {
-        const val DEFAULT_DECIMAL_PLACES = 2
-    }
     fun distributePercentagesEvenly(sourceAmountCents: Long, participantIds: List<String>): List<SplitPreviewShare>
     fun redistributeRemainingPercentage(
         editedPercentage: BigDecimal,
@@ -15,7 +13,7 @@ interface SplitPreviewService {
         lockedPercentages: Map<String, BigDecimal> = emptyMap()
     ): List<SplitPreviewShare>
     fun calculateAmountFromPercentage(percentage: BigDecimal, sourceAmountCents: Long): Long
-    fun parseAmountToCents(input: String, decimalDigits: Int = DEFAULT_DECIMAL_PLACES): Long
+    fun parseAmountToCents(input: String, decimalDigits: Int = DomainConstants.DEFAULT_DECIMAL_PLACES): Long
     fun parseToDecimal(input: String): BigDecimal
     fun parseToDecimalOrNull(input: String): BigDecimal?
 }

--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/impl/PreviewCashExchangeRateUseCaseImpl.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/impl/PreviewCashExchangeRateUseCaseImpl.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.usecase.expense.impl
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.CashRatePreview
 import es.pedrazamiguez.splittrip.domain.model.CashRatePreviewResult
@@ -17,10 +18,6 @@ class PreviewCashExchangeRateUseCaseImpl(
     private val expenseCalculatorService: ExpenseCalculatorService,
     private val exchangeRateCalculationService: ExchangeRateCalculationService
 ) : PreviewCashExchangeRateUseCase {
-
-    companion object {
-        private const val RATE_PRECISION = 6
-    }
 
     override suspend operator fun invoke(
         groupId: String,
@@ -75,7 +72,7 @@ class PreviewCashExchangeRateUseCaseImpl(
         }
 
         val weightedDisplayRate = BigDecimal(totalWithdrawn)
-            .divide(BigDecimal(totalDeducted), RATE_PRECISION, RoundingMode.HALF_UP)
+            .divide(BigDecimal(totalDeducted), DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
         return CashRatePreviewResult.Available(
             CashRatePreview(displayRate = weightedDisplayRate)
         )

--- a/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExchangeRateCalculationServiceTest.kt
+++ b/domain/src/test/kotlin/es/pedrazamiguez/splittrip/domain/service/ExchangeRateCalculationServiceTest.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.domain.service
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.service.impl.ExchangeRateCalculationServiceImpl
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -353,7 +354,7 @@ class ExchangeRateCalculationServiceTest {
     @Test
     fun `displayRateToCalculationRate handles invalid input defaults to one`() {
         val result = service.displayRateToCalculationRate("invalid")
-        assertEquals(BigDecimal.ONE.setScale(6), result)
+        assertEquals(BigDecimal.ONE.setScale(DomainConstants.RATE_PRECISION), result)
     }
 
     // ── Locale-specific rate parsing (Spanish) ───────────────────────────

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseAddOnUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseAddOnUiMapper.kt
@@ -1,5 +1,6 @@
 package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
 
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.converter.CurrencyConverter
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.model.AddOn
@@ -14,10 +15,6 @@ import java.math.RoundingMode
  * function-count threshold.
  */
 class AddExpenseAddOnUiMapper {
-
-    private companion object {
-        private const val RATE_PRECISION = 6
-    }
 
     /**
      * Maps add-on UI models to domain [AddOn] objects.
@@ -52,7 +49,7 @@ class AddExpenseAddOnUiMapper {
         val normalizedRate = CurrencyConverter.normalizeAmountString(displayExchangeRate.trim())
         val displayRate = normalizedRate.toBigDecimalOrNull() ?: BigDecimal.ONE
         return if (displayRate.compareTo(BigDecimal.ZERO) != 0) {
-            BigDecimal.ONE.divide(displayRate, RATE_PRECISION, RoundingMode.HALF_UP)
+            BigDecimal.ONE.divide(displayRate, DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
         } else {
             BigDecimal.ONE
         }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapper.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.converter.CurrencyConverter
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
 import es.pedrazamiguez.splittrip.domain.enums.AddOnType
@@ -47,10 +48,6 @@ class AddExpenseUiMapper(
     private val addOnMapper: AddExpenseAddOnUiMapper,
     private val splitPreviewService: SplitPreviewService
 ) {
-
-    companion object {
-        private const val RATE_PRECISION = 6
-    }
 
     // ── Date Formatting ────────────────────────────────────────────────────
 
@@ -101,7 +98,7 @@ class AddExpenseUiMapper(
             CurrencyConverter.normalizeAmountString(state.displayExchangeRate.trim())
         val displayRate = normalizedDisplayRate.toBigDecimalOrNull() ?: BigDecimal.ONE
         val internalRate = if (displayRate.compareTo(BigDecimal.ZERO) != 0) {
-            BigDecimal.ONE.divide(displayRate, RATE_PRECISION, RoundingMode.HALF_UP)
+            BigDecimal.ONE.divide(displayRate, DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
         } else {
             BigDecimal.ZERO
         }
@@ -211,7 +208,7 @@ class AddExpenseUiMapper(
 
         val isForeign = expense.sourceCurrency != expense.groupCurrency
         val displayRate = if (expense.exchangeRate.compareTo(BigDecimal.ZERO) != 0) {
-            BigDecimal.ONE.divide(expense.exchangeRate, RATE_PRECISION, RoundingMode.HALF_UP)
+            BigDecimal.ONE.divide(expense.exchangeRate, DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
                 .stripTrailingZeros().toPlainString()
         } else {
             "1.0"
@@ -322,7 +319,7 @@ class AddExpenseUiMapper(
 
     private fun getAddOnDisplayRate(exchangeRate: BigDecimal): String {
         return if (exchangeRate.compareTo(BigDecimal.ZERO) != 0) {
-            BigDecimal.ONE.divide(exchangeRate, RATE_PRECISION, RoundingMode.HALF_UP)
+            BigDecimal.ONE.divide(exchangeRate, DomainConstants.RATE_PRECISION, RoundingMode.HALF_UP)
                 .stripTrailingZeros().toPlainString()
         } else {
             "1.0"

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapperTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/mapper/AddExpenseUiMapperTest.kt
@@ -3,6 +3,7 @@ package es.pedrazamiguez.splittrip.features.expense.presentation.mapper
 import es.pedrazamiguez.splittrip.core.common.provider.LocaleProvider
 import es.pedrazamiguez.splittrip.core.common.provider.ResourceProvider
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.model.CurrencyUiModel
+import es.pedrazamiguez.splittrip.domain.constant.DomainConstants
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
 import es.pedrazamiguez.splittrip.domain.enums.AddOnType
 import es.pedrazamiguez.splittrip.domain.enums.AddOnValueType
@@ -818,7 +819,7 @@ class AddExpenseUiMapperTest {
             assertEquals(
                 0,
                 BigDecimal("0.909091").compareTo(
-                    rate.setScale(6, java.math.RoundingMode.HALF_UP)
+                    rate.setScale(DomainConstants.RATE_PRECISION, java.math.RoundingMode.HALF_UP)
                 )
             )
         }

--- a/wiki/core-services-catalog.md
+++ b/wiki/core-services-catalog.md
@@ -206,9 +206,13 @@ All components are `@Composable` functions following Material 3 design. They acc
 | `UiConstants` | `constant/UiConstants.kt` | UI-layer constants (animation durations, sizes, etc.). |
 | `NavigationUtils` | `navigation/NavigationUtils.kt` | Helper functions for common navigation patterns (popBackStack, navigate with arguments). |
 | `DoubleTapBackToExitHandler` | `navigation/DoubleTapBackToExitHandler.kt` | Composable that implements "press back twice to exit" behavior. |
+| `DomainConstants.DEFAULT_DECIMAL_PLACES` | `domain/.../constant/DomainConstants.kt` | `2` — canonical default decimal places for domain money math and parsing defaults. |
+| `DomainConstants.RATE_PRECISION` | `domain/.../constant/DomainConstants.kt` | `6` — canonical intermediate precision for exchange-rate division operations. |
 | `AppConstants.FLOW_RETENTION_TIME` | `core/common/.../AppConstants.kt` | `5000L` ms — `WhileSubscribed` stop timeout for hot flows. |
 | `AppConstants.FLOW_REPLAY_EXPIRATION` | `core/common/.../AppConstants.kt` | `0L` ms — replay cache reset delay (prevents stale-state flash on tab re-entry). |
 | `AppConstants.BALANCE_COMPUTATION_DEBOUNCE_MS` | `core/common/.../AppConstants.kt` | `300L` ms — debounce applied to the balance computation flow to absorb rapid Firestore reconciliation bursts. |
+
+`AppConstants` remains the source of app-lifecycle/UI-layer timing constants; domain precision constants live in `DomainConstants` to keep module boundaries clean.
 
 ---
 


### PR DESCRIPTION
Add DomainConstants (DEFAULT_DECIMAL_PLACES=2, RATE_PRECISION=6) and replace scattered local decimal/place/rate constants across the domain and feature code. Updated interfaces, implementations, mappers, tests, and wiki references to use the centralized constants and removed duplicated companion-object constants to ensure consistent precision for money math and exchange-rate calculations.

## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1199 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
