### PR TITLE
[SPLTRP-1564]: Remove or correctly use unused `*Ref` (`DocumentReference`) fields in Firestore documents

### DIFF
--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreCashWithdrawalDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreCashWithdrawalDataSourceImpl.kt
@@ -39,7 +39,6 @@ class FirestoreCashWithdrawalDataSourceImpl(
         val withdrawalDocument = withdrawal.toDocument(
             withdrawalId,
             groupId,
-            groupDocRef,
             userId
         )
 
@@ -61,7 +60,6 @@ class FirestoreCashWithdrawalDataSourceImpl(
         val withdrawalDocument = withdrawal.toDocument(
             withdrawal.id,
             groupId,
-            groupDocRef,
             userId
         )
 

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreContributionDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreContributionDataSourceImpl.kt
@@ -39,7 +39,6 @@ class FirestoreContributionDataSourceImpl(
         val contributionDocument = contribution.toDocument(
             contributionId,
             groupId,
-            groupDocRef,
             userId
         )
 

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreExpenseDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreExpenseDataSourceImpl.kt
@@ -44,7 +44,6 @@ class FirestoreExpenseDataSourceImpl(
         val expenseDocument = expense.toDocument(
             expenseId,
             groupId,
-            groupDocRef,
             userId
         )
 
@@ -155,7 +154,7 @@ class FirestoreExpenseDataSourceImpl(
         val expenseDocRef = groupDocRef
             .collection(ExpenseDocument.COLLECTION_PATH)
             .document(expenseId)
-        val expenseDocument = expense.toDocument(expenseId, groupId, groupDocRef, userId)
+        val expenseDocument = expense.toDocument(expenseId, groupId, userId)
 
         val withdrawalRefs = expectedRemainingAmounts.keys.map { withdrawalId ->
             groupDocRef

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupDataSourceImpl.kt
@@ -56,7 +56,7 @@ class FirestoreGroupDataSourceImpl(
                 userId
             )
             val adminMemberDocument = toAdminMemberDocument(
-                groupDocRef,
+                groupId,
                 userId
             )
 
@@ -82,7 +82,7 @@ class FirestoreGroupDataSourceImpl(
                                 .collection(GroupMemberDocument.collectionPath(groupId))
                                 .document(memberId)
                             val memberDocument = toRegularMemberDocument(
-                                groupDocRef,
+                                groupId,
                                 memberId,
                                 addedBy = userId
                             )
@@ -232,10 +232,11 @@ class FirestoreGroupDataSourceImpl(
                     .collection(GroupMemberDocument.collectionPath(groupId))
                     .document(memberId)
                 val memberDocument = toRegularMemberDocument(
-                    groupDocRef,
+                    groupId,
                     memberId,
                     addedBy = addedBy
                 )
+
                 set(memberDocRef, memberDocument)
             }
             update(
@@ -394,8 +395,7 @@ class FirestoreGroupDataSourceImpl(
         }
 
     private fun extractGroupReferences(documents: List<DocumentSnapshot>) = documents.mapNotNull { doc ->
-        doc.getDocumentReference(GroupMemberDocument.FIELD_GROUP_REF)
-            ?: doc.reference.parent.parent
+        doc.reference.parent.parent
     }
 
     override suspend fun reconcileUnregisteredUser(pendingUserId: String, activeUserId: String) {

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupReconciler.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreGroupReconciler.kt
@@ -24,8 +24,6 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
     }
 
     private suspend fun executeReconcileUnregisteredUser(pendingUserId: String, activeUserId: String) {
-        val userRef = firestore.collection(UserDocument.COLLECTION_PATH).document(activeUserId)
-
         val matchingGroupsSnapshot = firestore.collection(GroupDocument.COLLECTION_PATH)
             .whereArrayContains("memberIds", pendingUserId)
             .get()
@@ -33,7 +31,7 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
 
         for (groupDoc in matchingGroupsSnapshot.documents) {
             val groupId = groupDoc.id
-            reconcileGroupData(groupId, groupDoc.reference, pendingUserId, activeUserId, userRef)
+            reconcileGroupData(groupId, groupDoc.reference, pendingUserId, activeUserId)
         }
 
         // Delete users/$pendingUserId document
@@ -44,8 +42,7 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
         groupId: String,
         groupDocRef: DocumentReference,
         pendingUserId: String,
-        activeUserId: String,
-        userRef: DocumentReference
+        activeUserId: String
     ) {
         val memberDocRef = firestore.collection(GroupDocument.COLLECTION_PATH)
             .document(groupId)
@@ -91,15 +88,14 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
                 memberDocRef,
                 activeMemberDocRef,
                 pendingMemberSnap,
-                activeUserId,
-                userRef
+                activeUserId
             )
 
-            updateExpensesInTransaction(transaction, freshExpenseSnaps, pendingUserId, activeUserId, userRef)
+            updateExpensesInTransaction(transaction, freshExpenseSnaps, pendingUserId, activeUserId)
 
-            updateContributionsInTransaction(transaction, freshContributionSnaps, pendingUserId, activeUserId, userRef)
+            updateContributionsInTransaction(transaction, freshContributionSnaps, pendingUserId, activeUserId)
 
-            updateWithdrawalsInTransaction(transaction, freshWithdrawalSnaps, pendingUserId, activeUserId, userRef)
+            updateWithdrawalsInTransaction(transaction, freshWithdrawalSnaps, pendingUserId, activeUserId)
         }.await()
     }
 
@@ -120,16 +116,14 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
         memberDocRef: DocumentReference,
         activeMemberDocRef: DocumentReference,
         pendingMemberSnap: DocumentSnapshot,
-        activeUserId: String,
-        userRef: DocumentReference
+        activeUserId: String
     ) {
         if (pendingMemberSnap.exists()) {
             val memberDoc = pendingMemberSnap.toObject(GroupMemberDocument::class.java)
             if (memberDoc != null) {
                 val activeMemberDoc = memberDoc.copy(
                     memberId = activeUserId,
-                    userId = activeUserId,
-                    userRef = userRef
+                    userId = activeUserId
                 )
                 transaction.set(activeMemberDocRef, activeMemberDoc)
                 transaction.delete(memberDocRef)
@@ -141,12 +135,11 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
         transaction: Transaction,
         expenseSnaps: List<DocumentSnapshot>,
         pendingUserId: String,
-        activeUserId: String,
-        userRef: DocumentReference
+        activeUserId: String
     ) {
         for (freshExpSnap in expenseSnaps) {
             val expense = freshExpSnap.toObject(ExpenseDocument::class.java) ?: continue
-            val updatedExpense = expense.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId, userRef)
+            val updatedExpense = expense.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
             if (updatedExpense != null) {
                 transaction.set(freshExpSnap.reference, updatedExpense)
             }
@@ -157,12 +150,11 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
         transaction: Transaction,
         contributionSnaps: List<DocumentSnapshot>,
         pendingUserId: String,
-        activeUserId: String,
-        userRef: DocumentReference
+        activeUserId: String
     ) {
         for (freshContrSnap in contributionSnaps) {
             val contribution = freshContrSnap.toObject(ContributionDocument::class.java) ?: continue
-            val updatedContribution = contribution.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId, userRef)
+            val updatedContribution = contribution.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
             if (updatedContribution != null) {
                 transaction.set(freshContrSnap.reference, updatedContribution)
             }
@@ -173,12 +165,11 @@ class FirestoreGroupReconciler(private val firestore: FirebaseFirestore) {
         transaction: Transaction,
         withdrawalSnaps: List<DocumentSnapshot>,
         pendingUserId: String,
-        activeUserId: String,
-        userRef: DocumentReference
+        activeUserId: String
     ) {
         for (freshWithdSnap in withdrawalSnaps) {
             val withdrawal = freshWithdSnap.toObject(CashWithdrawalDocument::class.java) ?: continue
-            val updatedWithdrawal = withdrawal.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId, userRef)
+            val updatedWithdrawal = withdrawal.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
             if (updatedWithdrawal != null) {
                 transaction.set(freshWithdSnap.reference, updatedWithdrawal)
             }

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreSubunitDataSourceImpl.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/FirestoreSubunitDataSourceImpl.kt
@@ -39,7 +39,6 @@ class FirestoreSubunitDataSourceImpl(
         val subunitDocument = subunit.toDocument(
             subunitId,
             groupId,
-            groupDocRef,
             userId
         )
 
@@ -61,7 +60,6 @@ class FirestoreSubunitDataSourceImpl(
         val subunitDocument = subunit.toDocument(
             subunit.id,
             groupId,
-            groupDocRef,
             userId
         )
 

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/ReconciliationMappers.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/ReconciliationMappers.kt
@@ -1,6 +1,5 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.datasource.impl
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.CashWithdrawalDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ContributionDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseDocument
@@ -8,28 +7,23 @@ import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseSplitD
 
 internal fun ExpenseDocument.getUpdatedIfNeedsUpdate(
     pendingUserId: String,
-    activeUserId: String,
-    userRef: DocumentReference
+    activeUserId: String
 ): ExpenseDocument? {
     var needsUpdate = false
     var payerId = this.payerId
-    var payerRef = this.payerRef
     var createdBy = this.createdBy
-    var createdByRef = this.createdByRef
 
     if (payerId == pendingUserId) {
         payerId = activeUserId
-        payerRef = userRef
         needsUpdate = true
     }
     if (createdBy == pendingUserId) {
         createdBy = activeUserId
-        createdByRef = userRef
         needsUpdate = true
     }
 
     val updatedSplits = this.splits.map { split ->
-        val updatedSplit = split.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId, userRef)
+        val updatedSplit = split.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
         if (updatedSplit != null) {
             needsUpdate = true
             updatedSplit
@@ -41,9 +35,7 @@ internal fun ExpenseDocument.getUpdatedIfNeedsUpdate(
     return if (needsUpdate) {
         this.copy(
             payerId = payerId,
-            payerRef = payerRef,
             createdBy = createdBy,
-            createdByRef = createdByRef,
             splits = updatedSplits
         )
     } else {
@@ -53,32 +45,25 @@ internal fun ExpenseDocument.getUpdatedIfNeedsUpdate(
 
 internal fun ExpenseSplitDocument.getUpdatedIfNeedsUpdate(
     pendingUserId: String,
-    activeUserId: String,
-    userRef: DocumentReference
+    activeUserId: String
 ): ExpenseSplitDocument? {
     var splitUpdated = false
     var sUserId = this.userId
-    var sUserRef = this.userRef
     var sCoveredById = this.isCoveredById
-    var sCoveredByRef = this.isCoveredByRef
 
     if (sUserId == pendingUserId) {
         sUserId = activeUserId
-        sUserRef = userRef
         splitUpdated = true
     }
     if (sCoveredById == pendingUserId) {
         sCoveredById = activeUserId
-        sCoveredByRef = userRef
         splitUpdated = true
     }
 
     return if (splitUpdated) {
         this.copy(
             userId = sUserId,
-            userRef = sUserRef,
-            isCoveredById = sCoveredById,
-            isCoveredByRef = sCoveredByRef
+            isCoveredById = sCoveredById
         )
     } else {
         null
@@ -87,13 +72,11 @@ internal fun ExpenseSplitDocument.getUpdatedIfNeedsUpdate(
 
 internal fun ContributionDocument.getUpdatedIfNeedsUpdate(
     pendingUserId: String,
-    activeUserId: String,
-    userRef: DocumentReference
+    activeUserId: String
 ): ContributionDocument? {
     var needsUpdate = false
     var cUserId = this.userId
     var cCreatedBy = this.createdBy
-    var cCreatedByRef = this.createdByRef
 
     if (cUserId == pendingUserId) {
         cUserId = activeUserId
@@ -101,15 +84,13 @@ internal fun ContributionDocument.getUpdatedIfNeedsUpdate(
     }
     if (cCreatedBy == pendingUserId) {
         cCreatedBy = activeUserId
-        cCreatedByRef = userRef
         needsUpdate = true
     }
 
     return if (needsUpdate) {
         this.copy(
             userId = cUserId,
-            createdBy = cCreatedBy,
-            createdByRef = cCreatedByRef
+            createdBy = cCreatedBy
         )
     } else {
         null
@@ -118,13 +99,11 @@ internal fun ContributionDocument.getUpdatedIfNeedsUpdate(
 
 internal fun CashWithdrawalDocument.getUpdatedIfNeedsUpdate(
     pendingUserId: String,
-    activeUserId: String,
-    userRef: DocumentReference
+    activeUserId: String
 ): CashWithdrawalDocument? {
     var needsUpdate = false
     var wWithdrawnBy = this.withdrawnBy
     var wCreatedBy = this.createdBy
-    var wCreatedByRef = this.createdByRef
 
     if (wWithdrawnBy == pendingUserId) {
         wWithdrawnBy = activeUserId
@@ -132,15 +111,13 @@ internal fun CashWithdrawalDocument.getUpdatedIfNeedsUpdate(
     }
     if (wCreatedBy == pendingUserId) {
         wCreatedBy = activeUserId
-        wCreatedByRef = userRef
         needsUpdate = true
     }
 
     return if (needsUpdate) {
         this.copy(
             withdrawnBy = wWithdrawnBy,
-            createdBy = wCreatedBy,
-            createdByRef = wCreatedByRef
+            createdBy = wCreatedBy
         )
     } else {
         null

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ActivityLogDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ActivityLogDocument.kt
@@ -1,16 +1,12 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class ActivityLogDocument(
     val activityId: String = "",
     val type: String = "UNKNOWN",
-    val byUserRef: DocumentReference? = null,
     val byUserId: String = "",
-    val onGroupRef: DocumentReference? = null,
     val onGroupId: String = "",
-    val targetExpenseRef: DocumentReference? = null,
     val targetExpenseId: String? = null,
     val loggedAt: Timestamp? = null
 )

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/AttachmentDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/AttachmentDocument.kt
@@ -1,13 +1,11 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class AttachmentDocument(
     val path: String = "",
     val mime: String? = null,
     val sizeBytes: Long? = null,
-    val uploadedByRef: DocumentReference? = null,
     val uploadedById: String? = null,
     val uploadedAt: Timestamp? = null
 )

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/CashWithdrawalDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/CashWithdrawalDocument.kt
@@ -1,12 +1,10 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class CashWithdrawalDocument(
     val withdrawalId: String = "",
     val groupId: String = "",
-    val groupRef: DocumentReference? = null,
     val withdrawnBy: String = "",
     val withdrawalScope: String = "GROUP",
     val subunitId: String? = null,
@@ -20,7 +18,6 @@ data class CashWithdrawalDocument(
     val notes: String? = null,
     val receiptLocalUri: String? = null,
     val createdBy: String = "",
-    val createdByRef: DocumentReference? = null,
     var createdAt: Timestamp? = null,
     var lastUpdatedAt: Timestamp? = null,
     val reason: String? = null

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ContributionDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ContributionDocument.kt
@@ -1,12 +1,10 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class ContributionDocument(
     val contributionId: String = "",
     val groupId: String = "",
-    val groupRef: DocumentReference? = null,
     val userId: String = "",
     val contributionScope: String = "USER",
     val subunitId: String? = null,
@@ -17,7 +15,6 @@ data class ContributionDocument(
     val equivalentBaseAmountCents: Long? = null,
     val exchangeRate: String? = null,
     val createdBy: String = "",
-    val createdByRef: DocumentReference? = null,
     var contributionDate: Timestamp? = null,
     var createdAt: Timestamp? = null,
     var lastUpdatedAt: Timestamp? = null

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ExpenseDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ExpenseDocument.kt
@@ -1,12 +1,10 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class ExpenseDocument(
     val expenseId: String = "",
     val groupId: String = "",
-    val groupRef: DocumentReference? = null,
     val operationDate: Timestamp? = null,
     val expenseCategory: String = "OTHER",
     val expenseSubcategory: String? = null,
@@ -27,7 +25,6 @@ data class ExpenseDocument(
     val dueDate: Timestamp? = null,
     val payerType: String = "GROUP",
     val payerId: String? = null,
-    val payerRef: DocumentReference? = null,
     val paidAt: Timestamp? = null,
     val splits: List<ExpenseSplitDocument> = emptyList(),
     val splitType: String = "EQUAL",
@@ -35,7 +32,6 @@ data class ExpenseDocument(
     val cashTranches: List<Map<String, Any>> = emptyList(),
     val notes: String? = null,
     val createdBy: String = "",
-    val createdByRef: DocumentReference? = null,
     val createdAt: Timestamp? = null,
     val lastUpdatedBy: String? = null,
     val lastUpdatedAt: Timestamp? = null

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ExpenseSplitDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ExpenseSplitDocument.kt
@@ -1,20 +1,15 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
-import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.PropertyName
 
 data class ExpenseSplitDocument(
     val userId: String = "",
-    val userRef: DocumentReference? = null,
     val subunitId: String? = null,
-    val subunitRef: DocumentReference? = null,
     val amountCents: Long? = null,
     val percentage: String? = null,
     @get:PropertyName("excluded") @set:PropertyName("excluded")
     var isExcluded: Boolean = false,
     @get:PropertyName("coveredById") @set:PropertyName("coveredById")
     var isCoveredById: String? = null,
-    @get:PropertyName("coveredByRef") @set:PropertyName("coveredByRef")
-    var isCoveredByRef: DocumentReference? = null,
     val splitType: String? = null
 )

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/GroupDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/GroupDocument.kt
@@ -1,7 +1,6 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class GroupDocument(
     val groupId: String = "",
@@ -12,7 +11,6 @@ data class GroupDocument(
     val memberIds: List<String> = emptyList(),
     val mainImagePath: String = "",
     val createdBy: String = "",
-    val createdByRef: DocumentReference? = null,
     val createdAt: Timestamp? = null,
     val lastUpdatedAt: Timestamp? = null,
     val status: String = "ACTIVE",

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/GroupMemberDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/GroupMemberDocument.kt
@@ -1,14 +1,11 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class GroupMemberDocument(
     val memberId: String = "",
     val groupId: String = "",
-    val groupRef: DocumentReference? = null,
     val userId: String = "",
-    val userRef: DocumentReference? = null,
     val role: String = "MEMBER",
     val alias: String? = null,
     val addedBy: String = "",
@@ -18,6 +15,5 @@ data class GroupMemberDocument(
         fun collectionPath(groupId: String) = "groups/$groupId/members"
         const val SUBCOLLECTION_PATH = "members"
         const val USER_ID_FIELD = "userId"
-        const val FIELD_GROUP_REF = "groupRef"
     }
 }

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/SubunitDocument.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/SubunitDocument.kt
@@ -1,17 +1,14 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.document
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 
 data class SubunitDocument(
     val subunitId: String = "",
     val groupId: String = "",
-    val groupRef: DocumentReference? = null,
     val name: String = "",
     val memberIds: List<String> = emptyList(),
     val memberShares: Map<String, String> = emptyMap(),
     val createdBy: String = "",
-    val createdByRef: DocumentReference? = null,
     var createdAt: Timestamp? = null,
     var lastUpdatedAt: Timestamp? = null
 ) {

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/CashWithdrawalDocumentMapper.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/CashWithdrawalDocumentMapper.kt
@@ -1,6 +1,5 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AddOnDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.CashWithdrawalDocument
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
@@ -14,11 +13,10 @@ import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
-fun CashWithdrawal.toDocument(withdrawalId: String, groupId: String, groupDocRef: DocumentReference, userId: String) =
+fun CashWithdrawal.toDocument(withdrawalId: String, groupId: String, userId: String) =
     CashWithdrawalDocument(
         withdrawalId = withdrawalId,
         groupId = groupId,
-        groupRef = groupDocRef,
         withdrawnBy = withdrawnBy.ifBlank { userId },
         withdrawalScope = withdrawalScope.name,
         subunitId = subunitId,

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ContributionDocumentMapper.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ContributionDocumentMapper.kt
@@ -1,17 +1,15 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ContributionDocument
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.Contribution
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
-fun Contribution.toDocument(contributionId: String, groupId: String, groupDocRef: DocumentReference, userId: String) =
+fun Contribution.toDocument(contributionId: String, groupId: String, userId: String) =
     ContributionDocument(
         contributionId = contributionId,
         groupId = groupId,
-        groupRef = groupDocRef,
         userId = this.userId.ifBlank { userId },
         contributionScope = contributionScope.name,
         subunitId = subunitId,

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseDocumentMapper.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseDocumentMapper.kt
@@ -1,7 +1,6 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AddOnDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AttachmentDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseDocument
@@ -22,12 +21,12 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.Date
 
-fun Expense.toDocument(expenseId: String, groupId: String, groupDocRef: DocumentReference, userId: String) =
+fun Expense.toDocument(expenseId: String, groupId: String, userId: String) =
     ExpenseDocument(
         expenseId = expenseId,
         groupId = groupId,
-        groupRef = groupDocRef,
         title = title,
+
         expenseCategory = category.name,
         expenseSubcategory = subcategory.name.takeUnless { subcategory == ExpenseSubcategory.UNSPECIFIED },
         vendor = vendor,

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/GroupDocumentMapper.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/GroupDocumentMapper.kt
@@ -1,7 +1,6 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.GroupDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.GroupMemberDocument
 import es.pedrazamiguez.splittrip.domain.enums.GroupStatus
@@ -41,21 +40,19 @@ fun GroupDocument.toDomain(): Group? {
     )
 }
 
-fun toAdminMemberDocument(groupDocRef: DocumentReference, userId: String, addedBy: String = userId) =
+fun toAdminMemberDocument(groupId: String, userId: String, addedBy: String = userId) =
     GroupMemberDocument(
         memberId = userId,
-        groupId = groupDocRef.id,
-        groupRef = groupDocRef,
+        groupId = groupId,
         userId = userId,
         role = "ADMIN",
         addedBy = addedBy,
         joinedAt = Timestamp.now()
     )
 
-fun toRegularMemberDocument(groupDocRef: DocumentReference, memberId: String, addedBy: String) = GroupMemberDocument(
+fun toRegularMemberDocument(groupId: String, memberId: String, addedBy: String) = GroupMemberDocument(
     memberId = memberId,
-    groupId = groupDocRef.id,
-    groupRef = groupDocRef,
+    groupId = groupId,
     userId = memberId,
     role = "MEMBER",
     addedBy = addedBy,

--- a/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/SubunitDocumentMapper.kt
+++ b/data/firebase/src/main/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/SubunitDocumentMapper.kt
@@ -1,6 +1,5 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.SubunitDocument
 import es.pedrazamiguez.splittrip.domain.model.Subunit
 import java.math.BigDecimal
@@ -9,14 +8,12 @@ import java.time.LocalDateTime
 fun Subunit.toDocument(
     subunitId: String,
     groupId: String,
-    groupDocRef: DocumentReference,
     userId: String
 ): SubunitDocument {
     val now = LocalDateTime.now()
     return SubunitDocument(
         subunitId = subunitId,
         groupId = groupId,
-        groupRef = groupDocRef,
         name = name,
         memberIds = memberIds,
         memberShares = memberShares.mapValues { it.value.toPlainString() },

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/ReconciliationMappersTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/datasource/impl/ReconciliationMappersTest.kt
@@ -1,0 +1,225 @@
+package es.pedrazamiguez.splittrip.data.firebase.firestore.datasource.impl
+
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.CashWithdrawalDocument
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ContributionDocument
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseDocument
+import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseSplitDocument
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ReconciliationMappersTest {
+
+    private val pendingUserId = "pending-user-123"
+    private val activeUserId = "active-user-456"
+    private val otherUserId = "other-user-789"
+
+    @Nested
+    inner class ExpenseDocumentReconciliation {
+
+        @Test
+        fun `updates payerId when matching pending user`() {
+            val doc = ExpenseDocument(
+                expenseId = "exp-1",
+                payerId = pendingUserId,
+                createdBy = otherUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(activeUserId, updated?.payerId)
+            assertEquals(otherUserId, updated?.createdBy)
+        }
+
+        @Test
+        fun `updates createdBy when matching pending user`() {
+            val doc = ExpenseDocument(
+                expenseId = "exp-1",
+                payerId = otherUserId,
+                createdBy = pendingUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(otherUserId, updated?.payerId)
+            assertEquals(activeUserId, updated?.createdBy)
+        }
+
+        @Test
+        fun `updates nested splits when split matches pending user`() {
+            val doc = ExpenseDocument(
+                expenseId = "exp-1",
+                payerId = otherUserId,
+                createdBy = otherUserId,
+                splits = listOf(
+                    ExpenseSplitDocument(userId = pendingUserId),
+                    ExpenseSplitDocument(userId = otherUserId)
+                )
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(activeUserId, updated?.splits?.get(0)?.userId)
+            assertEquals(otherUserId, updated?.splits?.get(1)?.userId)
+        }
+
+        @Test
+        fun `returns null when no fields match pending user`() {
+            val doc = ExpenseDocument(
+                expenseId = "exp-1",
+                payerId = otherUserId,
+                createdBy = otherUserId,
+                splits = listOf(
+                    ExpenseSplitDocument(userId = otherUserId)
+                )
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNull(updated)
+        }
+    }
+
+    @Nested
+    inner class ExpenseSplitDocumentReconciliation {
+
+        @Test
+        fun `updates userId when matching pending user`() {
+            val split = ExpenseSplitDocument(
+                userId = pendingUserId,
+                isCoveredById = otherUserId
+            )
+
+            val updated = split.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(activeUserId, updated?.userId)
+            assertEquals(otherUserId, updated?.isCoveredById)
+        }
+
+        @Test
+        fun `updates isCoveredById when matching pending user`() {
+            val split = ExpenseSplitDocument(
+                userId = otherUserId,
+                isCoveredById = pendingUserId
+            )
+
+            val updated = split.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(otherUserId, updated?.userId)
+            assertEquals(activeUserId, updated?.isCoveredById)
+        }
+
+        @Test
+        fun `returns null when split does not match pending user`() {
+            val split = ExpenseSplitDocument(
+                userId = otherUserId,
+                isCoveredById = otherUserId
+            )
+
+            val updated = split.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNull(updated)
+        }
+    }
+
+    @Nested
+    inner class ContributionDocumentReconciliation {
+
+        @Test
+        fun `updates userId when matching pending user`() {
+            val doc = ContributionDocument(
+                contributionId = "c-1",
+                userId = pendingUserId,
+                createdBy = otherUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(activeUserId, updated?.userId)
+            assertEquals(otherUserId, updated?.createdBy)
+        }
+
+        @Test
+        fun `updates createdBy when matching pending user`() {
+            val doc = ContributionDocument(
+                contributionId = "c-1",
+                userId = otherUserId,
+                createdBy = pendingUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(otherUserId, updated?.userId)
+            assertEquals(activeUserId, updated?.createdBy)
+        }
+
+        @Test
+        fun `returns null when no fields match pending user`() {
+            val doc = ContributionDocument(
+                contributionId = "c-1",
+                userId = otherUserId,
+                createdBy = otherUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNull(updated)
+        }
+    }
+
+    @Nested
+    inner class CashWithdrawalDocumentReconciliation {
+
+        @Test
+        fun `updates withdrawnBy when matching pending user`() {
+            val doc = CashWithdrawalDocument(
+                withdrawalId = "w-1",
+                withdrawnBy = pendingUserId,
+                createdBy = otherUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(activeUserId, updated?.withdrawnBy)
+            assertEquals(otherUserId, updated?.createdBy)
+        }
+
+        @Test
+        fun `updates createdBy when matching pending user`() {
+            val doc = CashWithdrawalDocument(
+                withdrawalId = "w-1",
+                withdrawnBy = otherUserId,
+                createdBy = pendingUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNotNull(updated)
+            assertEquals(otherUserId, updated?.withdrawnBy)
+            assertEquals(activeUserId, updated?.createdBy)
+        }
+
+        @Test
+        fun `returns null when no fields match pending user`() {
+            val doc = CashWithdrawalDocument(
+                withdrawalId = "w-1",
+                withdrawnBy = otherUserId,
+                createdBy = otherUserId
+            )
+
+            val updated = doc.getUpdatedIfNeedsUpdate(pendingUserId, activeUserId)
+
+            assertNull(updated)
+        }
+    }
+}

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ExpenseSplitDocumentTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/document/ExpenseSplitDocumentTest.kt
@@ -22,8 +22,7 @@ class ExpenseSplitDocumentTest {
 
     private val expectedMappings = mapOf(
         "isExcluded" to "excluded",
-        "isCoveredById" to "coveredById",
-        "isCoveredByRef" to "coveredByRef"
+        "isCoveredById" to "coveredById"
     )
 
     @Nested

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/CashWithdrawalDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/CashWithdrawalDocumentMapperTest.kt
@@ -1,6 +1,5 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AddOnDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.CashWithdrawalDocument
 import es.pedrazamiguez.splittrip.domain.enums.AddOnMode
@@ -10,7 +9,6 @@ import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.enums.PaymentMethod
 import es.pedrazamiguez.splittrip.domain.model.AddOn
 import es.pedrazamiguez.splittrip.domain.model.CashWithdrawal
-import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,7 +23,6 @@ class CashWithdrawalDocumentMapperTest {
     private val testGroupId = "group-456"
     private val testUserId = "user-789"
     private val testActorId = "actor-111"
-    private val testGroupDocRef: DocumentReference = mockk(relaxed = true)
     private val testTimestamp = LocalDateTime.of(2026, 1, 15, 12, 30, 0)
     private val testFirebaseTimestamp = testTimestamp.toTimestampUtc()!!
 
@@ -53,13 +50,11 @@ class CashWithdrawalDocumentMapperTest {
             val document = fullWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
             assertEquals(testWithdrawalId, document.withdrawalId)
             assertEquals(testGroupId, document.groupId)
-            assertEquals(testGroupDocRef, document.groupRef)
             assertEquals("user-1", document.withdrawnBy)
             assertEquals("GROUP", document.withdrawalScope)
             assertNull(document.subunitId)
@@ -81,7 +76,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = subunitWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -99,7 +93,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = personalWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -112,7 +105,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = fullWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -132,7 +124,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalNoTimestamps.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -148,7 +139,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalBlankUser.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -160,7 +150,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = fullWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -172,7 +161,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = fullWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -186,7 +174,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalBlankCreatedBy.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -202,7 +189,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalPreciseRate.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -220,7 +206,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalWithDetails.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -234,7 +219,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = fullWithdrawal.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -455,7 +439,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalWithAddOns.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -475,7 +458,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalWithAddOns.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -489,7 +471,6 @@ class CashWithdrawalDocumentMapperTest {
             val document = withdrawalNoAddOns.toDocument(
                 testWithdrawalId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ContributionDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ContributionDocumentMapperTest.kt
@@ -1,10 +1,8 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ContributionDocument
 import es.pedrazamiguez.splittrip.domain.enums.PayerType
 import es.pedrazamiguez.splittrip.domain.model.Contribution
-import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,7 +19,6 @@ class ContributionDocumentMapperTest {
     private val testActorId = "actor-111"
     private val testSubunitId = "subunit-101"
     private val testLinkedExpenseId = "expense-202"
-    private val testGroupDocRef: DocumentReference = mockk(relaxed = true)
     private val testTimestamp = LocalDateTime.of(2026, 1, 15, 12, 30, 0)
     private val testFirebaseTimestamp = testTimestamp.toTimestampUtc()!!
 
@@ -45,13 +42,11 @@ class ContributionDocumentMapperTest {
             val document = fullContribution.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
             assertEquals(testContributionId, document.contributionId)
             assertEquals(testGroupId, document.groupId)
-            assertEquals(testGroupDocRef, document.groupRef)
             assertEquals(testUserId, document.userId)
             assertEquals(testSubunitId, document.subunitId)
             assertEquals(50000L, document.amountCents)
@@ -64,7 +59,6 @@ class ContributionDocumentMapperTest {
             val document = fullContribution.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -78,7 +72,6 @@ class ContributionDocumentMapperTest {
             val document = contributionBlankUser.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -90,7 +83,6 @@ class ContributionDocumentMapperTest {
             val document = fullContribution.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -104,7 +96,6 @@ class ContributionDocumentMapperTest {
             val document = contributionBlankCreatedBy.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -118,7 +109,6 @@ class ContributionDocumentMapperTest {
             val document = contributionNoSubunit.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -132,7 +122,6 @@ class ContributionDocumentMapperTest {
             val document = contributionWithLinkedExpense.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -146,7 +135,6 @@ class ContributionDocumentMapperTest {
             val document = contributionWithLinkedSettlement.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -158,7 +146,6 @@ class ContributionDocumentMapperTest {
             val document = fullContribution.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -171,7 +158,6 @@ class ContributionDocumentMapperTest {
             val document = fullContribution.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -191,7 +177,6 @@ class ContributionDocumentMapperTest {
             val document = contributionNoTimestamps.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 
@@ -212,7 +197,6 @@ class ContributionDocumentMapperTest {
             val document = contribution.toDocument(
                 testContributionId,
                 testGroupId,
-                testGroupDocRef,
                 testActorId
             )
 

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseDocumentMapperTest.kt
@@ -1,7 +1,6 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
 import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AddOnDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.AttachmentDocument
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseDocument
@@ -20,7 +19,6 @@ import es.pedrazamiguez.splittrip.domain.model.CashTranche
 import es.pedrazamiguez.splittrip.domain.model.Expense
 import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
 import es.pedrazamiguez.splittrip.domain.model.ReceiptAttachment
-import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -35,7 +33,6 @@ class ExpenseDocumentMapperTest {
     private val testExpenseId = "expense-123"
     private val testGroupId = "group-456"
     private val testUserId = "user-789"
-    private val testGroupDocRef: DocumentReference = mockk(relaxed = true)
     private val testTimestamp = LocalDateTime.of(2026, 1, 15, 12, 30, 0)
     private val testFirebaseTimestamp = testTimestamp.toTimestampUtc()!!
 
@@ -76,11 +73,10 @@ class ExpenseDocumentMapperTest {
 
         @Test
         fun `maps all core fields correctly`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals(testExpenseId, document.expenseId)
             assertEquals(testGroupId, document.groupId)
-            assertEquals(testGroupDocRef, document.groupRef)
             assertEquals("Dinner", document.title)
             assertEquals(5000L, document.amountCents)
             assertEquals("EUR", document.currency)
@@ -94,7 +90,7 @@ class ExpenseDocumentMapperTest {
         @Test
         fun `maps payerType to document`() {
             val expense = fullExpense.copy(payerType = PayerType.USER)
-            val document = expense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals("USER", document.payerType)
         }
@@ -102,14 +98,14 @@ class ExpenseDocumentMapperTest {
         @Test
         fun `maps payerId to document when non-null`() {
             val expense = fullExpense.copy(payerType = PayerType.USER, payerId = "payer-123")
-            val document = expense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals("payer-123", document.payerId)
         }
 
         @Test
         fun `maps null payerId to null in document`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals("GROUP", document.payerType)
             assertNull(document.payerId)
@@ -117,7 +113,7 @@ class ExpenseDocumentMapperTest {
 
         @Test
         fun `maps enum fields by name`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals("FOOD", document.expenseCategory)
             assertEquals("RESTAURANT", document.expenseSubcategory)
@@ -129,14 +125,14 @@ class ExpenseDocumentMapperTest {
         @Test
         fun `omits expenseSubcategory in document when UNSPECIFIED`() {
             val expense = fullExpense.copy(subcategory = ExpenseSubcategory.UNSPECIFIED)
-            val document = expense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertNull(document.expenseSubcategory)
         }
 
         @Test
         fun `maps createdAt and lastUpdatedAt when present`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertNotNull(document.createdAt)
             assertNotNull(document.lastUpdatedAt)
@@ -151,7 +147,6 @@ class ExpenseDocumentMapperTest {
             val document = expenseWithoutTimestamps.toDocument(
                 testExpenseId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -164,7 +159,7 @@ class ExpenseDocumentMapperTest {
             val opDate = LocalDateTime.of(2026, 1, 10, 10, 0, 0)
             val opFirebaseTimestamp = opDate.toTimestampUtc()!!
             val expense = fullExpense.copy(operationDate = opDate)
-            val document = expense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals(opFirebaseTimestamp, document.operationDate)
         }
@@ -172,14 +167,14 @@ class ExpenseDocumentMapperTest {
         @Test
         fun `falls back to createdAt for operationDate when operationDate is null`() {
             val expense = fullExpense.copy(operationDate = null, createdAt = testTimestamp)
-            val document = expense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals(testFirebaseTimestamp, document.operationDate)
         }
 
         @Test
         fun `maps userId to createdBy and lastUpdatedBy`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals(testUserId, document.createdBy)
             assertEquals(testUserId, document.lastUpdatedBy)
@@ -187,7 +182,7 @@ class ExpenseDocumentMapperTest {
 
         @Test
         fun `maps dueDate correctly`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertNotNull(document.dueDate)
             assertEquals(testFirebaseTimestamp, document.dueDate)
@@ -196,14 +191,14 @@ class ExpenseDocumentMapperTest {
         @Test
         fun `maps null dueDate to null`() {
             val expenseNoDueDate = fullExpense.copy(dueDate = null)
-            val document = expenseNoDueDate.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expenseNoDueDate.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertNull(document.dueDate)
         }
 
         @Test
         fun `maps cashTranches to list of maps`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals(2, document.cashTranches.size)
 
@@ -219,14 +214,14 @@ class ExpenseDocumentMapperTest {
         @Test
         fun `maps empty cashTranches to empty list`() {
             val expenseNoCash = fullExpense.copy(cashTranches = emptyList())
-            val document = expenseNoCash.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = expenseNoCash.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertTrue(document.cashTranches.isEmpty())
         }
 
         @Test
         fun `maps splits to split documents`() {
-            val document = fullExpense.toDocument(testExpenseId, testGroupId, testGroupDocRef, testUserId)
+            val document = fullExpense.toDocument(testExpenseId, testGroupId, testUserId)
 
             assertEquals(2, document.splits.size)
             assertEquals("user-1", document.splits[0].userId)
@@ -602,7 +597,6 @@ class ExpenseDocumentMapperTest {
             val document = expenseWithAddOn.toDocument(
                 testExpenseId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -628,7 +622,6 @@ class ExpenseDocumentMapperTest {
             val document = expenseWithAttachment.toDocument(
                 testExpenseId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -650,7 +643,6 @@ class ExpenseDocumentMapperTest {
             val document = expenseWithLocalAttachment.toDocument(
                 testExpenseId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -664,7 +656,6 @@ class ExpenseDocumentMapperTest {
             val document = expenseNoAttachment.toDocument(
                 testExpenseId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseSplitDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/ExpenseSplitDocumentMapperTest.kt
@@ -1,9 +1,8 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
-import com.google.firebase.firestore.DocumentReference
+
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.ExpenseSplitDocument
 import es.pedrazamiguez.splittrip.domain.enums.SplitType
 import es.pedrazamiguez.splittrip.domain.model.ExpenseSplit
-import io.mockk.mockk
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -11,10 +10,10 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+
 class ExpenseSplitDocumentMapperTest {
     private val testUserId = "user-123"
     private val testCoveredByUserId = "user-456"
-    private val testDocRef: DocumentReference = mockk(relaxed = true)
 
     @Nested
     inner class ToDomain {
@@ -25,8 +24,7 @@ class ExpenseSplitDocumentMapperTest {
                 amountCents = 5000L,
                 percentage = "33.33",
                 isExcluded = false,
-                isCoveredById = null,
-                isCoveredByRef = null
+                isCoveredById = null
             )
             val domain = document.toDomain()
             assertEquals(testUserId, domain.userId)
@@ -52,8 +50,7 @@ class ExpenseSplitDocumentMapperTest {
             val document = ExpenseSplitDocument(
                 userId = testUserId,
                 amountCents = 3000L,
-                isCoveredById = testCoveredByUserId,
-                isCoveredByRef = testDocRef
+                isCoveredById = testCoveredByUserId
             )
             val domain = document.toDomain()
             assertEquals(testCoveredByUserId, domain.isCoveredById)

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/GroupDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/GroupDocumentMapperTest.kt
@@ -1,10 +1,7 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.GroupDocument
 import es.pedrazamiguez.splittrip.domain.model.Group
-import io.mockk.every
-import io.mockk.mockk
 import java.time.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -211,13 +208,9 @@ class GroupDocumentMapperTest {
     @Nested
     inner class ToAdminMemberDocumentTest {
 
-        private val groupDocRef = mockk<DocumentReference> {
-            every { id } returns testGroupId
-        }
-
         @Test
         fun `sets userId and memberId to provided userId`() {
-            val doc = toAdminMemberDocument(groupDocRef, testUserId)
+            val doc = toAdminMemberDocument(testGroupId, testUserId)
 
             assertEquals(testUserId, doc.userId)
             assertEquals(testUserId, doc.memberId)
@@ -225,22 +218,21 @@ class GroupDocumentMapperTest {
 
         @Test
         fun `sets role to ADMIN`() {
-            val doc = toAdminMemberDocument(groupDocRef, testUserId)
+            val doc = toAdminMemberDocument(testGroupId, testUserId)
 
             assertEquals("ADMIN", doc.role)
         }
 
         @Test
-        fun `sets groupId and groupRef from document reference`() {
-            val doc = toAdminMemberDocument(groupDocRef, testUserId)
+        fun `sets groupId correctly`() {
+            val doc = toAdminMemberDocument(testGroupId, testUserId)
 
             assertEquals(testGroupId, doc.groupId)
-            assertEquals(groupDocRef, doc.groupRef)
         }
 
         @Test
         fun `defaults addedBy to userId when not specified`() {
-            val doc = toAdminMemberDocument(groupDocRef, testUserId)
+            val doc = toAdminMemberDocument(testGroupId, testUserId)
 
             assertEquals(testUserId, doc.addedBy)
         }
@@ -248,7 +240,7 @@ class GroupDocumentMapperTest {
         @Test
         fun `uses explicit addedBy when provided`() {
             val adminUserId = "admin-789"
-            val doc = toAdminMemberDocument(groupDocRef, testUserId, addedBy = adminUserId)
+            val doc = toAdminMemberDocument(testGroupId, testUserId, addedBy = adminUserId)
 
             assertEquals(adminUserId, doc.addedBy)
             assertEquals(testUserId, doc.userId)
@@ -256,7 +248,7 @@ class GroupDocumentMapperTest {
 
         @Test
         fun `sets joinedAt to a non-null local timestamp`() {
-            val doc = toAdminMemberDocument(groupDocRef, testUserId)
+            val doc = toAdminMemberDocument(testGroupId, testUserId)
 
             assertNotNull(doc.joinedAt)
         }
@@ -265,15 +257,12 @@ class GroupDocumentMapperTest {
     @Nested
     inner class ToRegularMemberDocumentTest {
 
-        private val groupDocRef = mockk<DocumentReference> {
-            every { id } returns testGroupId
-        }
         private val memberId = "member-789"
         private val addedByUserId = "admin-456"
 
         @Test
         fun `sets userId and memberId to provided memberId`() {
-            val doc = toRegularMemberDocument(groupDocRef, memberId, addedBy = addedByUserId)
+            val doc = toRegularMemberDocument(testGroupId, memberId, addedBy = addedByUserId)
 
             assertEquals(memberId, doc.userId)
             assertEquals(memberId, doc.memberId)
@@ -281,29 +270,28 @@ class GroupDocumentMapperTest {
 
         @Test
         fun `sets role to MEMBER`() {
-            val doc = toRegularMemberDocument(groupDocRef, memberId, addedBy = addedByUserId)
+            val doc = toRegularMemberDocument(testGroupId, memberId, addedBy = addedByUserId)
 
             assertEquals("MEMBER", doc.role)
         }
 
         @Test
-        fun `sets groupId and groupRef from document reference`() {
-            val doc = toRegularMemberDocument(groupDocRef, memberId, addedBy = addedByUserId)
+        fun `sets groupId correctly`() {
+            val doc = toRegularMemberDocument(testGroupId, memberId, addedBy = addedByUserId)
 
             assertEquals(testGroupId, doc.groupId)
-            assertEquals(groupDocRef, doc.groupRef)
         }
 
         @Test
         fun `sets addedBy to the user who added the member`() {
-            val doc = toRegularMemberDocument(groupDocRef, memberId, addedBy = addedByUserId)
+            val doc = toRegularMemberDocument(testGroupId, memberId, addedBy = addedByUserId)
 
             assertEquals(addedByUserId, doc.addedBy)
         }
 
         @Test
         fun `addedBy differs from memberId when admin adds another user`() {
-            val doc = toRegularMemberDocument(groupDocRef, memberId, addedBy = addedByUserId)
+            val doc = toRegularMemberDocument(testGroupId, memberId, addedBy = addedByUserId)
 
             assertEquals(addedByUserId, doc.addedBy)
             assertEquals(memberId, doc.userId)
@@ -312,7 +300,7 @@ class GroupDocumentMapperTest {
 
         @Test
         fun `sets joinedAt to a non-null local timestamp`() {
-            val doc = toRegularMemberDocument(groupDocRef, memberId, addedBy = addedByUserId)
+            val doc = toRegularMemberDocument(testGroupId, memberId, addedBy = addedByUserId)
 
             assertNotNull(doc.joinedAt)
         }

--- a/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/SubunitDocumentMapperTest.kt
+++ b/data/firebase/src/test/kotlin/es/pedrazamiguez/splittrip/data/firebase/firestore/mapper/SubunitDocumentMapperTest.kt
@@ -1,9 +1,7 @@
 package es.pedrazamiguez.splittrip.data.firebase.firestore.mapper
 
-import com.google.firebase.firestore.DocumentReference
 import es.pedrazamiguez.splittrip.data.firebase.firestore.document.SubunitDocument
 import es.pedrazamiguez.splittrip.domain.model.Subunit
-import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,7 +16,6 @@ class SubunitDocumentMapperTest {
     private val testSubunitId = "subunit-123"
     private val testGroupId = "group-456"
     private val testUserId = "user-789"
-    private val testGroupDocRef: DocumentReference = mockk(relaxed = true)
     private val testTimestamp = LocalDateTime.of(2026, 3, 13, 12, 30, 0)
     private val testFirebaseTimestamp = testTimestamp.toTimestampUtc()!!
     private val testName = "Antonio & Me"
@@ -49,13 +46,11 @@ class SubunitDocumentMapperTest {
             val document = fullSubunit.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
             assertEquals(testSubunitId, document.subunitId)
             assertEquals(testGroupId, document.groupId)
-            assertEquals(testGroupDocRef, document.groupRef)
             assertEquals(testName, document.name)
             assertEquals(testMemberIds, document.memberIds)
             assertEquals(testMemberSharesDoc, document.memberShares)
@@ -67,7 +62,6 @@ class SubunitDocumentMapperTest {
             val document = fullSubunit.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -87,7 +81,6 @@ class SubunitDocumentMapperTest {
             val document = subunitNoTimestamps.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -105,7 +98,6 @@ class SubunitDocumentMapperTest {
             val document = subunit.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -123,7 +115,6 @@ class SubunitDocumentMapperTest {
             val document = subunit.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -140,7 +131,6 @@ class SubunitDocumentMapperTest {
             val document = subunit.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -154,7 +144,6 @@ class SubunitDocumentMapperTest {
             val document = subunit.toDocument(
                 testSubunitId,
                 testGroupId,
-                testGroupDocRef,
                 testUserId
             )
 
@@ -168,7 +157,6 @@ class SubunitDocumentMapperTest {
         private val fullDocument = SubunitDocument(
             subunitId = testSubunitId,
             groupId = testGroupId,
-            groupRef = testGroupDocRef,
             name = testName,
             memberIds = testMemberIds,
             memberShares = testMemberSharesDoc,


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes in this PR. What does it do? -->

## 💡 Motivation

<!-- Explain why these changes are needed. What problem does this solve? -->

## 🔗 Related Issues

<!-- Link to related issues. Use "Closes #XXX" to auto-close issues when PR is merged -->
Closes #1564 

## 🧪 Testing Instructions

<!-- Describe how to test these changes. What should reviewers verify? -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings if this PR includes UI changes -->

## ✅ Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated documentation as needed
