### PR TITLE
[SPLTRP-1464]: Fix legacy SCHEDULED expenses missing `expectedGroupAmountCents`

### DIFF
--- a/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
+++ b/features/expenses/src/main/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModel.kt
@@ -356,8 +356,10 @@ class ExpenseDetailViewModel(
                 val updatedSplits = domainExpense.splits.mapIndexed { index, split ->
                     split.copy(amountCents = newAmounts[index])
                 }
+                val originalExpectedAmount = domainExpense.expectedGroupAmount ?: domainExpense.groupAmount
                 val updatedExpense = domainExpense.copy(
                     groupAmount = actualGroupAmountCents,
+                    expectedGroupAmount = originalExpectedAmount,
                     exchangeRate = newRate,
                     paymentStatus = PaymentStatus.FINISHED,
                     splits = updatedSplits

--- a/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
+++ b/features/expenses/src/test/kotlin/es/pedrazamiguez/splittrip/features/expense/presentation/viewmodel/ExpenseDetailViewModelTest.kt
@@ -743,7 +743,47 @@ class ExpenseDetailViewModelTest {
                         groupId = testGroupId,
                         expense = match {
                             it.paymentStatus == PaymentStatus.FINISHED &&
-                                it.groupAmount == 1300L
+                                it.groupAmount == 1300L &&
+                                it.expectedGroupAmount == 1200L
+                        },
+                        pairedContributionScope = PayerType.USER,
+                        pairedSubunitId = null
+                    )
+                }
+
+                collectJob.cancel()
+            }
+
+        @Test
+        fun `ConfirmPayment handles legacy expense with null expectedGroupAmount`() =
+            runTest(testDispatcher) {
+                // Given
+                val legacyExpense = testExpense.copy(
+                    paymentStatus = PaymentStatus.SCHEDULED,
+                    groupAmount = 1200L,
+                    expectedGroupAmount = null,
+                    splits = listOf(
+                        es.pedrazamiguez.splittrip.domain.model.ExpenseSplit(userId = testUserId, amountCents = 1200L)
+                    )
+                )
+                every { getExpenseByIdFlowUseCase(testExpenseId) } returns flowOf(legacyExpense)
+                every { exchangeRateCalculationService.calculateImpliedRate(any(), any()) } returns BigDecimal.ONE
+                every { remainderDistributionService.rescaleAmounts(any(), any(), any(), any()) } returns listOf(1300L)
+                coEvery { updateExpenseUseCase(any(), any(), any(), any()) } returns Result.success(Unit)
+                val collectJob = backgroundScope.launch { viewModel.uiState.collect {} }
+                viewModel.setExpenseId(testExpenseId)
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(ExpenseDetailUiEvent.ConfirmPayment(actualGroupAmountCents = 1300L))
+                advanceUntilIdle()
+
+                // Then
+                coVerify(exactly = 1) {
+                    updateExpenseUseCase(
+                        groupId = testGroupId,
+                        expense = match {
+                            it.groupAmount == 1300L && it.expectedGroupAmount == 1200L
                         },
                         pairedContributionScope = PayerType.USER,
                         pairedSubunitId = null


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1464 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
