### PR TITLE
[SPLTRP-1428]: Hide `ArithmeticOperatorBar` when soft keyboard is hidden

### DIFF
--- a/app/src/androidTest/kotlin/es/pedrazamiguez/splittrip/screens/ArithmeticOperatorBarTest.kt
+++ b/app/src/androidTest/kotlin/es/pedrazamiguez/splittrip/screens/ArithmeticOperatorBarTest.kt
@@ -1,0 +1,52 @@
+package es.pedrazamiguez.splittrip.screens
+
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import es.pedrazamiguez.splittrip.core.designsystem.foundation.SplitTripTheme
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.input.ArithmeticKeyboardState
+import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.input.ArithmeticOperatorBar
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI tests for [ArithmeticOperatorBar].
+ */
+@RunWith(AndroidJUnit4::class)
+class ArithmeticOperatorBarTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun hidesOperatorBar_whenKeyboardIsHidden_evenIfStateIsVisible() {
+        val state = ArithmeticKeyboardState(isVisible = true)
+
+        composeRule.setContent {
+            SplitTripTheme {
+                ArithmeticOperatorBar(state = state)
+            }
+        }
+
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription("Plus").assertDoesNotExist()
+    }
+
+    @Test
+    fun hidesOperatorBar_whenStateIsNotVisible() {
+        val state = ArithmeticKeyboardState(isVisible = false)
+
+        composeRule.setContent {
+            SplitTripTheme {
+                ArithmeticOperatorBar(state = state)
+            }
+        }
+
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription("Plus").assertDoesNotExist()
+    }
+}

--- a/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/input/ArithmeticOperatorBar.kt
+++ b/core/design-system/src/main/kotlin/es/pedrazamiguez/splittrip/core/designsystem/presentation/component/input/ArithmeticOperatorBar.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -30,13 +33,14 @@ import es.pedrazamiguez.splittrip.core.designsystem.icon.outline.MathPlus
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.component.rememberLocale
 import es.pedrazamiguez.splittrip.core.designsystem.presentation.formatter.formatArithmeticPreview
 
+@OptIn(ExperimentalLayoutApi::class)
 @Suppress("LongMethod")
 @Composable
 fun ArithmeticOperatorBar(
     state: ArithmeticKeyboardState,
     modifier: Modifier = Modifier
 ) {
-    if (!state.isVisible) return
+    if (!state.isVisible || !WindowInsets.isImeVisible) return
 
     val locale = rememberLocale()
 


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1428 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
