### PR TITLE
[SPLTRP-1379]: Expense list scroll position resets when navigating back from expense detail

### DIFF
--- a/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/PersistExpenseStrategy.kt
+++ b/domain/src/main/kotlin/es/pedrazamiguez/splittrip/domain/usecase/expense/strategy/PersistExpenseStrategy.kt
@@ -123,7 +123,7 @@ abstract class BasePersistExpenseStrategy(
             amount = effectiveAmount,
             currency = expense.groupCurrency,
             linkedExpenseId = expense.id,
-            createdAt = expense.createdAt // propagate expense date so paired contribution isn't stamped with today
+            createdAt = expense.createdAt
         )
         contributionRepository.addContribution(groupId, pairedContribution)
     }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/navigation/ExpensesNavigation.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/navigation/ExpensesNavigation.kt
@@ -20,6 +20,7 @@ fun NavGraphBuilder.expensesGraph() {
         val navController = LocalTabNavController.current
         AddExpenseFeature(
             onAddExpenseSuccess = {
+                navController.previousBackStackEntry?.savedStateHandle?.set("expenseAdded", true)
                 navController.popBackStack()
             }
         )

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/RestoreScrollEffect.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/RestoreScrollEffect.kt
@@ -1,0 +1,24 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.component
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.ExpensesUiState
+
+@Composable
+internal fun RestoreScrollEffect(listState: LazyListState, uiState: ExpensesUiState) {
+    var hasRestoredScroll by remember { mutableStateOf(false) }
+    val expenseGroups = uiState.expenseGroups
+    LaunchedEffect(uiState.isLoading) {
+        if (!uiState.isLoading && !hasRestoredScroll && expenseGroups.isNotEmpty()) {
+            if (uiState.scrollPosition > 0 || uiState.scrollOffset > 0) {
+                listState.scrollToItem(uiState.scrollPosition, uiState.scrollOffset)
+            }
+            hasRestoredScroll = true
+        }
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/TrackScrollEffect.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/component/TrackScrollEffect.kt
@@ -1,0 +1,22 @@
+package es.pedrazamiguez.splittrip.features.expense.presentation.component
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import es.pedrazamiguez.splittrip.core.designsystem.constant.UiConstants
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+
+@OptIn(FlowPreview::class)
+@Composable
+internal fun TrackScrollEffect(
+    listState: LazyListState,
+    onScrollPositionChanged: (Int, Int) -> Unit
+) {
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+            .debounce(UiConstants.SCROLL_POSITION_DEBOUNCE_MS)
+            .collect { (index, offset) -> onScrollPositionChanged(index, offset) }
+    }
+}

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ExpensesFeature.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/feature/ExpensesFeature.kt
@@ -20,6 +20,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
 
+@Suppress("LongMethod")
 @Composable
 fun ExpensesFeature(
     expensesViewModel: ExpensesViewModel = koinViewModel<ExpensesViewModel>(),
@@ -61,6 +62,17 @@ fun ExpensesFeature(
                 is ExpensesUiAction.ShowCancelError -> {
                     pillController.showPill(message = action.message.asString(context))
                 }
+                is ExpensesUiAction.ScrollToTop -> Unit // Handled by ExpensesScreen
+            }
+        }
+    }
+
+    val currentBackStackEntry = navController.currentBackStackEntry
+    LaunchedEffect(currentBackStackEntry) {
+        currentBackStackEntry?.savedStateHandle?.getStateFlow("expenseAdded", false)?.collectLatest { added ->
+            if (added) {
+                expensesViewModel.onEvent(ExpensesUiEvent.ExpenseAdded)
+                currentBackStackEntry.savedStateHandle.remove<Boolean>("expenseAdded")
             }
         }
     }
@@ -77,6 +89,7 @@ fun ExpensesFeature(
 
     ExpensesScreen(
         uiState = effectiveUiState,
+        actions = expensesViewModel.actions,
         onExpenseClicked = { expenseId ->
             navController.navigate(Routes.expenseDetailRoute(expenseId))
         },

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ExpensesScreen.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/screen/ExpensesScreen.kt
@@ -16,11 +16,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import es.pedrazamiguez.splittrip.core.designsystem.constant.UiConstants
 import es.pedrazamiguez.splittrip.core.designsystem.extension.sharedElementAnimation
 import es.pedrazamiguez.splittrip.core.designsystem.foundation.spacing
 import es.pedrazamiguez.splittrip.core.designsystem.icon.TablerIcons
@@ -39,18 +37,21 @@ import es.pedrazamiguez.splittrip.core.designsystem.presentation.topbar.remember
 import es.pedrazamiguez.splittrip.core.designsystem.transition.LocalAnimatedVisibilityScope
 import es.pedrazamiguez.splittrip.core.designsystem.transition.LocalSharedTransitionScope
 import es.pedrazamiguez.splittrip.features.expense.R
+import es.pedrazamiguez.splittrip.features.expense.presentation.component.RestoreScrollEffect
+import es.pedrazamiguez.splittrip.features.expense.presentation.component.TrackScrollEffect
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.list.DateHeaderItem
 import es.pedrazamiguez.splittrip.features.expense.presentation.component.list.ExpenseItem
 import es.pedrazamiguez.splittrip.features.expense.presentation.model.ExpenseUiModel
+import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.action.ExpensesUiAction
 import es.pedrazamiguez.splittrip.features.expense.presentation.viewmodel.state.ExpensesUiState
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.Flow
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "CognitiveComplexMethod")
-@OptIn(FlowPreview::class, ExperimentalSharedTransitionApi::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalSharedTransitionApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun ExpensesScreen(
     uiState: ExpensesUiState = ExpensesUiState(),
+    actions: Flow<ExpensesUiAction>? = null,
     onExpenseClicked: (String) -> Unit = { _ -> },
     onEditExpenseClick: (String) -> Unit = {},
     onScrollPositionChanged: (Int, Int) -> Unit = { _, _ -> },
@@ -69,18 +70,17 @@ fun ExpensesScreen(
         initialFirstVisibleItemScrollOffset = uiState.scrollOffset
     )
 
-    LaunchedEffect(listState) {
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .debounce(UiConstants.SCROLL_POSITION_DEBOUNCE_MS)
-            .collect { (index, offset) ->
-                onScrollPositionChanged(index, offset)
-            }
-    }
+    RestoreScrollEffect(listState = listState, uiState = uiState)
+    TrackScrollEffect(listState = listState, onScrollPositionChanged = onScrollPositionChanged)
 
-    val totalExpenseCount = uiState.expenseGroups.sumOf { it.expenses.size }
-    LaunchedEffect(totalExpenseCount) {
-        if (totalExpenseCount > 0 && !uiState.isLoading && listState.firstVisibleItemIndex > 0) {
-            listState.animateScrollToItem(0)
+    LaunchedEffect(actions) {
+        actions?.collect { action ->
+            when (action) {
+                is ExpensesUiAction.ScrollToTop -> {
+                    listState.animateScrollToItem(0)
+                }
+                else -> Unit
+            }
         }
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpensesViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpensesViewModel.kt
@@ -169,6 +169,9 @@ class ExpensesViewModel(
 
             is ExpensesUiEvent.DeleteExpense -> handleDeleteExpense(event.expenseId)
             is ExpensesUiEvent.CancelExpense -> handleCancelExpense(event.expenseId)
+            ExpensesUiEvent.ExpenseAdded -> {
+                viewModelScope.launch { _actions.emit(ExpensesUiAction.ScrollToTop) }
+            }
         }
     }
 

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/action/ExpensesUiAction.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/action/ExpensesUiAction.kt
@@ -8,4 +8,5 @@ sealed interface ExpensesUiAction {
     data class ShowDeleteError(val message: UiText) : ExpensesUiAction
     data class ShowCancelSuccess(val message: UiText) : ExpensesUiAction
     data class ShowCancelError(val message: UiText) : ExpensesUiAction
+    data object ScrollToTop : ExpensesUiAction
 }

--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/ExpensesUiEvent.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/event/ExpensesUiEvent.kt
@@ -5,4 +5,5 @@ sealed interface ExpensesUiEvent {
     data class ScrollPositionChanged(val index: Int, val offset: Int) : ExpensesUiEvent
     data class DeleteExpense(val expenseId: String) : ExpensesUiEvent
     data class CancelExpense(val expenseId: String) : ExpensesUiEvent
+    data object ExpenseAdded : ExpensesUiEvent
 }

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpensesViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpensesViewModelTest.kt
@@ -794,6 +794,27 @@ class ExpensesViewModelTest {
             coVerify(exactly = 0) { updateExpenseUseCase(any(), any(), any(), any(), any(), any()) }
             collectJob.cancel()
         }
+
+        @Test
+        fun `onEvent ExpenseAdded emits ScrollToTop action`() = runTest(testDispatcher) {
+            // Given
+            viewModel = createViewModel()
+            val actions = mutableListOf<ExpensesUiAction>()
+            val actionsJob = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.actions.collect { actions.add(it) }
+            }
+
+            // When
+            viewModel.onEvent(ExpensesUiEvent.ExpenseAdded)
+            advanceUntilIdle()
+
+            // Then
+            assertTrue(
+                actions.any { it is ExpensesUiAction.ScrollToTop },
+                "Expected ScrollToTop action"
+            )
+            actionsJob.cancel()
+        }
     }
 
     private fun createViewModel() = ExpensesViewModel(


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1379 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
